### PR TITLE
[mdsctl] fix - values.yaml not .html

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -313,7 +313,7 @@ templateValues() {
     export $varname=${version}${suffix}
   done
   mkdir -p dist
-  envsubst < helm/mds/values.yaml.tpl > dist/values.html
+  envsubst < helm/mds/values.yaml.tpl > dist/values.yaml
   echo "Wrote dist/values.yaml"
 }
 


### PR DESCRIPTION
Fixes an unfortunate typo in the templateValues() function of mdsctl