### PR TITLE
[mds-daily] *URGENT PATCH* Assume cache as source-of-truth for getTimeSinceLastEvent

### DIFF
--- a/packages/mds-daily/db-helpers.ts
+++ b/packages/mds-daily/db-helpers.ts
@@ -29,9 +29,9 @@ export const getTripCountsSince = async ({ start_time, end_time, provider_info, 
 export const getTimeSinceLastEvent = async ({ provider_info, fail }: DbHelperArgs) => {
   try {
     const start = now()
-    await cache.getMostRecentEventByProvider()
-    const rows = await db.getMostRecentEventByProvider()
-    // TODO fall back to DB if we're missing providers
+    const rows = await cache.getMostRecentEventByProvider()
+    /* FIXME fall back to DB if we're missing providers
+       await db.getMostRecentEventByProvider() */
     const finish = now()
     const timeElapsed = finish - start
     await log.info(`MDS-DAILY cache.getMostRecentEventByProvider() time elapsed: ${timeElapsed}`)


### PR DESCRIPTION
This resolves a performance issue in production causing last_day_stats_by_provider to not ever respond due to an ~75s query `db.getMostRecentEventByProvider()`. Actually providing fallback logic based on validation of the cache response will be added in a subsequent PR.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [x] Daily
- [ ] Native
- [ ] Policy Author