### PR TITLE
[mds-audit] Speed up VIN lookup by parallelizing cache reads

### DIFF
--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -172,7 +172,7 @@ export async function getVehicle(provider_id: UUID, vehicle_id: string) {
   if (!device) {
     return null
   }
-  const deviceStatus = (await cache.readDeviceStatus(device.device_id)) as VehicleEvent & Device
+  const deviceStatus = (await cache.readDeviceStatus(device.device_id)) as (VehicleEvent & Device) | null
   if (deviceStatus !== null) {
     const status = EVENT_STATUS_MAP[deviceStatus.event_type as VEHICLE_EVENT]
     const updated = deviceStatus.timestamp

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -353,40 +353,37 @@ async function readDevices(device_ids: UUID[]) {
 }
 
 async function readDeviceStatus(device_id: UUID) {
-  let event: VehicleEvent
-  let device: Device
-  const cachedInfo = []
-  try {
-    event = await readEvent(device_id)
-    cachedInfo.push(event)
-  } catch (err) {
-    if (err.name !== 'NotFoundError') {
-      throw err
-    }
-    log.info('Missing vehicle event', 'device_id', device_id)
-  }
-  try {
-    device = await readDevice(device_id)
-    cachedInfo.push(device)
-  } catch (err) {
-    if (err.name !== 'NotFoundError') {
-      throw err
-    }
-    log.info('Missing vehicle device', 'device_id', device_id)
-  }
-
-  const deviceStatusMap: { [device_id: string]: CachedItem | {} } = {}
-  cachedInfo.map(item => {
-    deviceStatusMap[item.device_id] = deviceStatusMap[item.device_id] || {}
-    Object.assign(deviceStatusMap[item.device_id], item)
-  })
-  const statuses = Object.values(deviceStatusMap)
-  const statusWithTelemetry = statuses.find((status: any) => status.telemetry)
-  if (statusWithTelemetry === undefined) {
-    log.info('Missing vehicle telemetry', 'device_id', device_id)
-    return statuses[0]
-  }
-  return statusWithTelemetry
+  let ret: {} | null = null
+  const promises = [readEvent(device_id), readDevice(device_id)]
+  // Catch all NotFoundErrors
+  await Promise.all(
+    promises.map(p =>
+      p.catch(err => {
+        if (err.name !== 'NotFoundError') {
+          throw err
+        }
+      })
+    )
+  )
+    .then(results => {
+      const deviceStatusMap: { [device_id: string]: CachedItem | {} } = {}
+      results.map(item => {
+        if (item !== undefined) {
+          deviceStatusMap[item.device_id] = deviceStatusMap[item.device_id] || {}
+          Object.assign(deviceStatusMap[item.device_id], item)
+        }
+      })
+      const statuses = Object.values(deviceStatusMap)
+      const statusWithTelemetry = statuses.find((status: any) => status.telemetry)
+      /* eslint-disable-next-line promise/always-return */
+      if (statusWithTelemetry === undefined && statuses.length > 0) {
+        ;[ret] = statuses
+      } else if (statusWithTelemetry !== undefined) {
+        ret = statusWithTelemetry
+      }
+    })
+    .catch(err => log.error('Error reading device status', err))
+  return ret
 }
 
 /* eslint-reason redis external lib weirdness */

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -362,19 +362,16 @@ async function readDeviceStatus(device_id: UUID) {
       }
     })
   )
-  return await Promise.all(promises)
-    .then((results: any) => {
-      const deviceStatusMap: { [device_id: string]: CachedItem | {} } = {}
-      results
-        .filter((item: any) => item !== undefined)
-        .map((item: any) => {
-          deviceStatusMap[item.device_id] = deviceStatusMap[item.device_id] || {}
-          Object.assign(deviceStatusMap[item.device_id], item)
-        })
-      const statuses = Object.values(deviceStatusMap)
-      return statuses.find((status: any) => status.telemetry) || statuses[0] || null
+  const results = await Promise.all(promises).catch(err => log.error('Error reading device status', err))
+  const deviceStatusMap: { [device_id: string]: CachedItem | {} } = {}
+  results
+    .filter((item: CachedItem) => item !== undefined)
+    .map((item: CachedItem) => {
+      deviceStatusMap[item.device_id] = deviceStatusMap[item.device_id] || {}
+      Object.assign(deviceStatusMap[item.device_id], item)
     })
-    .catch(err => log.error('Error reading device status', err))
+  const statuses = Object.values(deviceStatusMap)
+  return statuses.find((status: any) => status.telemetry) || statuses[0] || null
 }
 
 /* eslint-reason redis external lib weirdness */


### PR DESCRIPTION
## PR Checklist

 - [X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [X] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [X] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author

The VIN lookup endpoint currently calls `db.readDeviceByVehicleId`, then `cache.readDevice`, then `cache.readEvent`. This PR should make those two cache fetches execute in parallel. I expect that to be effective because (somewhat surprisingly) the cache seems to be the bottleneck in this endpoint:

| Function | Mean response time (s) | p95 response time (s) |
| ------------------------- | ----------- | --------- |
| Get VIN endpoint handler | 4.08 | 18.9 |
| db.readDeviceByVehicleId | 0.8 | 3.5 |
| cache.readDevice | 1.8 | 6.5 |
| cache.readEvent | 3.1 | 8.9 |

Refs [MDSAAS-357](https://lacunadotai.atlassian.net/browse/MDSAAS-357).

Please let me know if there's a cleaner / more idiomatic way to write this `Promise.all`.