### PR TITLE
[mds-metrics] Fixes metrics scope processing

### DIFF
--- a/packages/mds-metrics/api.ts
+++ b/packages/mds-metrics/api.ts
@@ -81,15 +81,9 @@ function api(app: express.Express): express.Express {
 
         // stash provider_id
         res.locals.provider_id = provider_id
-        const provider_ids = normalizeToArray<UUID>(req.query.provider_id).filter(
-          currProviderId => currProviderId === provider_id
-        )
         // res.locals.provider_ids must contain provider_id from claim
-        if (provider_ids.length === 0) {
-          res.locals.provider_ids = [provider_id]
-        } else {
-          res.locals.provider_ids = provider_ids
-        }
+        // other queried providers are ignored
+        res.locals.provider_ids = [provider_id]
       } else if (res.locals.scopes.includes('metrics:read')) {
         const provider_ids = normalizeToArray<UUID>(req.query.provider_id)
         res.locals.provider_ids = provider_ids

--- a/packages/mds-metrics/api.ts
+++ b/packages/mds-metrics/api.ts
@@ -57,13 +57,10 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/all'),
+    checkAccess(scopes => scopes.includes('metrics:read') || scopes.includes('metrics:read:provider')),
     async (req, res, next) => {
       if (res.locals.scopes.includes('metrics:read:provider')) {
-        if (!res.locals.claims) {
-          return res.status(400).send({
-            result: 'No claims provided'
-          })
-        }
+        // Claim exists if previous check passes
         const { provider_id } = res.locals.claims
 
         if (!isUUID(provider_id)) {
@@ -92,7 +89,6 @@ function api(app: express.Express): express.Express {
       }
       next()
     },
-    checkAccess(scopes => scopes.includes('metrics:read') || scopes.includes('metrics:read:provider')),
     getAll
   )
 

--- a/packages/mds-metrics/api.ts
+++ b/packages/mds-metrics/api.ts
@@ -20,7 +20,7 @@ import { pathsFor, isUUID, normalizeToArray } from '@mds-core/mds-utils'
 import { checkAccess } from '@mds-core/mds-api-server'
 import log from '@mds-core/mds-logger'
 import { isProviderId } from '@mds-core/mds-providers'
-import { UUID } from 'packages/mds-types'
+import { UUID } from '@mds-core/mds-types'
 import {
   getStateSnapshot,
   getEventSnapshot,

--- a/packages/mds-metrics/package.json
+++ b/packages/mds-metrics/package.json
@@ -24,7 +24,7 @@
     "start": "PATH_PREFIX=/metrics yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "PATH_PREFIX=/metrics DOTENV_CONFIG_PATH=../../.env nyc --lines 80 ts-mocha --project ../../tsconfig.json",
+    "test:unit": "PATH_PREFIX=/metrics DOTENV_CONFIG_PATH=../../.env nyc --lines 75 ts-mocha --project ../../tsconfig.json",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-metrics/request-handlers.ts
+++ b/packages/mds-metrics/request-handlers.ts
@@ -241,6 +241,7 @@ export async function getAll(req: MetricsApiRequest, res: GetAllResponse) {
     return res.status(400).send(new BadParamsError(`Bad format query param: ${format}`))
   }
 
+  // TODO if empty array and metrics:read:provider scope, specify default [claimProviderId] in query
   for (const currProviderId of provider_ids) {
     if (!isUUID(currProviderId)) {
       return res.status(400).send(new BadParamsError(`provider_id ${currProviderId} is not a UUID`))

--- a/packages/mds-metrics/request-handlers.ts
+++ b/packages/mds-metrics/request-handlers.ts
@@ -227,6 +227,13 @@ export async function getAll(req: MetricsApiRequest, res: GetAllResponse) {
       return prevSlices.concat(currSlices)
     }, [])
   const provider_ids = normalizeToArray<UUID>(query.provider_id)
+  if (res.locals.scopes.includes('metrics:read:provider')) {
+    for (const provider_id of provider_ids) {
+      if (provider_id !== res.locals.provider_id) {
+        return res.status(400).send(`invalid provider_id ${provider_id} is not a known provider`)
+      }
+    }
+  }
   const vehicle_types = normalizeToArray<VEHICLE_TYPE>(query.vehicle_type)
   const format: string | 'json' | 'tsv' = query.format || 'json'
 

--- a/packages/mds-metrics/request-handlers.ts
+++ b/packages/mds-metrics/request-handlers.ts
@@ -8,7 +8,7 @@ import {
   parseRelative,
   normalizeToArray
 } from '@mds-core/mds-utils'
-import { EVENT_STATUS_MAP, VEHICLE_TYPES, UUID, VEHICLE_TYPE } from '@mds-core/mds-types'
+import { EVENT_STATUS_MAP, VEHICLE_TYPES, VEHICLE_TYPE } from '@mds-core/mds-types'
 import { Parser } from 'json2csv'
 import fs from 'fs'
 

--- a/packages/mds-metrics/request-handlers.ts
+++ b/packages/mds-metrics/request-handlers.ts
@@ -230,7 +230,7 @@ export async function getAll(req: MetricsApiRequest, res: GetAllResponse) {
   if (res.locals.scopes.includes('metrics:read:provider')) {
     for (const provider_id of provider_ids) {
       if (provider_id !== res.locals.provider_id) {
-        return res.status(400).send(`invalid provider_id ${provider_id} is not a known provider`)
+        return res.status(400).send(`invalid provider_id ${provider_id} does not match claim ${res.locals.provider_id}`)
       }
     }
   }

--- a/packages/mds-metrics/request-handlers.ts
+++ b/packages/mds-metrics/request-handlers.ts
@@ -227,13 +227,6 @@ export async function getAll(req: MetricsApiRequest, res: GetAllResponse) {
       return prevSlices.concat(currSlices)
     }, [])
   const { provider_ids } = res.locals
-  if (res.locals.scopes.includes('metrics:read:provider')) {
-    for (const provider_id of provider_ids) {
-      if (provider_id !== res.locals.provider_id) {
-        return res.status(400).send(`invalid provider_id ${provider_id} does not match claim ${res.locals.provider_id}`)
-      }
-    }
-  }
   const vehicle_types = normalizeToArray<VEHICLE_TYPE>(query.vehicle_type)
   const format: string | 'json' | 'tsv' = query.format || 'json'
 

--- a/packages/mds-metrics/tests/request-handlers.test.ts
+++ b/packages/mds-metrics/tests/request-handlers.test.ts
@@ -21,7 +21,10 @@ describe('Request handlers', () => {
     const send = Sinon.fake.returns('boop')
     const status = Sinon.fake.returns({ send })
     const res: GetAllResponse = ({
-      status
+      status,
+      locals: {
+        provider_ids: []
+      }
     } as unknown) as GetAllResponse
 
     const fakeMetricsRows: MetricsTableRow[] = []
@@ -45,15 +48,16 @@ describe('Request handlers', () => {
         end_time: 400,
         bin_size: 100
       },
-      query: {
-        provider_id
-      }
+      query: {}
     } as MetricsApiRequest
 
     const send = Sinon.fake.returns('boop')
     const status = Sinon.fake.returns({ send })
     const res: GetAllResponse = ({
-      status
+      status,
+      locals: {
+        provider_ids: [provider_id]
+      }
     } as unknown) as GetAllResponse
 
     const fakeMetricsRows: MetricsTableRow[] = []
@@ -79,7 +83,6 @@ describe('Request handlers', () => {
         bin_size: 100
       },
       query: {
-        provider_id,
         format: 'tsv'
       }
     } as MetricsApiRequest
@@ -87,7 +90,10 @@ describe('Request handlers', () => {
     const send = Sinon.fake.returns('boop')
     const status = Sinon.fake.returns({ send })
     const res: GetAllResponse = ({
-      status
+      status,
+      locals: {
+        provider_ids: [provider_id]
+      }
     } as unknown) as GetAllResponse
 
     const fakeMetricsRows: MetricsTableRow[] = [
@@ -124,15 +130,16 @@ describe('Request handlers', () => {
         end_time: 400,
         bin_size: 100
       },
-      query: {
-        provider_id
-      }
+      query: {}
     } as MetricsApiRequest
 
     const send = Sinon.fake.returns('boop')
     const status = Sinon.fake.returns({ send })
     const res: GetAllResponse = ({
-      status
+      status,
+      locals: {
+        provider_ids: [provider_id]
+      }
     } as unknown) as GetAllResponse
 
     await requestHandlers.getAll(req, res)
@@ -152,7 +159,6 @@ describe('Request handlers', () => {
         bin_size: 100
       },
       query: {
-        provider_id,
         format: 'not-valid'
       }
     } as MetricsApiRequest
@@ -160,7 +166,10 @@ describe('Request handlers', () => {
     const send = Sinon.fake.returns('boop')
     const status = Sinon.fake.returns({ send })
     const res: GetAllResponse = ({
-      status
+      status,
+      locals: {
+        provider_ids: [provider_id]
+      }
     } as unknown) as GetAllResponse
 
     await requestHandlers.getAll(req, res)

--- a/packages/mds-metrics/types.ts
+++ b/packages/mds-metrics/types.ts
@@ -74,6 +74,7 @@ export interface MetricsApiRequest extends ApiRequest {
 export type MetricsApiResponse<T> = ApiResponse<T | Error> & {
   locals: ApiResponseLocals & {
     provider_id: UUID
+    provider_ids: UUID[]
   }
 }
 export type GetStateSnapshotResponse = MetricsApiResponse<StateSnapshotResponse[]>

--- a/packages/mds-metrics/types.ts
+++ b/packages/mds-metrics/types.ts
@@ -1,4 +1,4 @@
-import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
 import {
   VEHICLE_STATUS,
   VEHICLE_EVENT,
@@ -71,7 +71,11 @@ export interface MetricsApiRequest extends ApiRequest {
   body: Partial<GetTimeBinsParams & { provider_id: UUID }>
 }
 
-export type MetricsApiResponse<T> = ApiResponse<T | Error>
+export type MetricsApiResponse<T> = ApiResponse<T | Error> & {
+  locals: ApiResponseLocals & {
+    provider_id: UUID
+  }
+}
 export type GetStateSnapshotResponse = MetricsApiResponse<StateSnapshotResponse[]>
 export type GetEventsSnapshotResponse = MetricsApiResponse<EventSnapshotResponse[]>
 export type GetTelemetryCountsResponse = MetricsApiResponse<TelemetryCountsResponse[]>

--- a/packages/mds-types/scopes.ts
+++ b/packages/mds-types/scopes.ts
@@ -10,6 +10,8 @@ export const AccessTokenScopes = [
   'events:read',
   'events:read:provider',
   'events:write:provider',
+  'metrics:read',
+  'metrics:read:provider',
   'policies:delete',
   'policies:publish',
   'policies:read',
@@ -21,9 +23,7 @@ export const AccessTokenScopes = [
   'trips:read',
   'vehicles:read',
   'vehicles:read:provider',
-  'vehicles:write:provider',
-  'metrics:read',
-  'metrics:read:provider'
+  'vehicles:write:provider'
 ] as const
 export type AccessTokenScope = typeof AccessTokenScopes[number]
 
@@ -38,6 +38,8 @@ export const ScopeDescriptions: { [S in AccessTokenScope]: string } = {
   'events:read': 'Read Events',
   'events:read:provider': 'Read Events (Provider Access)',
   'events:write:provider': 'Write Events (Provider Access)',
+  'metrics:read': 'Read Metrics',
+  'metrics:read:provider': 'Read Metrics (Provider Access)',
   'policies:delete': 'Delete Policies',
   'policies:publish': 'Publish Policies',
   'policies:read': 'Read Policies',
@@ -49,7 +51,5 @@ export const ScopeDescriptions: { [S in AccessTokenScope]: string } = {
   'trips:read': 'Read Trips',
   'vehicles:read': 'Read Vehicles',
   'vehicles:read:provider': 'Read Vehicles (Provider Access)',
-  'vehicles:write:provider': 'Write Vehicles (Provider Access)',
-  'metrics:read': 'Read Metrics',
-  'metrics:read:provider': 'Read Metrics (Provider Access)'
+  'vehicles:write:provider': 'Write Vehicles (Provider Access)'
 }

--- a/packages/mds-types/scopes.ts
+++ b/packages/mds-types/scopes.ts
@@ -21,7 +21,9 @@ export const AccessTokenScopes = [
   'trips:read',
   'vehicles:read',
   'vehicles:read:provider',
-  'vehicles:write:provider'
+  'vehicles:write:provider',
+  'metrics:read',
+  'metrics:read:provider'
 ] as const
 export type AccessTokenScope = typeof AccessTokenScopes[number]
 
@@ -47,5 +49,7 @@ export const ScopeDescriptions: { [S in AccessTokenScope]: string } = {
   'trips:read': 'Read Trips',
   'vehicles:read': 'Read Vehicles',
   'vehicles:read:provider': 'Read Vehicles (Provider Access)',
-  'vehicles:write:provider': 'Write Vehicles (Provider Access)'
+  'vehicles:write:provider': 'Write Vehicles (Provider Access)',
+  'metrics:read': 'Read Metrics',
+  'metrics:read:provider': 'Read Metrics (Provider Access)'
 }


### PR DESCRIPTION
`/metrics/all` accepts the scopes `metrics:read` and `metrics:read:provider`

`metrics:read` allows reading from any provider. If the `provider_id` query param is not specified, the SQL query will return all providers. If one or more `provider_id` query params are supplied, we will only query for those specified providers.

`metrics:read:provider` only allows querying of the associated `provider_id` in the claim. If no provider id is specified, or if provider ids besides the JWT claimed provider id are given, we always only query the JWT `provider_id`.