### PR TITLE
[mds-utils] Unify state transition representation

### DIFF
--- a/packages/mds-utils/state-machine.ts
+++ b/packages/mds-utils/state-machine.ts
@@ -1,0 +1,49 @@
+import { VEHICLE_STATUSES, VEHICLE_EVENTS, VEHICLE_STATUS, VEHICLE_EVENT } from '@mds-core/mds-types'
+
+const stateTransitionDict: {
+  [S in VEHICLE_STATUS]: Partial<
+    {
+      [E in VEHICLE_EVENT]: VEHICLE_STATUS
+    }
+  >
+} = {
+  [VEHICLE_STATUSES.available]: {
+    [VEHICLE_EVENTS.deregister]: VEHICLE_STATUSES.inactive,
+    [VEHICLE_EVENTS.agency_pick_up]: VEHICLE_STATUSES.removed,
+    [VEHICLE_EVENTS.service_end]: VEHICLE_STATUSES.unavailable,
+    [VEHICLE_EVENTS.trip_start]: VEHICLE_STATUSES.trip
+  },
+  [VEHICLE_STATUSES.elsewhere]: {
+    [VEHICLE_EVENTS.trip_enter]: VEHICLE_STATUSES.trip,
+    [VEHICLE_EVENTS.provider_pick_up]: VEHICLE_STATUSES.removed,
+    [VEHICLE_EVENTS.deregister]: VEHICLE_STATUSES.inactive,
+    [VEHICLE_EVENTS.provider_drop_off]: VEHICLE_STATUSES.available
+  },
+  [VEHICLE_STATUSES.inactive]: {},
+  [VEHICLE_STATUSES.removed]: {
+    [VEHICLE_EVENTS.register]: VEHICLE_STATUSES.removed,
+    [VEHICLE_EVENTS.trip_enter]: VEHICLE_STATUSES.trip,
+    [VEHICLE_EVENTS.provider_drop_off]: VEHICLE_STATUSES.available,
+    [VEHICLE_EVENTS.deregister]: VEHICLE_STATUSES.inactive
+  },
+  [VEHICLE_STATUSES.reserved]: {
+    [VEHICLE_EVENTS.trip_start]: VEHICLE_STATUSES.trip,
+    [VEHICLE_EVENTS.cancel_reservation]: VEHICLE_STATUSES.available
+  },
+  [VEHICLE_STATUSES.trip]: {
+    [VEHICLE_EVENTS.trip_leave]: VEHICLE_STATUSES.elsewhere,
+    [VEHICLE_EVENTS.trip_end]: VEHICLE_STATUSES.available
+  },
+  [VEHICLE_STATUSES.unavailable]: {
+    [VEHICLE_EVENTS.service_start]: VEHICLE_STATUSES.available,
+    [VEHICLE_EVENTS.deregister]: VEHICLE_STATUSES.inactive,
+    [VEHICLE_EVENTS.agency_pick_up]: VEHICLE_STATUSES.removed,
+    [VEHICLE_EVENTS.provider_pick_up]: VEHICLE_STATUSES.removed
+  }
+}
+
+const getNextState = (currStatus: VEHICLE_STATUS, nextEvent: VEHICLE_EVENT): VEHICLE_STATUS | undefined => {
+  return stateTransitionDict[currStatus]?.[nextEvent]
+}
+
+export { stateTransitionDict, getNextState }

--- a/packages/mds-utils/tests/utils.spec.ts
+++ b/packages/mds-utils/tests/utils.spec.ts
@@ -16,6 +16,7 @@
 
 import test from 'unit.js'
 import assert from 'assert'
+import { VEHICLE_EVENTS, VehicleEvent } from '@mds-core/mds-types'
 import {
   routeDistance,
   filterEmptyHelper,
@@ -23,6 +24,8 @@ import {
   parseCount,
   parseUnit,
   parseIsRelative,
+  isStateTransitionValidOld,
+  isStateTransitionValid,
   normalizeToArray
 } from '../utils'
 
@@ -144,6 +147,23 @@ describe('Tests Utilities', () => {
     })
     it('Leaves array untouched', () => {
       assert.deepStrictEqual(normalizeToArray(['test1', 'test2']), ['test1', 'test2'])
+    })
+  })
+
+  describe('State machine', () => {
+    it('Tests state transitions', () => {
+      const events = Object.keys(VEHICLE_EVENTS)
+      for (const event_type_A of events) {
+        for (const event_type_B of events) {
+          const eventA = { event_type: event_type_A } as VehicleEvent
+          const eventB = { event_type: event_type_B } as VehicleEvent
+          assert.strictEqual(
+            isStateTransitionValid(eventA, eventB),
+            isStateTransitionValidOld(eventA, eventB),
+            `${eventA.event_type}, ${eventB.event_type}`
+          )
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
The `isTransitionValidOld()` will be removed, I left it in to verify compliance with the existing implementation.

At some point I'd like to re-evaluate the `VEHICLE_STATUS`/`VEHICLE_STATUSES`/`EVENT_STATUS_MAP`/`STATUS_EVENT_MAP` stuff so we could just lean on this dictionary as well. I'd also like to re-evaluate our custom rolled `Enum` implementation.

