### PR TITLE
use branch name for docker image tag suffix

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -294,13 +294,7 @@ buildImage() {
 }
 
 getBranchSuffix() {
-  case "$(git rev-parse --abbrev-ref HEAD)" in
-    master) suffix="";;
-    develop) suffix="-prerelease";;
-    *) suffix="-unstable";;
-  esac
-
-  echo ${suffix}
+  git rev-parse --abbrev-ref HEAD | sed -r -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^/-/'
 }
 
 # TODO: DRY

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -294,7 +294,7 @@ buildImage() {
 }
 
 getBranchSuffix() {
-  git rev-parse --abbrev-ref HEAD | sed -r -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^/-/'
+  git rev-parse --abbrev-ref HEAD | sed -E -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^/-/'
 }
 
 # TODO: DRY

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -354,7 +354,7 @@ async function readDevices(device_ids: UUID[]) {
 
 async function readDeviceStatus(device_id: UUID) {
   // Read event and device in parallel, catching NotFoundErrors
-  const promises = [readEvent(device_id), readDevice(device_id)].map(p =>
+  const promises = [readEvent(device_id), readDevice(device_id)].map((p: Promise<{}>) =>
     /* eslint-disable-next-line promise/prefer-await-to-callbacks */
     p.catch((err: Error) => {
       if (err.name !== 'NotFoundError') {


### PR DESCRIPTION
converts the branch name into the suffix in the docker image tag.  Prevents competing branches from stomping on each others' build output.