### PR TITLE
support traditional command options and tab completion

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -163,6 +163,7 @@ commands:
   uninstall[:{service[,{service}]}]                   : uninstall specified service(s); default: ${configs[uninstall]}
   reinstall[:{service[,{service}]}]                   : reinstall specified service(s); default: ${configs[reinstall]}
   home                                                : return installation directory
+  completion                                          : return bash-completion
 
 where service in:
   helm
@@ -968,6 +969,7 @@ for arg in "${@}"; do
     invoke uninstall "$(normalize ${arg})"
     invoke install "$(normalize ${arg})";;
     home) echo ${configs[home]};;
+    completion) cat ${configs[home]}/bin/mdsctl-completion.bash;;
     *) usage "unknown command: ${arg}"
   esac
 done; unset arg

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -133,6 +133,23 @@ usage() {
   cat << EOF
 usage: $(basename ${0}) [--options] [commands]
 
+options:
+  [-c | --configure] [{key}={value}[,{key}={value}]   : set configuration value(s) by key(s)
+                   [{key}+={value}[,{key}+={value}]   : append configuraiton value(s) by key(s)
+                   [{key}=                            : clear configuration value(s) by key(s)
+  [-p | --preset] [preset-key[,preset-key]]           : preset configuration(s)
+  [-w | --workdir] [WORK-DIR]                         : specify working directory
+  [-s | --sleep] [PAUSE]                              : specify pause time
+  [-q | --quiet]                                      : less verbose
+  [-h | --help]                                       : usage
+
+where preset-key in:
+  minimal                                             : minimal service deployment; default: preset(local) + mds-agency, postgresql, redis
+  local                                               : local resource (cpu, memory) deployment; default: limitsCpu=200m, limitsMemory=200Mi, requestsCpu=20m, requestsMemory=32Mi
+  disabled                                            : disable service deployment; default: all
+  no-events                                           : disable eventing services
+  no-persistence                                      : disable persistence
+
 commands:
   bootstrap                                           : install dependencies; default: ${configs[tools]},${configs[bootstrap]}
   build                                               : build project
@@ -145,15 +162,7 @@ commands:
   cli:[postgresql,redis]                              : create a cli console for the provided service
   uninstall[:{service[,{service}]}]                   : uninstall specified service(s); default: ${configs[uninstall]}
   reinstall[:{service[,{service}]}]                   : reinstall specified service(s); default: ${configs[reinstall]}
-  help                                                : help message
-
-options:
-  --configure:{key}={value}[,{key}={value}]           : set configuration value by key
-  --configure:{key}+={value}                          : append configuration value by key
-  --configure:{key}=                                  : clears configuration value by key
-  --preset:[preset-key[,preset-key]]                  : preset configurations
-  --home                                              : returns installation directory
-  --quiet                                             : less verbose
+  home                                                : return installation directory
 
 where service in:
   helm
@@ -186,13 +195,6 @@ where app in:
   jaeger                                              : jaeger; see https://www.jaegertracing.io
   kiali                                               : kiali; see https://www.kiali.io
   bookinfo                                            : bookinfo; see https://istio.io/docs/examples/bookinfo
-
-where preset-key in:
-  minimal                                             : minimal service deployment; default: preset(local) + mds-agency, postgresql, redis
-  local                                               : local resource (cpu, memory) deployment; default: limitsCpu=200m, limitsMemory=200Mi, requestsCpu=20m, requestsMemory=32Mi
-  disabled                                            : disable service deployment; default: all
-  no-events                                           : disable eventing services
-  no-persistence                                      : disable persistence
 
 example:
   % ./bin/$(basename ${0}) bootstrap build install:mds test:integration
@@ -907,6 +909,34 @@ preset() {
 }
 
 check $(basename ${0})
+
+while getopts ":w:s:c:p:q-:h-:" opt; do
+  case "${opt}" in
+    -)
+      case "${OPTARG}" in
+        configure) configure "$(echo ${!OPTIND} | cut -d ':' -f 2-)"; OPTIND=$(( ${OPTIND} + 1 ));;
+        configure=*) configure "$(echo "${OPTARG#*=}" | cut -d ':' -f 2-)";;
+        presets) preset "$(normalize ${!OPTIND})"; OPTIND=$(( ${OPTIND} + 1 ));;
+        presets=*) preset "$(normalize ${OPTARG#*=})";;
+        workdir) configs[workdir]="${!OPTIND}"; OPTIND=$(( ${OPTIND} + 1 ));;
+        workdir=*) configs[workdir]="${OPTARG#*=}";;
+        sleep) configs[pause]="${!OPTIND}"; OPTIND=$(( ${OPTIND} + 1 ));;
+        sleep=*) configs[pause]="${OPTARG#*=}";;
+        quiet) confgs[quiet]=true;;
+        help) usage;;
+        *) [ "${OPTERR}" = 1 ] && [ "${optspec:0:1}" != ":" ] && echo "unknown option --${OPTARG}";;
+      esac;;
+    c) configure "$(echo ${OPTARG} | cut -d ':' -f 2-)";;
+    p) preset "$(normalize ${OPTARG})";;
+    w) configs[workdir]=${OPTARG};;
+    s) configs[pause]=${OPTARG};;
+    q) configs[quiet]=true;;
+    h) usage;;
+    :) usage "option -${OPTARG} requires an argument" 1;;
+    \?) [ "${OPTERR}" != 1 ] || [ "${optspec:0:1}" = ":" ] && usage "unknown option -${OPTARG}" 1;;
+  esac
+done
+
 [[ ${#} == 0 ]] && usage
 [[ ! -d ${configs[workdir]} ]] && mkdir -p ${configs[workdir]}
 
@@ -938,10 +968,10 @@ for arg in "${@}"; do
     invoke uninstall "$(normalize ${arg})"
     invoke install "$(normalize ${arg})";;
     help) usage;;
-    --configure:* | configure:* | -c:*) configure "$(echo ${arg} | cut -d ':' -f 2-)";;
-    --preset:* | preset:* | -p:*) preset "$(normalize ${arg})";;
-    --home | -h) echo ${configs[home]};;
-    --quiet | -q) configs[quiet]=true;;
+    # --configure:* | configure:* | -c:*) configure "$(echo ${arg} | cut -d ':' -f 2-)";;
+    # --preset:* | preset:* | -p:*) preset "$(normalize ${arg})";;
+    home) echo ${configs[home]};;
+    # --quiet | -q) configs[quiet]=true;;
     *) usage "unknown command: ${arg}"
   esac
 done; unset arg

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -915,8 +915,8 @@ while getopts ":w:s:c:p:q-:h-:" opt; do
       case "${OPTARG}" in
         configure) configure "$(echo ${!OPTIND} | cut -d ':' -f 2-)"; OPTIND=$(( ${OPTIND} + 1 ));;
         configure=*) configure "$(echo "${OPTARG#*=}" | cut -d ':' -f 2-)";;
-        presets) preset "$(normalize ${!OPTIND})"; OPTIND=$(( ${OPTIND} + 1 ));;
-        presets=*) preset "$(normalize ${OPTARG#*=})";;
+        preset) preset "$(normalize ${!OPTIND})"; OPTIND=$(( ${OPTIND} + 1 ));;
+        preset=*) preset "$(normalize ${OPTARG#*=})";;
         workdir) configs[workdir]="${!OPTIND}"; OPTIND=$(( ${OPTIND} + 1 ));;
         workdir=*) configs[workdir]="${OPTARG#*=}";;
         sleep) configs[pause]="${!OPTIND}"; OPTIND=$(( ${OPTIND} + 1 ));;

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -967,11 +967,7 @@ for arg in "${@}"; do
     reinstall:*)
     invoke uninstall "$(normalize ${arg})"
     invoke install "$(normalize ${arg})";;
