### PR TITLE
Support merging multiple settings properties

### DIFF
--- a/packages/mds-config-service/client.ts
+++ b/packages/mds-config-service/client.ts
@@ -1,4 +1,6 @@
 import fs from 'fs'
+import { format } from 'path'
+import { homedir } from 'os'
 import { promisify } from 'util'
 import { NotFoundError, UnsupportedTypeError } from '@mds-core/mds-utils'
 import JSON5 from 'json5'
@@ -14,11 +16,11 @@ const statFile = async (path: string): Promise<string | null> => {
   return null
 }
 
-const getFilePath = async (name = 'settings'): Promise<string> => {
+const getFilePath = async (property: string): Promise<string> => {
   const { MDS_CONFIG_PATH = '/mds-config' } = process.env
-  const path = MDS_CONFIG_PATH.endsWith('/') ? MDS_CONFIG_PATH : `${MDS_CONFIG_PATH}/`
-  const json5 = await statFile(`${path}${name}.json5`)
-  return json5 ?? `${path}${name}.json`
+  const dir = (MDS_CONFIG_PATH.endsWith('/') ? MDS_CONFIG_PATH : `${MDS_CONFIG_PATH}/`).replace('~', homedir())
+  const json5 = await statFile(format({ dir, name: property, ext: '.json5' }))
+  return json5 ?? format({ dir, name: property, ext: '.json' })
 }
 
 const readFileAsync = promisify(fs.readFile)
@@ -31,7 +33,7 @@ const readFile = async (path: string): Promise<string> => {
   }
 }
 
