### PR TITLE
[mds-agency] [mds-web-sockets] Improve agency/telemetry error handling, and add basic health check to WebSocket client

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -412,12 +412,6 @@ export const submitVehicleTelemetry = async (req: AgencyApiRequest, res: AgencyA
     if (valid.length) {
       const recorded_telemetry = await writeTelemetry(valid)
 
-      try {
-        await socket.writeTelemetry(recorded_telemetry)
-      } catch (err) {
-        await log.error('Failed to write telemetry to socket', err)
-      }
-
       const delta = Date.now() - start
       if (delta > 300) {
         log.info(

--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -395,11 +395,15 @@ export function getServiceArea(event: VehicleEvent): UUID | null {
 
 export async function writeTelemetry(telemetry: Telemetry | Telemetry[]) {
   const recorded_telemetry = await db.writeTelemetry(Array.isArray(telemetry) ? telemetry : [telemetry])
-  await Promise.all([
-    cache.writeTelemetry(recorded_telemetry),
-    stream.writeTelemetry(recorded_telemetry),
-    socket.writeTelemetry(recorded_telemetry)
-  ])
+  try {
+    await Promise.all([
+      cache.writeTelemetry(recorded_telemetry),
+      stream.writeTelemetry(recorded_telemetry),
+      socket.writeTelemetry(recorded_telemetry)
+    ])
+  } catch (err) {
+    await log.warn(`Failed to write telemetry to cache/socket/stream, ${err}`)
+  }
   return recorded_telemetry
 }
 

--- a/packages/mds-web-sockets/client.ts
+++ b/packages/mds-web-sockets/client.ts
@@ -5,7 +5,7 @@ import { setWsHeartbeat, WebSocketBase } from 'ws-heartbeat/client'
 import requestPromise from 'request-promise'
 import { ENTITY_TYPE } from './types'
 
-const { TOKEN, URL = 'ws://mds-web-sockets:4000' } = process.env
+const { TOKEN, URL = 'mds-web-sockets:4000' } = process.env
 
 let connection: WebSocket
 
@@ -20,12 +20,12 @@ async function getClient() {
   }
 
   try {
-    const res = await requestPromise(URL)
+    const res = await requestPromise(`http://${URL}`)
 
     if (res.statusCode === 503) {
       throw new Error('Could not connect to WebSocket server')
     }
-    connection = new WebSocket(URL)
+    connection = new WebSocket(`ws://${URL}`)
 
     setWsHeartbeat(connection as WebSocketBase, 'PING')
 

--- a/packages/mds-web-sockets/client.ts
+++ b/packages/mds-web-sockets/client.ts
@@ -34,8 +34,12 @@ function getClient() {
 
 /* Force test event to be send back to client */
 async function sendPush(entity: ENTITY_TYPE, data: VehicleEvent | Telemetry) {
-  const client = getClient()
-  return client.send(`PUSH%${entity}%${JSON.stringify(data)}`)
+  try {
+    const client = getClient()
+    return client.send(`PUSH%${entity}%${JSON.stringify(data)}`)
+  } catch (err) {
+    await log.warn(err)
+  }
 }
 
 export function writeTelemetry(telemetries: Telemetry[]) {


### PR DESCRIPTION
Previously, agency/telemetry POST requests would send a 400 response to clients on a failed write to cache/stream/socket; this PR resolves the extraneous error bubbling to the API client. It also adds a basic health check to the internal WebSocket client used by agency to validate that the WebSocket http server is running before attempting to establish a connection.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [x] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author