-    help) usage;;
-    # --configure:* | configure:* | -c:*) configure "$(echo ${arg} | cut -d ':' -f 2-)";;
-    # --preset:* | preset:* | -p:*) preset "$(normalize ${arg})";;
     home) echo ${configs[home]};;
-    # --quiet | -q) configs[quiet]=true;;
     *) usage "unknown command: ${arg}"
   esac
 done; unset arg

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -54,7 +54,7 @@ declare -A configs=(
   ["os"]="${MDS_OS:-`uname`}"
   ["rc"]="${MDS_RC:-~/.bashrc ~/.zshrc}"
   ["workdir"]="/tmp/mds/tools"
-  ["brew"]="${MDS_BREW:-oq jq gettext yarn nvm kubernetes-helm pgcli redis python git}"
+  ["brew"]="${MDS_BREW:-oq jq gettext yarn nvm kubernetes-helm pgcli redis git}"
   ["tools"]="${MDS_TOOLCHAIN:-kubernetes-helm,pgcli}"
   ["image-repository"]="${MDS_IMAGE_REPOSITORY:-}"
   ["simulator-repository"]="${MDS_SIMULATOR_REPOSITORY:-}"
@@ -537,10 +537,8 @@ installSimulator() {
       git clone ${configs[simulator-repository]} ${configs[simulator]})
   fi
 
-  (export PATH=$(brew --prefix python)/bin:$(brew --prefix python)/libexec/bin:${PATH};
-    cd ${configs[simulator]};
+  (cd ${configs[simulator]};
     git pull;
-    pip install -r requirements.txt;
     docker build -t trackgen .;
     helm install ./helm --name trackgen)
 }
@@ -941,7 +939,7 @@ done
 [[ ${#} == 0 ]] && usage
 [[ ! -d ${configs[workdir]} ]] && mkdir -p ${configs[workdir]}
 
-for arg in "${@}"; do
+for arg in "${@:$OPTIND}"; do
   case "${arg}" in
     bootstrap) bootstrap || warn  "${arg} failure";;
     build) build || usage "${arg} failure";;

--- a/bin/mdsctl-completion.bash
+++ b/bin/mdsctl-completion.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+options="--configure --preset --workdir --quiet --help"
+commands="bootstrap build install test open token forward unforward cli uninstall reinstall"
+
+_mdsctl_complete() {
+  local cur prev opts cmds
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  opts=${options}
+  cmds=${commands}
+
+  case ${cur} in
+    -*) COMPREPLY=($(compgen -W "${opts}" -- ${cur})); return 0;;
+    [a-z]* | '') COMPREPLY=($(compgen -W "${cmds}" -- ${cur})); return 0;;
+  esac
+}
+
+complete -F _mdsctl_complete mdsctl


### PR DESCRIPTION
support traditional command options, by short-and-long key, eg:

- `% mdsctl -p [preset[,preset]] ...`
- `% mdsctl --preset [preset[,preset]] ...`
- `% mdsctl --preset=[preset[,preset]] ...`

support tab completion, eg:

- `% . <(mdsctl completion)`
- `% mdsctl<tab><tab>`
- `% mdsctl -<tab><tab>'

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


