### PR TITLE
mdscl/istio: install (un)install via helm straight up

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -740,13 +740,13 @@ uninstallKiali() {
 uninstallIstio() {
   kubectl get namespace istio-system > /dev/null 2>&1 && {
     check ${FUNCNAME[0]}
-    helm delete --purge istio
-    helm delete --purge istio-init
+    helm delete --purge istio ${configs[dryrun]:+--dry-run}
+    helm delete --purge istio-init ${configs[dryrun]:+--dry-run}
     kubectl delete namespace istio-system ${configs[dryrun]:+--dry-run}
     kubectl delete -f ${configs[istio]}/install/kubernetes/helm/istio-init/files \
       ${configs[dryrun]:+--dry-run} > /dev/null
   }
-  [ -d ${configs[istio]} ] && /bin/rm -rf ${configs[istio]}
+  [[ -d ${configs[istio]} && -z "${configs[dryrun]}" ]] && echo "/bin/rm -rf ${configs[istio]}"
 }
 
 uninstallDashboard() {

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -429,19 +429,19 @@ installIstio() {
 
     installNamespace istio-system
     pause 2
-    helm template ${configs[istio]}/install/kubernetes/helm/istio-init \
-      --name istio-init --namespace istio-system | \
-      kubectl apply -f - ${configs[dryrun]:+--dry-run}
+    helm install ${configs[istio]}/install/kubernetes/helm/istio-init \
+      --name istio-init --namespace istio-system \
+      ${configs[dryrun]:+--dry-run}
     # todo: query pod status
     pause 5
 
     (( $(kubectl get crds | grep "istio.io" | wc -l) == 23 )) && \
       echo "istio successfully installed" || echo "istio installation failure"
 
-    helm template ${configs[istio]}/install/kubernetes/helm/istio \
+    helm install ${configs[istio]}/install/kubernetes/helm/istio \
       --name istio --namespace istio-system \
-      --values ${configs[istio]}/install/kubernetes/helm/istio/values${configs[istio-profile]}.yaml | \
-      kubectl apply -f - ${configs[dryrun]:+--dry-run}
+      --values ${configs[istio]}/install/kubernetes/helm/istio/values${configs[istio-profile]}.yaml \
+      ${configs[dryrun]:+--dry-run}
     labelNamespaceIstioInjection default
   }
 }
@@ -740,11 +740,8 @@ uninstallKiali() {
 uninstallIstio() {
   kubectl get namespace istio-system > /dev/null 2>&1 && {
     check ${FUNCNAME[0]}
-    helm template ${configs[istio]}/install/kubernetes/helm/istio \
-      --name istio \
-      --namespace istio-system \
-      --values ${configs[istio]}/install/kubernetes/helm/istio/values-istio-demo.yaml | \
-        kubectl delete -f - ${configs[dryrun]:+--dry-run}
+    helm delete --purge istio
+    helm delete --purge istio-init
     kubectl delete namespace istio-system ${configs[dryrun]:+--dry-run}
     kubectl delete -f ${configs[istio]}/install/kubernetes/helm/istio-init/files \
       ${configs[dryrun]:+--dry-run} > /dev/null


### PR DESCRIPTION
patch mdsctl to (un)install istio-1.2.6 via helm directly

note:

- the feature/jwtodd-nats branch u/d istiio-1.3.5
- more extensive testing was done locally then that included below, namely `./bin/mdsctl build install:mds`

considerations:

- thought about preemptively deleting instio-init post install but opted to let it reside till it is better understood

verify:

```
# note: clean cluster (this patch is not backwards compatible per se
% ./bin/mdsctl install:istio
% kubectl get pods -n istio-system
[istio pods]
% helm list
...
istio     	1       	Wed Nov 13 16:27:14 2019	DEPLOYED	istio-1.2.6     	1.2.6      	istio-system
istio-init	1       	Wed Nov 13 16:27:08 2019	DEPLOYED	istio-init-1.2.6	1.2.6      	istio-system
% ./bin/mdsctl uninstall:istio
% kubectl get namespaces
% helm list
```


