### PR TITLE
Add standard API request logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/mocha": "5.2.7",
     "@types/mockdate": "2.0.0",
     "@types/moment-timezone": "0.5.12",
+    "@types/morgan": "1.7.37",
     "@types/node": "10.14.21",
     "@types/pg": "7.11.2",
     "@types/point-in-polygon": "1.0.0",

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -1,6 +1,8 @@
+import morgan from 'morgan'
 import bodyParser from 'body-parser'
 import express from 'express'
 import cors from 'cors'
+import logger from '@mds-core/mds-logger'
 import { pathsFor, AuthorizationError } from '@mds-core/mds-utils'
 import { AuthorizationHeaderApiAuthorizer, ApiAuthorizer, ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 import { AccessTokenScope } from '@mds-core/mds-types'
@@ -58,33 +60,52 @@ export const ApiServer = (
   // Disable x-powered-by header
   app.disable('x-powered-by')
 
-  // Parse JSON body
-  app.use(bodyParser.json({ limit: '5mb' }))
-
-  // Enable CORS
+  // Middleware
   app.use(
+    //
+    // Request logging
+    //
+    morgan('tiny', {
+      skip: (req, res) => {
+        // By default only log 400/500 errors
+        const { REQUEST_LOG_LEVEL = 400 } = process.env
+        return res.statusCode < Number(REQUEST_LOG_LEVEL)
+      },
+      // Use logger, but remove extra line feed added by morgan stream option
+      stream: { write: msg => logger.info(msg.slice(0, -1)) }
+    }),
+    //
+    // JSON body parser
+    //
+    bodyParser.json({ limit: '5mb' }),
+    //
+    // CORS
+    //
     handleCors
       ? cors() // Server handles CORS
       : (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
-          // Gateway handles CORS pre-flight
-          if (req.method !== 'OPTIONS') {
-            res.header('Access-Control-Allow-Origin', '*')
-          }
+          res.header('Access-Control-Allow-Origin', '*')
           next()
-        }
-  )
-
-  // Authorizer
-  app.use((req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
-    const { MAINTENANCE: maintenance } = process.env
-    if (maintenance) {
-      return res.status(503).send(about())
+        },
+    //
+    // Maintenance
+    //
+    (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
+      if (process.env.MAINTENANCE) {
+        return res.status(503).send(about())
+      }
+      next()
+    },
+    //
+    // Authorizer
+    //
+    (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
+      const claims = authorizer(req)
+      res.locals.claims = claims
+      res.locals.scopes = claims && claims.scope ? (claims.scope.split(' ') as AccessTokenScope[]) : []
+      next()
     }
-    const claims = authorizer(req)
-    res.locals.claims = claims
-    res.locals.scopes = claims && claims.scope ? (claims.scope.split(' ') as AccessTokenScope[]) : []
-    next()
-  })
+  )
 
   app.get(pathsFor('/'), async (req: ApiRequest, res: ApiResponse) => {
     // 200 OK

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -68,8 +68,8 @@ export const ApiServer = (
     morgan('tiny', {
       skip: (req, res) => {
         // By default only log 400/500 errors
-        const { REQUEST_LOG_LEVEL = 400 } = process.env
-        return res.statusCode < Number(REQUEST_LOG_LEVEL)
+        const { API_REQUEST_LOG_LEVEL = 400 } = process.env
+        return res.statusCode < Number(API_REQUEST_LOG_LEVEL)
       },
       // Use logger, but remove extra line feed added by morgan stream option
       stream: { write: msg => logger.info(msg.slice(0, -1)) }

--- a/packages/mds-api-server/package.json
+++ b/packages/mds-api-server/package.json
@@ -22,7 +22,8 @@
     "@mds-core/mds-utils": "0.1.17",
     "body-parser": "1.19.0",
     "cors": "2.8.5",
-    "express": "4.17.1"
+    "express": "4.17.1",
+    "morgan": "1.9.1"
   },
   "license": "Apache-2.0"
 }

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -125,7 +125,6 @@ function api(app: express.Express): express.Express {
           // stash audit_subject_id and timestamp (for recording db writes)
           res.locals.audit_subject_id = subject_id
           res.locals.recorded = Date.now()
-          log.info(subject_id, req.method, req.originalUrl)
           return next()
         }
       }

--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -53,16 +53,10 @@ function api(app: express.Express): express.Express {
   // ///////////////////// begin middleware ///////////////////////
   app.use(async (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
     if (!(req.path.includes('/health') || req.path === '/')) {
-      try {
-        if (!res.locals.claims) {
-          return res.status(401).send({ error: new AuthorizationError('missing_claims') })
-        }
-      } catch (err) {
-        /* istanbul ignore next */
-        return InternalServerError(req, res, err)
+      if (!res.locals.claims) {
+        return res.status(401).send({ error: new AuthorizationError('missing_claims') })
       }
     }
-    logger.info(req.method, req.originalUrl)
     return next()
   })
   // ///////////////////// begin middleware ///////////////////////

--- a/packages/mds-provider/tests/test.ts
+++ b/packages/mds-provider/tests/test.ts
@@ -177,7 +177,7 @@ describe('Tests app', () => {
       .get('/trips')
       .expect(401)
       .end((err, result) => {
-        test.value(result.text).is('Unauthorized')
+        test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })
   })
@@ -253,7 +253,7 @@ describe('Tests app', () => {
       .get('/status_changes')
       .expect(401)
       .end((err, result) => {
-        test.value(result.text).is('Unauthorized')
+        test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,13 @@
   dependencies:
     moment ">=2.14.0"
 
+"@types/morgan@1.7.37":
+  version "1.7.37"
+  resolved "https://registry.yarnpkg.com/@types/morgan/-/morgan-1.7.37.tgz#ebdd0b0f0276073f85283bf4f03c7c54284874df"
+  integrity sha512-tIdEA10BcHcOumMmUiiYdw8lhiVVq62r0ghih5Xpp4WETkfsMiTUZL4w9jCI502BBOrKhFrAOGml9IeELvVaBA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*", "@types/node@>=8.9.0":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
@@ -2205,6 +2212,13 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -6589,6 +6603,17 @@ moment@2.24.0, "moment@>= 2.9.0", moment@>=2.14.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+morgan@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7088,6 +7113,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
 Added a standard way to log requests across all APIs. By default only `400/500` errors are logged, but that is controllable via the `API_REQUEST_LOG_LEVEL` environment variable. When enabled, logs containing `:method :url :status :res[content-length] - :response-time ms` are emitted via `mds-logger`
```
INFO GET /provider/status_changes 200 5896 - 71.805 ms
INFO GET /provider/status_changesd 404 163 - 2.178 ms
INFO GET /provider/status_changes 200 5896 - 22.579 ms
INFO GET /agency 200 97 - 6.518 ms
INFO GET /agency/health 200 216 - 1.245 ms
INFO GET /agency/vehicles 200 9476 - 67.195 ms
INFO GET /native 200 97 - 4.252 ms
INFO GET /native/health 200 215 - 1.226 ms
INFO GET /native/vehicles/68fd5e1d-55c5-45b7-b000-13831fd77507 404 125 - 51.734 ms
INFO GET /native/providers 200 3767 - 1.610 ms
INFO GET /audit/trips 200 23 - 42.919 ms
INFO POST /audit/trips/8c71f055-b5ef-4de3-a483-1d4a350a13ab/start 200 133 - 108.106 ms
```