### PR TITLE
Increase test timeout to support k8s DB/Redis

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -163,6 +163,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -190,6 +192,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -216,6 +220,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -244,6 +250,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -271,6 +279,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -298,6 +308,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -325,6 +337,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -351,6 +365,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -377,6 +393,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -404,6 +422,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -431,6 +451,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -458,6 +480,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -485,6 +509,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",
@@ -511,6 +537,8 @@
         "999999",
         "--colors",
         "--recursive",
+        "--timeout",
+        "5000",
         "'tests/**/*.ts'"
       ],
       "console": "integratedTerminal",

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -31,7 +31,7 @@
     "start": "PATH_PREFIX=/agency yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/agency DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/agency DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-api-authorizer/package.json
+++ b/packages/mds-api-authorizer/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 84 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 84 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   },
   "keywords": [
     "mds"

--- a/packages/mds-api-server/package.json
+++ b/packages/mds-api-server/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   },
   "keywords": [
     "mds"

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -12,7 +12,7 @@
     "start": "PATH_PREFIX=/audit yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/audit DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/audit DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -12,7 +12,7 @@
     "start": "PATH_PREFIX=/compliance yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/compliance DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/compliance DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -30,7 +30,7 @@
     "start": "PATH_PREFIX=/agency yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/agency DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 50 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/agency DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 50 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-db/package.json
+++ b/packages/mds-db/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 0 ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --timeout 6000 --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts && nyc report --reporter=html"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 0 ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --timeout 6000 --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts && nyc report --reporter=html"
   },
   "author": "City of Los Angeles",
   "license": "Apache-2.0",

--- a/packages/mds-logger/package.json
+++ b/packages/mds-logger/package.json
@@ -21,6 +21,6 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   }
 }

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 50 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 50 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   },
   "author": "City of Los Angeles",
   "license": "Apache-2.0",

--- a/packages/mds-native/package.json
+++ b/packages/mds-native/package.json
@@ -14,7 +14,7 @@
     "start": "PATH_PREFIX=/native yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/native DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/native DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-policy-author/package.json
+++ b/packages/mds-policy-author/package.json
@@ -29,7 +29,7 @@
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/policy-author DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --timeout 4000 --project ../../tsconfig.json --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy-author DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --timeout 4000 --project ../../tsconfig.json --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && ts-node"
   }

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -30,7 +30,7 @@
     "start": "PATH_PREFIX=/policy yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/policy DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -15,7 +15,7 @@
     "stream": "yarn watch stream",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/policy DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-types/package.json
+++ b/packages/mds-types/package.json
@@ -16,6 +16,6 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   }
 }

--- a/packages/mds-utils/package.json
+++ b/packages/mds-utils/package.json
@@ -23,6 +23,6 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 35 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 35 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive --timeout 5000 tests/**/*.ts"
   }
 }


### PR DESCRIPTION
Tests will _occasionally_ timeout when port forwarding to Postgres and Redis running inside Kubernetes. Increase the _mocha_ timeout above the default of 2s to mitigate this.


