### PR TITLE
[mds-agency] Fix bad event missing timestamp error message

### DIFF
--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -276,7 +276,7 @@ export async function badEvent(event: VehicleEvent) {
   if (event.timestamp === undefined) {
     return {
       error: 'missing_param',
-      error_description: 'missing enum field "event_type"'
+      error_description: 'missing enum field "timestamp"'
     }
   }
   if (!isTimestamp(event.timestamp)) {


### PR DESCRIPTION
@wesleyfsmith and I were pairing and calling the agency event API and getting a very confusing error message. Turns out we were indeed missing the timestamp field, but the message was saying `error_type`.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [x] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