-const asJson = <TSettings extends object>(utf8: string): TSettings => {
+const asJson = <TSettings extends {}>(utf8: string): TSettings => {
   try {
     const json: TSettings = JSON5.parse(utf8)
     return json
@@ -40,8 +42,13 @@ const asJson = <TSettings extends object>(utf8: string): TSettings => {
   }
 }
 
-export const getSettings = async <TSettings extends object>(name?: string): Promise<TSettings> => {
-  const path = await getFilePath(name)
+const readJsonFile = async <TSettings extends {}>(property: string): Promise<TSettings> => {
+  const path = await getFilePath(property)
   const file = await readFile(path)
   return asJson<TSettings>(file)
+}
+
+export const getSettings = async <TConfig extends {} = {}>(...properties: string[]) => {
+  const settings = await Promise.all(properties.map(property => readJsonFile(property)))
+  return settings.reduce<TConfig>((config, setting) => Object.assign(config, setting), {} as TConfig)
 }

--- a/packages/mds-config-service/client.ts
+++ b/packages/mds-config-service/client.ts
@@ -49,8 +49,10 @@ const readJsonFile = async <TSettings extends {}>(property: string): Promise<TSe
 }
 
 export const client = {
-  getSettings: async <TConfig extends {} = {}>(...properties: string[]) => {
-    const settings = await Promise.all(properties.map(property => readJsonFile(property)))
+  getSettings: async <TConfig extends {} = {}>(properties: string | string[]) => {
+    const settings = await Promise.all(
+      (Array.isArray(properties) ? properties : [properties]).map(property => readJsonFile(property))
+    )
     return settings.reduce<TConfig>((config, setting) => Object.assign(config, setting), {} as TConfig)
   }
 }

--- a/packages/mds-config-service/index.ts
+++ b/packages/mds-config-service/index.ts
@@ -1,3 +1,1 @@
-import { getSettings } from './client'
-
-export default { getSettings }
+export { client } from './client'

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -26,7 +26,7 @@ describe('Test Config Client', () => {
 
   it('Multiple Settings File (missing)', async () => {
     try {
-      const settings = await client.getSettings('package', 'missing')
+      const settings = await client.getSettings(['package', 'missing'])
       test.value(settings).is(null)
     } catch (error) {
       test.value(error instanceof NotFoundError).is(true)
@@ -34,10 +34,10 @@ describe('Test Config Client', () => {
   })
 
   it('Multiple Settings File', async () => {
-    const config = await client.getSettings<{ name?: string; compilerOptions?: { outDir?: string } }>(
+    const config = await client.getSettings<{ name?: string; compilerOptions?: { outDir?: string } }>([
       'package',
       'tsconfig.build'
-    )
+    ])
     test.value(config).isNot(null)
     test.value(config.name).is('@mds-core/mds-config-service')
     test.value(config.compilerOptions?.outDir).is('dist')

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -1,6 +1,6 @@
 import test from 'unit.js'
 import { NotFoundError } from '@mds-core/mds-utils'
-import client from '../index'
+import { client } from '../client'
 
 describe('Test Config Client', () => {
   before(() => {

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -3,19 +3,41 @@ import { NotFoundError } from '@mds-core/mds-utils'
 import client from '../index'
 
 describe('Test Config Client', () => {
-  it('Missing Settings File', async () => {
+  before(() => {
+    process.env.MDS_CONFIG_PATH = './'
+  })
+
+  it('Single Settings File (missing)', async () => {
     try {
-      const settings = await client.getSettings()
+      const settings = await client.getSettings('missing')
       test.value(settings).is(null)
     } catch (error) {
       test.value(error instanceof NotFoundError).is(true)
     }
   })
 
-  it('Parse Settings File', async () => {
-    process.env.MDS_CONFIG_PATH = './'
+  it('Single Settings File', async () => {
     const settings = await client.getSettings<{ name: string }>('package')
     test.value(settings).isNot(null)
     test.value(settings.name).is('@mds-core/mds-config-service')
+  })
+
+  it('Multiple Settings File (missing)', async () => {
+    try {
+      const settings = await client.getSettings('package', 'missing')
+      test.value(settings).is(null)
+    } catch (error) {
+      test.value(error instanceof NotFoundError).is(true)
+    }
+  })
+
+  it('Multiple Settings File', async () => {
+    const config = await client.getSettings<{ name?: string; compilerOptions?: { outDir?: string } }>(
+      'package',
+      'tsconfig.build'
+    )
+    test.value(config).isNot(null)
+    test.value(config.name).is('@mds-core/mds-config-service')
+    test.value(config.compilerOptions?.outDir).is('dist')
   })
 })

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -2,6 +2,8 @@ import test from 'unit.js'
 import { NotFoundError } from '@mds-core/mds-utils'
 import { client } from '../client'
 
+const { MDS_CONFIG_PATH } = process.env
+
 describe('Test Config Client', () => {
   before(() => {
     process.env.MDS_CONFIG_PATH = './'
@@ -39,5 +41,9 @@ describe('Test Config Client', () => {
     test.value(config).isNot(null)
     test.value(config.name).is('@mds-core/mds-config-service')
     test.value(config.compilerOptions?.outDir).is('dist')
+  })
+
+  after(() => {
+    process.env.MDS_CONFIG_PATH = MDS_CONFIG_PATH
   })
 })

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -20,13 +20,16 @@ import client from '@mds-core/mds-config-service'
 import { ConfigApiGetSettingsRequest, ConfigApiResponse } from './types'
 
 function api(app: express.Express): express.Express {
-  app.get(pathsFor('/settings/:name?'), async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse) => {
-    const { name } = req.params
+  app.get(pathsFor('/settings/:properties?'), async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse) => {
+    const properties = (req.params.properties ?? 'settings')
+      .toLowerCase()
+      .replace(' ', '')
+      .split(',')
     try {
-      const settings = await client.getSettings(name)
+      const settings = await client.getSettings(...properties)
       return res.status(200).send(settings)
     } catch (error) {
-      return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, settings: name })
+      return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
     }
   })
 

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -27,7 +27,7 @@ import {
 const getSettings = async (req: ConfigApiRequest, res: ConfigApiResponse) => {
   const { properties } = res.locals
   try {
-    const settings = await client.getSettings(...properties)
+    const settings = await client.getSettings(properties)
     return res.status(200).send(settings)
   } catch (error) {
     return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
@@ -39,8 +39,7 @@ function api(app: express.Express): express.Express {
   app.get(
     pathsFor('/settings'),
     async (req: ConfigApiGetMergedSettingsRequest, res: ConfigApiResponse, next: express.NextFunction) => {
-      const { p: properties = ['settings'] } = req.query
-      res.locals.properties = Array.isArray(properties) ? properties : [properties]
+      res.locals.properties = req.query.p ?? 'settings'
       return next()
     },
     getSettings
@@ -50,8 +49,7 @@ function api(app: express.Express): express.Express {
   app.get(
     pathsFor('/settings/:property'),
     async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse, next: express.NextFunction) => {
-      const { property } = req.params
-      res.locals.properties = [property]
+      res.locals.properties = req.params.property
       return next()
     },
     getSettings

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -16,17 +16,14 @@
 
 import express from 'express'
 import { pathsFor, NotFoundError } from '@mds-core/mds-utils'
-import client from '@mds-core/mds-config-service'
+import { client } from '@mds-core/mds-config-service'
 import { ConfigApiGetSettingsRequest, ConfigApiResponse } from './types'
 
 function api(app: express.Express): express.Express {
-  app.get(pathsFor('/settings/:properties?'), async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse) => {
-    const properties = (req.params.properties ?? 'settings')
-      .toLowerCase()
-      .replace(' ', '')
-      .split(',')
+  app.get(pathsFor('/settings'), async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse) => {
+    const { p: properties = ['settings'] } = req.query
     try {
-      const settings = await client.getSettings(...properties)
+      const settings = await client.getSettings(...(Array.isArray(properties) ? properties : [properties]))
       return res.status(200).send(settings)
     } catch (error) {
       return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -17,18 +17,45 @@
 import express from 'express'
 import { pathsFor, NotFoundError } from '@mds-core/mds-utils'
 import { client } from '@mds-core/mds-config-service'
-import { ConfigApiGetSettingsRequest, ConfigApiResponse } from './types'
+import {
+  ConfigApiGetSettingsRequest,
+  ConfigApiResponse,
+  ConfigApiGetMergedSettingsRequest,
+  ConfigApiRequest
+} from './types'
+
+const getSettings = async (req: ConfigApiRequest, res: ConfigApiResponse) => {
+  const { properties } = res.locals
+  try {
+    const settings = await client.getSettings(...properties)
+    return res.status(200).send(settings)
+  } catch (error) {
+    return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
+  }
+}
 
 function api(app: express.Express): express.Express {
-  app.get(pathsFor('/settings'), async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse) => {
-    const { p: properties = ['settings'] } = req.query
-    try {
-      const settings = await client.getSettings(...(Array.isArray(properties) ? properties : [properties]))
-      return res.status(200).send(settings)
-    } catch (error) {
-      return res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
-    }
-  })
+  // Return multiple settings properties specified in the query string merged into a single object
+  app.get(
+    pathsFor('/settings'),
+    async (req: ConfigApiGetMergedSettingsRequest, res: ConfigApiResponse, next: express.NextFunction) => {
+      const { p: properties = ['settings'] } = req.query
+      res.locals.properties = Array.isArray(properties) ? properties : [properties]
+      return next()
+    },
+    getSettings
+  )
+
+  // Return a single settings property specified as a route parameter
+  app.get(
+    pathsFor('/settings/:property'),
+    async (req: ConfigApiGetSettingsRequest, res: ConfigApiResponse, next: express.NextFunction) => {
+      const { property } = req.params
+      res.locals.properties = [property]
+      return next()
+    },
+    getSettings
+  )
 
   return app
 }

--- a/packages/mds-config/tests/api.spec.ts
+++ b/packages/mds-config/tests/api.spec.ts
@@ -31,7 +31,7 @@ describe('Testing API', () => {
 
   it(`Single Settings File (404)`, done => {
     request
-      .get(`/config/settings?p=missing`)
+      .get(`/config/settings/missing`)
       .expect(404)
       .end((err, result) => {
         test.value(result.body.name).is('NotFoundError')
@@ -41,7 +41,7 @@ describe('Testing API', () => {
 
   it(`Single Settings File (200)`, done => {
     request
-      .get(`/config/settings?p=package`)
+      .get(`/config/settings/package`)
       .expect(200)
       .end((err, result) => {
         test.value(result.body.name).is('@mds-core/mds-config')

--- a/packages/mds-config/tests/api.spec.ts
+++ b/packages/mds-config/tests/api.spec.ts
@@ -22,10 +22,16 @@ import { api } from '../api'
 
 const request = supertest(ApiServer(api))
 
+const { MDS_CONFIG_PATH } = process.env
+
 describe('Testing API', () => {
+  before(() => {
+    process.env.MDS_CONFIG_PATH = './'
+  })
+
   it(`Single Settings File (404)`, done => {
     request
-      .get(`/config/settings/missing`)
+      .get(`/config/settings?p=missing`)
       .expect(404)
       .end((err, result) => {
         test.value(result.body.name).is('NotFoundError')
@@ -34,9 +40,8 @@ describe('Testing API', () => {
   })
 
   it(`Single Settings File (200)`, done => {
-    process.env.MDS_CONFIG_PATH = './'
     request
-      .get(`/config/settings/package`)
+      .get(`/config/settings?p=package`)
       .expect(200)
       .end((err, result) => {
         test.value(result.body.name).is('@mds-core/mds-config')
@@ -46,7 +51,7 @@ describe('Testing API', () => {
 
   it(`Multiple Settings File (404)`, done => {
     request
-      .get(`/config/settings/package,missing`)
+      .get(`/config/settings?p=package&p=missing`)
       .expect(404)
       .end((err, result) => {
         test.value(result.body.name).is('NotFoundError')
@@ -55,13 +60,16 @@ describe('Testing API', () => {
   })
 
   it(`Multiple Settings Files (200)`, done => {
-    process.env.MDS_CONFIG_PATH = './'
     request
-      .get(`/config/settings/package,tsconfig.build`)
+      .get(`/config/settings?p=package&p=tsconfig.build`)
       .expect(200)
       .end((err, result) => {
         test.value(result.body.name).is('@mds-core/mds-config')
         done(err)
       })
+  })
+
+  after(() => {
+    process.env.MDS_CONFIG_PATH = MDS_CONFIG_PATH
   })
 })

--- a/packages/mds-config/tests/api.spec.ts
+++ b/packages/mds-config/tests/api.spec.ts
@@ -23,7 +23,7 @@ import { api } from '../api'
 const request = supertest(ApiServer(api))
 
 describe('Testing API', () => {
-  it(`Missing Config File`, done => {
+  it(`Single Settings File (404)`, done => {
     request
       .get(`/config/settings/missing`)
       .expect(404)
@@ -33,10 +33,31 @@ describe('Testing API', () => {
       })
   })
 
-  it(`Read Config File`, done => {
+  it(`Single Settings File (200)`, done => {
     process.env.MDS_CONFIG_PATH = './'
     request
       .get(`/config/settings/package`)
+      .expect(200)
+      .end((err, result) => {
+        test.value(result.body.name).is('@mds-core/mds-config')
+        done(err)
+      })
+  })
+
+  it(`Multiple Settings File (404)`, done => {
+    request
+      .get(`/config/settings/package,missing`)
+      .expect(404)
+      .end((err, result) => {
+        test.value(result.body.name).is('NotFoundError')
+        done(err)
+      })
+  })
+
+  it(`Multiple Settings Files (200)`, done => {
+    process.env.MDS_CONFIG_PATH = './'
+    request
+      .get(`/config/settings/package,tsconfig.build`)
       .expect(200)
       .end((err, result) => {
         test.value(result.body.name).is('@mds-core/mds-config')

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -19,7 +19,7 @@ import { Params, ParamsDictionary } from 'express-serve-static-core'
 export type ConfigApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
 export interface ConfigApiResponse extends ApiResponse {
   locals: ApiResponseLocals & {
-    properties: string[]
+    properties: string | string[]
   }
 }
 

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -19,4 +19,6 @@ import { Params, ParamsDictionary } from 'express-serve-static-core'
 export type ConfigApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
 export type ConfigApiResponse = ApiResponse
 
-export type ConfigApiGetSettingsRequest = ConfigApiRequest<{ properties: string }>
+export interface ConfigApiGetSettingsRequest extends ConfigApiRequest {
+  query: Partial<{ [P in 'p']: string | string[] }>
+}

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -19,4 +19,4 @@ import { Params, ParamsDictionary } from 'express-serve-static-core'
 export type ConfigApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
 export type ConfigApiResponse = ApiResponse
 
-export type ConfigApiGetSettingsRequest = ConfigApiRequest<{ name: string }>
+export type ConfigApiGetSettingsRequest = ConfigApiRequest<{ properties: string }>

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -13,12 +13,18 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
-import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
 import { Params, ParamsDictionary } from 'express-serve-static-core'
 
 export type ConfigApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
-export type ConfigApiResponse = ApiResponse
+export interface ConfigApiResponse extends ApiResponse {
+  locals: ApiResponseLocals & {
+    properties: string[]
+  }
+}
 
-export interface ConfigApiGetSettingsRequest extends ConfigApiRequest {
+export type ConfigApiGetSettingsRequest = ConfigApiRequest<{ property: string }>
+
+export interface ConfigApiGetMergedSettingsRequest extends ConfigApiRequest {
   query: Partial<{ [P in 'p']: string | string[] }>
 }


### PR DESCRIPTION
Allow merging multiple settings properties with one GET request.

A single settings property is specified as a route param: 
`GET /config/settings/{property}`

Multiple settings properties are specified as query string parameters: 
`GET /config/settings?p={property1}&p={property2}`