### PR TITLE
Update Config API to support partial configs

### DIFF
--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -10,47 +10,53 @@ describe('Test Config Client', () => {
   })
 
   it('Single Settings File (missing)', async () => {
-    try {
-      const settings = await client.getSettings('missing')
-      test.value(settings).is(null)
-    } catch (error) {
-      test.value(error instanceof NotFoundError).is(true)
-    }
+    const [error, settings] = await client.getSettings(['missing'])
+    test.value(error instanceof NotFoundError).is(true)
+    test.value(settings).is(null)
   })
 
   it('Single Settings File', async () => {
-    const settings = await client.getSettings<{ name: string }>('package')
+    const [error, settings] = await client.getSettings<{ name: string }>(['package'])
+    test.value(error).is(null)
     test.value(settings).isNot(null)
-    test.value(settings.name).is('@mds-core/mds-config-service')
+    test.value(settings?.name).is('@mds-core/mds-config-service')
   })
 
   it('Multiple Settings File (missing)', async () => {
-    try {
-      const settings = await client.getSettings(['package', 'missing'])
-      test.value(settings).is(null)
-    } catch (error) {
-      test.value(error instanceof NotFoundError).is(true)
-    }
+    const [error, settings] = await client.getSettings(['package', 'missing'])
+    test.value(error instanceof NotFoundError).is(true)
+    test.value(settings).is(null)
   })
 
   it('Multiple Settings File', async () => {
-    const config = await client.getSettings<{ name?: string; compilerOptions?: { outDir?: string } }>([
+    const [error, settings] = await client.getSettings<{ name?: string; compilerOptions?: { outDir?: string } }>([
       'package',
       'tsconfig.build'
     ])
-    test.value(config).isNot(null)
-    test.value(config.name).is('@mds-core/mds-config-service')
-    test.value(config.compilerOptions?.outDir).is('dist')
+    test.value(error).is(null)
+    test.value(settings).isNot(null)
+    test.value(settings?.name).is('@mds-core/mds-config-service')
+    test.value(settings?.compilerOptions?.outDir).is('dist')
+  })
+
+  it('Config Manager (missing)', async () => {
+    let caught: Error | null = null
+    try {
+      await ConfigurationManager<{ name?: string; compilerOptions?: { outDir?: string } }>(['missing']).settings()
+    } catch (error) {
+      caught = error
+    }
+    test.value(caught instanceof NotFoundError).is(true)
   })
 
   it('Config Manager', async () => {
-    const config = await ConfigurationManager<{ name?: string; compilerOptions?: { outDir?: string } }>([
+    const settings = await ConfigurationManager<{ name?: string; compilerOptions?: { outDir?: string } }>([
       'package',
       'tsconfig.build'
-    ]).configuration()
-    test.value(config).isNot(null)
-    test.value(config.name).is('@mds-core/mds-config-service')
-    test.value(config.compilerOptions?.outDir).is('dist')
+    ]).settings()
+    test.value(settings).isNot(null)
+    test.value(settings.name).is('@mds-core/mds-config-service')
+    test.value(settings.compilerOptions?.outDir).is('dist')
   })
 
   after(() => {

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -15,6 +15,13 @@ describe('Test Config Client', () => {
     test.value(settings).is(null)
   })
 
+  it('Single Settings File (partial)', async () => {
+    const [error, settings] = await client.getSettings<{ missing: unknown }>(['missing'], { partial: true })
+    test.value(error).is(null)
+    test.value(settings).isNot(null)
+    test.value(settings?.missing).is(null)
+  })
+
   it('Single Settings File', async () => {
     const [error, settings] = await client.getSettings<{ name: string }>(['package'])
     test.value(error).is(null)
@@ -26,6 +33,16 @@ describe('Test Config Client', () => {
     const [error, settings] = await client.getSettings(['package', 'missing'])
     test.value(error instanceof NotFoundError).is(true)
     test.value(settings).is(null)
+  })
+
+  it('Multiple Settings File (partial)', async () => {
+    const [error, settings] = await client.getSettings<{ name?: string; missing: unknown }>(['package', 'missing'], {
+      partial: true
+    })
+    test.value(error).is(null)
+    test.value(settings).isNot(null)
+    test.value(settings?.name).is('@mds-core/mds-config-service')
+    test.value(settings?.missing).is(null)
   })
 
   it('Multiple Settings File', async () => {

--- a/packages/mds-config-service/tests/client.spec.ts
+++ b/packages/mds-config-service/tests/client.spec.ts
@@ -16,14 +16,14 @@ describe('Test Config Client', () => {
   })
 
   it('Single Settings File (partial)', async () => {
-    const [error, settings] = await client.getSettings<{ missing: unknown }>(['missing'], { partial: true })
+    const [error, settings] = await client.getSettings<{ missing?: unknown }>(['missing'], { partial: true })
     test.value(error).is(null)
     test.value(settings).isNot(null)
     test.value(settings?.missing).is(null)
   })
 
   it('Single Settings File', async () => {
-    const [error, settings] = await client.getSettings<{ name: string }>(['package'])
+    const [error, settings] = await client.getSettings<{ name?: string }>(['package'])
     test.value(error).is(null)
     test.value(settings).isNot(null)
     test.value(settings?.name).is('@mds-core/mds-config-service')
@@ -36,7 +36,7 @@ describe('Test Config Client', () => {
   })
 
   it('Multiple Settings File (partial)', async () => {
-    const [error, settings] = await client.getSettings<{ name?: string; missing: unknown }>(['package', 'missing'], {
+    const [error, settings] = await client.getSettings<{ name?: string; missing?: unknown }>(['package', 'missing'], {
       partial: true
     })
     test.value(error).is(null)
@@ -64,6 +64,15 @@ describe('Test Config Client', () => {
       caught = error
     }
     test.value(caught instanceof NotFoundError).is(true)
+  })
+
+  it('Config Manager (partial)', async () => {
+    const settings = await ConfigurationManager<{ name?: string; missing?: unknown }>(['package', 'missing'], {
+      partial: true
+    }).settings()
+    test.value(settings).isNot(null)
+    test.value(settings.name).is('@mds-core/mds-config-service')
+    test.value(settings.missing).is(null)
   })
 
   it('Config Manager', async () => {

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -17,16 +17,14 @@
 import express from 'express'
 import { pathsFor, NotFoundError } from '@mds-core/mds-utils'
 import { client } from '@mds-core/mds-config-service'
-import {
-  ConfigApiGetSettingsRequest,
-  ConfigApiResponse,
-  ConfigApiGetMergedSettingsRequest,
-  ConfigApiRequest
-} from './types'
+import { ConfigApiGetSettingsRequest, ConfigApiResponse, ConfigApiGetMergedSettingsRequest } from './types'
 
-const getSettings = async (req: ConfigApiRequest, res: ConfigApiResponse) => {
+const getSettings = async (
+  req: ConfigApiGetSettingsRequest | ConfigApiGetMergedSettingsRequest,
+  res: ConfigApiResponse
+) => {
   const { properties } = res.locals
-  const [error, settings] = await client.getSettings(properties)
+  const [error, settings] = await client.getSettings(properties, { partial: req.query.partial === 'true' })
   return error
     ? res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
     : res.status(200).send(settings)

--- a/packages/mds-config/api.ts
+++ b/packages/mds-config/api.ts
@@ -15,7 +15,7 @@
  */
 
 import express from 'express'
-import { pathsFor, NotFoundError } from '@mds-core/mds-utils'
+import { pathsFor } from '@mds-core/mds-utils'
 import { client } from '@mds-core/mds-config-service'
 import { ConfigApiGetSettingsRequest, ConfigApiResponse, ConfigApiGetMergedSettingsRequest } from './types'
 
@@ -25,9 +25,7 @@ const getSettings = async (
 ) => {
   const { properties } = res.locals
   const [error, settings] = await client.getSettings(properties, { partial: req.query.partial === 'true' })
-  return error
-    ? res.status(error instanceof NotFoundError ? 404 : 500).send({ ...error, properties })
-    : res.status(200).send(settings)
+  return error ? res.status(404).send(error) : res.status(200).send(settings)
 }
 
 function api(app: express.Express): express.Express {

--- a/packages/mds-config/tests/api.spec.ts
+++ b/packages/mds-config/tests/api.spec.ts
@@ -29,7 +29,7 @@ describe('Testing API', () => {
     process.env.MDS_CONFIG_PATH = './'
   })
 
-  it(`Default Settings File (404)`, done => {
+  it(`Default Settings File (missing)`, done => {
     request
       .get(`/config/settings`)
       .expect(404)
@@ -39,7 +39,17 @@ describe('Testing API', () => {
       })
   })
 
-  it(`Single Settings File (404)`, done => {
+  it(`Default Settings File (partial)`, done => {
+    request
+      .get(`/config/settings?partial=true`)
+      .expect(200)
+      .end((err, result) => {
+        test.value(result.body.settings).is(null)
+        done(err)
+      })
+  })
+
+  it(`Single Settings File (missing)`, done => {
     request
       .get(`/config/settings?p=missing`)
       .expect(404)
@@ -49,7 +59,17 @@ describe('Testing API', () => {
       })
   })
 
-  it(`Single Settings File (200)`, done => {
+  it(`Single Settings File (partial)`, done => {
+    request
+      .get(`/config/settings/missing?partial=true`)
+      .expect(200)
+      .end((err, result) => {
+        test.value(result.body.missing).is(null)
+        done(err)
+      })
+  })
+
+  it(`Single Settings File`, done => {
     request
       .get(`/config/settings/package`)
       .expect(200)
@@ -59,7 +79,7 @@ describe('Testing API', () => {
       })
   })
 
-  it(`Multiple Settings File (404)`, done => {
+  it(`Multiple Settings File (missing)`, done => {
     request
       .get(`/config/settings?p=package&p=missing`)
       .expect(404)
@@ -69,7 +89,18 @@ describe('Testing API', () => {
       })
   })
 
-  it(`Multiple Settings Files (200)`, done => {
+  it(`Multiple Settings File (partial)`, done => {
+    request
+      .get(`/config/settings?p=package&p=missing&partial=true`)
+      .expect(200)
+      .end((err, result) => {
+        test.value(result.body.name).is('@mds-core/mds-config')
+        test.value(result.body.missing).is(null)
+        done(err)
+      })
+  })
+
+  it(`Multiple Settings Files`, done => {
     request
       .get(`/config/settings?p=package&p=tsconfig.build`)
       .expect(200)

--- a/packages/mds-config/tests/api.spec.ts
+++ b/packages/mds-config/tests/api.spec.ts
@@ -29,9 +29,19 @@ describe('Testing API', () => {
     process.env.MDS_CONFIG_PATH = './'
   })
 
+  it(`Default Settings File (404)`, done => {
+    request
+      .get(`/config/settings`)
+      .expect(404)
+      .end((err, result) => {
+        test.value(result.body.name).is('NotFoundError')
+        done(err)
+      })
+  })
+
   it(`Single Settings File (404)`, done => {
     request
-      .get(`/config/settings/missing`)
+      .get(`/config/settings?p=missing`)
       .expect(404)
       .end((err, result) => {
         test.value(result.body.name).is('NotFoundError')

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -19,7 +19,7 @@ import { Params, ParamsDictionary } from 'express-serve-static-core'
 export type ConfigApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
 export interface ConfigApiResponse extends ApiResponse {
   locals: ApiResponseLocals & {
-    properties: string | string[]
+    properties: string[]
   }
 }
 

--- a/packages/mds-config/types.ts
+++ b/packages/mds-config/types.ts
@@ -23,8 +23,18 @@ export interface ConfigApiResponse extends ApiResponse {
   }
 }
 
-export type ConfigApiGetSettingsRequest = ConfigApiRequest<{ property: string }>
+interface ConfigApiGetSettingsQueryParameters {
+  partial: string
+}
+
+export interface ConfigApiGetSettingsRequest extends ConfigApiRequest<{ property: string }> {
+  query: Partial<ConfigApiGetSettingsQueryParameters>
+}
+
+interface ConfigApiGetMergedSettingsQueryParameters extends ConfigApiGetSettingsQueryParameters {
+  p: string | string[]
+}
 
 export interface ConfigApiGetMergedSettingsRequest extends ConfigApiRequest {
-  query: Partial<{ [P in 'p']: string | string[] }>
+  query: Partial<ConfigApiGetMergedSettingsQueryParameters>
 }

--- a/packages/mds-provider-processor/src/configuration.ts
+++ b/packages/mds-provider-processor/src/configuration.ts
@@ -24,4 +24,4 @@ interface ProviderProcessorConfig {
 
 const manager = ConfigurationManager<ProviderProcessorConfig>(['organization', 'providers', 'compliance_sla'])
 
-export const getConfig = async () => manager.configuration()
+export const getConfig = async () => manager.settings()

--- a/packages/mds-trip-processor/src/configuration.ts
+++ b/packages/mds-trip-processor/src/configuration.ts
@@ -9,4 +9,4 @@ interface TripProcessorConfig {
 
 const manager = ConfigurationManager<TripProcessorConfig>(['compliance_sla'])
 
-export const getConfig = async () => manager.configuration()
+export const getConfig = async () => manager.settings()

--- a/packages/mds-utils/date-time-utils.ts
+++ b/packages/mds-utils/date-time-utils.ts
@@ -151,12 +151,4 @@ const parseRelative = (
   throw new BadParamsError(`Both start_offset and end_offset cannot be relative to each other`)
 }
 
-export {
-  parseOperator,
-  parseCount,
-  parseUnit,
-  parseOffset,
-  parseAnchorPoint,
-  parseRelative,
-  parseIsRelative
-}
+export { parseOperator, parseCount, parseUnit, parseOffset, parseAnchorPoint, parseRelative, parseIsRelative }


### PR DESCRIPTION
You can now include `?partial=true` to receive `null` values for settings and a `200 OK` rather than a `404 Not Found` error. 
```json
{
  "providers": [
    {
      "provider_name": "...",
      "provider_id": "..."
    }
  ],
  "foo": null
}
```
Also, cleaned up the response body for `404 Not Found` errors to provide insight into what properties failed without leaking any server setup information.
```json
{
  "name": "NotFoundError",
  "reason": "Settings Not Found",
  "info": {
    "found": [
      "providers"
    ],
    "missing": [
      "foo"
    ]
  }
}
```
Also, added corresponding tests to maintain coverage:
`@mds-core/mds-config-service`
```
-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |   96.23 |    86.36 |     100 |      96 |                   
 client.ts |   96.23 |    86.36 |     100 |      96 | 40,47             
-----------|---------|----------|---------|---------|-------------------
```
`@mds-core/mds-config`
```
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 api.ts   |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------
```