### PR TITLE
disable istio for cronjob deployments

### DIFF
--- a/helm/mds/templates/cronjob.yaml
+++ b/helm/mds/templates/cronjob.yaml
@@ -5,6 +5,8 @@ kind: CronJob
 metadata:
   name: {{ $name }}-cron
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    sidecar.istio.io/inject: "false"
 spec:
   schedule: {{ $cronjob.schedule | quote }}
   jobTemplate:


### PR DESCRIPTION
istio-enabled cronjobs are not being disposed of upon exit given the istio-sidecar container remains alive.

istio-enabling cronjobs provides no value, that i am aware of, at this time ... could be wrong, over time.

test:

- tested by inspecting `helm template ./helm/mds -x templates/cronjob.yaml`


