### PR TITLE
[mds-audit] Add option to skip bbox check when fetching vehicles

### DIFF
--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -650,6 +650,7 @@ function api(app: express.Express): express.Express {
     async (req, res) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const bbox = JSON.parse(req.query.bbox)
+      const strict = JSON.parse(req.query.strict || true)
 
       const url = urls.format({
         protocol: req.get('x-forwarded-proto') || req.protocol,
@@ -660,7 +661,7 @@ function api(app: express.Express): express.Express {
       const { provider_id } = req.query
 
       try {
-        const response = await getVehicles(skip, take, url, provider_id, req.query, bbox)
+        const response = await getVehicles(skip, take, url, provider_id, req.query, bbox, strict)
         return res.status(200).send(response)
       } catch (err) {
         await log.error('getVehicles fail', err)

--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -189,7 +189,8 @@ export async function getVehicles(
   url: string,
   provider_id: string,
   reqQuery: { [x: string]: string },
-  bbox: BoundingBox
+  bbox: BoundingBox,
+  strict = true
 ) {
   function fmt(query: { skip: number; take: number }): string {
     const flat: { [key: string]: number } = { ...reqQuery, ...query }
@@ -201,7 +202,7 @@ export async function getVehicles(
   }
 
   const start = now()
-  const statusesSuperset = ((await cache.readDevicesStatus({ bbox })) as (VehicleEvent & Device)[]).filter(
+  const statusesSuperset = ((await cache.readDevicesStatus({ bbox, strict })) as (VehicleEvent & Device)[]).filter(
     status =>
       EVENT_STATUS_MAP[status.event_type as VEHICLE_EVENT] !== VEHICLE_STATUSES.removed &&
       (!provider_id || status.provider_id === provider_id)


### PR DESCRIPTION
## PR Checklist

 - [X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [X] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [X] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author

Audit's "get vehicles by bbox" endpoint fetches events from redis using a `georadiusAsync` call, which accepts a circle (lat, lng, and radius) as its argument. The circle we use for this argument inscribes the original bbox, so there is an extra check to remove events outside the requested bbox from the response.

The audit mobile app can live without this extra check, so this PR adds an option to skip it and potentially speed up the endpoint.

Refs [MDSAAS-362](https://lacunadotai.atlassian.net/browse/MDSAAS-362).