### PR TITLE
[mds-web-sockets] Add proper env-injection to mds-web-sockets

### DIFF
--- a/container-images/mds-web-sockets/index.ts
+++ b/container-images/mds-web-sockets/index.ts
@@ -15,5 +15,10 @@
  */
 
 import { WebSocketServer } from '@mds-core/mds-web-sockets'
+import { env } from '@container-images/env-inject'
+
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4009 } = env()
 
 WebSocketServer()
+
+console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)


### PR DESCRIPTION
This enables the `about` (HTTP GET `$HOST/mds-websockets/`) to return a well-formed response. E.g.

```json
{
  "name": "@container-images/mds-web-sockets",
  "version": "0.0.1",
  "build": {
    "date": "2019-12-21T16:04:08.459Z",
    "branch": "bugfix/neil/env-inject-web-sockets",
    "commit": "ab47f5d"
  },
  "node": "10.16.3",
  "status": "Running"
}
```

## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


