### PR TITLE
Fix helm configmap glob

### DIFF
--- a/helm/mds/templates/configmap.yaml
+++ b/helm/mds/templates/configmap.yaml
@@ -4,5 +4,4 @@ metadata:
   name: mds-config-files
   namespace: {{ .Release.Namespace }}
 data:
-{{ (.Files.Glob (printf "files/mds-config/%s/*.json" .Release.Namespace) ).AsConfig | indent 2 }}
-{{ (.Files.Glob (printf "files/mds-config/%s/*.json5" .Release.Namespace) ).AsConfig | indent 2 }}
+{{ (.Files.Glob (printf "files/mds-config/%s/*.{json,json5}" .Release.Namespace) ).AsConfig | indent 2 }}


### PR DESCRIPTION
Fix an error in `mdsctl install:mds` when there are no mounted/symlink'ed config files. Also, now supports `json` _and/or_ `json5` file combinations.