### PR TITLE
[mds-cache, mds-db] Instrument some cache and db operations with timing logs

### DIFF
--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -211,7 +211,7 @@ export async function getVehicles(
     return [...acc, { ...item, status, updated }]
   }, [])
   const finish = now()
-  log.info(`getVehicles processing ${JSON.stringify(bbox)} time elapsed: ${finish - start}ms`)
+  log.info(`getVehicles processing ${JSON.stringify(bbox)} provider ${provider_id} time elapsed: ${finish - start}ms`)
 
   const noNext = skip + take >= statusesSuperset.length
   const noPrev = skip === 0 || skip > statusesSuperset.length

--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -32,6 +32,8 @@ import {
   VEHICLE_EVENT,
   VEHICLE_STATUSES
 } from '@mds-core/mds-types'
+import log from '@mds-core/mds-logger'
+import { now } from '@mds-core/mds-utils'
 
 export async function deleteAudit(audit_trip_id: UUID): Promise<number> {
   const result: number = await db.deleteAudit(audit_trip_id)
@@ -94,11 +96,15 @@ export async function readDevice(device_id: UUID, provider_id: UUID): Promise<Re
 
 export async function readDeviceByVehicleId(provider_id: UUID, vehicle_id: string): Promise<Recorded<Device> | null> {
   try {
+    const start = now()
     const result: Recorded<Device> = await db.readDeviceByVehicleId(
       provider_id,
       vehicle_id,
       vehicle_id.replace(/[\W_-]/g, '')
     )
+    const finish = now()
+    const timeElapsed = finish - start
+    log.info(`db.readDeviceByVehicleId ${provider_id} ${vehicle_id} time elapsed: ${timeElapsed}ms`)
     return result
   } catch (err) {
     return null
@@ -192,6 +198,7 @@ export async function getVehicles(
     return s
   }
 
+  const start = now()
   const statusesSuperset = ((await cache.readDevicesStatus({ bbox })) as (VehicleEvent & Device)[]).filter(
     status =>
       EVENT_STATUS_MAP[status.event_type as VEHICLE_EVENT] !== VEHICLE_STATUSES.removed &&
@@ -203,6 +210,8 @@ export async function getVehicles(
     const updated = item.timestamp
     return [...acc, { ...item, status, updated }]
   }, [])
+  const finish = now()
+  log.info(`getVehicles processing ${JSON.stringify(bbox)} time elapsed: ${finish - start}ms`)
 
   const noNext = skip + take >= statusesSuperset.length
   const noPrev = skip === 0 || skip > statusesSuperset.length

--- a/packages/mds-db/audits.ts
+++ b/packages/mds-db/audits.ts
@@ -71,6 +71,7 @@ export async function readAudits(query: ReadAuditsQueryParams) {
 
 export async function writeAudit(audit: Audit): Promise<Recorded<Audit>> {
   // write pg
+  const start = now()
   const client = await getWriteableClient()
   const sql = `INSERT INTO ${schema.TABLE.audits} (${cols_sql(schema.TABLE_COLUMNS.audits)}) VALUES (${vals_sql(
     schema.TABLE_COLUMNS.audits
@@ -80,6 +81,8 @@ export async function writeAudit(audit: Audit): Promise<Recorded<Audit>> {
   const {
     rows: [recorded_audit]
   }: { rows: Recorded<Audit>[] } = await client.query(sql, values)
+  const finish = now()
+  log.info(`MDS-DB writeAudit time elapsed: ${finish - start}ms`)
   return { ...audit, ...recorded_audit }
 }
 
@@ -110,6 +113,7 @@ export async function readAuditEvents(audit_trip_id: UUID): Promise<Recorded<Aud
 }
 
 export async function writeAuditEvent(audit_event: AuditEvent): Promise<Recorded<AuditEvent>> {
+  const start = now()
   const client = await getWriteableClient()
   const sql = `INSERT INTO ${schema.TABLE.audit_events} (${cols_sql(
     schema.TABLE_COLUMNS.audit_events
@@ -119,5 +123,7 @@ export async function writeAuditEvent(audit_event: AuditEvent): Promise<Recorded
   const {
     rows: [recorded_audit_event]
   }: { rows: Recorded<AuditEvent>[] } = await client.query(sql, values)
+  const finish = now()
+  log.info(`MDS-DB writeAuditEvent time elapsed: ${finish - start}ms`)
   return { ...audit_event, ...recorded_audit_event }
 }


### PR DESCRIPTION
## PR Checklist

 - [X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [X] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author

We've received field reports that the audit mobile app can be slow when looking a device up by VIN, viewing devices on the map, and submitting issues. These reports are documented in [MDSAAS-357](https://lacunadotai.atlassian.net/browse/MDSAAS-357), [MDSAAS-362](https://lacunadotai.atlassian.net/browse/MDSAAS-362), and [MDSAAS-363](https://lacunadotai.atlassian.net/browse/MDSAAS-363). Since each of these activities involve lots of different db, cache, and data processing operations, collecting timing stats on the relevant code blocks should tell us where to focus our performance improvement efforts.