### PR TITLE
Increase default timeout values to reduce spurious 503 errors from Istio

### DIFF
--- a/container-images/http-server/index.ts
+++ b/container-images/http-server/index.ts
@@ -1,6 +1,3 @@
-import { env } from '@container-images/env-inject'
-import express from 'express'
-
 /*
     Copyright 2019 City of Los Angeles.
 
@@ -16,6 +13,10 @@ import express from 'express'
     See the License for the specific language governing permissions and
     limitations under the License.
  */
+
+import { env } from '@container-images/env-inject'
+import express from 'express'
+
 const {
   npm_package_name,
   npm_package_version,
@@ -31,7 +32,7 @@ export const HttpServer = (port: number, api: express.Express) => {
     console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${port}`)
   )
 
-  // Increase default timeout values to reduce spurious 503 errors from Istio
+  // Increase default timeout values to mitigate spurious 503 errors from Istio
   server.keepAliveTimeout = Number(HTTP_KEEP_ALIVE_TIMEOUT)
   server.headersTimeout = Number(HTTP_HEADERS_TIMEOUT)
 

--- a/container-images/http-server/index.ts
+++ b/container-images/http-server/index.ts
@@ -1,0 +1,39 @@
+import { env } from '@container-images/env-inject'
+import express from 'express'
+
+/*
+    Copyright 2019 City of Los Angeles.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+const {
+  npm_package_name,
+  npm_package_version,
+  npm_package_git_commit,
+  HTTP_KEEP_ALIVE_TIMEOUT = 15000,
+  HTTP_HEADERS_TIMEOUT = 20000
+} = env()
+
+export const HttpServer = (port: number, api: express.Express) => {
+  const server = api.listen(port, () =>
+    /* eslint-reason avoids import of logger */
+    /* eslint-disable-next-line no-console */
+    console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${port}`)
+  )
+
+  // Increase default timeout values to reduce spurious 503 errors from Istio
+  server.keepAliveTimeout = Number(HTTP_KEEP_ALIVE_TIMEOUT)
+  server.headersTimeout = Number(HTTP_HEADERS_TIMEOUT)
+
+  return server
+}

--- a/container-images/http-server/package.json
+++ b/container-images/http-server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@container-images/http-server",
+  "version": "0.1.0",
+  "description": "Http server code for MDS APIs",
+  "main": "dist/index.js",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "yarn test:eslint && yarn test:unit",
+    "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
+    "test:unit": "exit 0"
+  },
+  "keywords": [
+    "mds"
+  ],
+  "author": "City of Los Angeles",
+  "dependencies": {
+    "@container-images/env-inject": "0.1.25",
+    "express": "4.17.1"
+  },
+  "license": "Apache-2.0"
+}

--- a/container-images/http-server/tsconfig.build.json
+++ b/container-images/http-server/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "references": [{ "path": "../../container-images/env-inject/tsconfig.build.json" }]
+}

--- a/container-images/mds-agency/index.ts
+++ b/container-images/mds-agency/index.ts
@@ -14,22 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-agency'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4001, HTTP_KEEP_ALIVE = 15000 } = env()
-
-const keepAliveTimeout = Number(HTTP_KEEP_ALIVE)
-
-const server = ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(
-    `${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}; (Timeout: ${keepAliveTimeout})`
-  )
-)
-
-server.keepAliveTimeout = keepAliveTimeout
-server.headersTimeout = keepAliveTimeout + 5000
+HttpServer(Number(process.env.PORT ?? 4001), ApiServer(api))

--- a/container-images/mds-agency/index.ts
+++ b/container-images/mds-agency/index.ts
@@ -19,10 +19,17 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-agency'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4001 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4001, HTTP_KEEP_ALIVE = 15000 } = env()
 
-ApiServer(api).listen(PORT, () =>
+const keepAliveTimeout = Number(HTTP_KEEP_ALIVE)
+
+const server = ApiServer(api).listen(PORT, () =>
   /* eslint-reason avoids import of logger */
   /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+  console.log(
+    `${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}; (Timeout: ${keepAliveTimeout})`
+  )
 )
+
+server.keepAliveTimeout = keepAliveTimeout
+server.headersTimeout = keepAliveTimeout + 5000

--- a/container-images/mds-agency/package.json
+++ b/container-images/mds-agency/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-agency": "0.0.28",
     "@mds-core/mds-api-server": "0.1.26"
   },

--- a/container-images/mds-agency/tsconfig.build.json
+++ b/container-images/mds-agency/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-agency/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-audit/index.ts
+++ b/container-images/mds-audit/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-audit'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4002 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4002), ApiServer(api))

--- a/container-images/mds-audit/package.json
+++ b/container-images/mds-audit/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-audit": "0.1.38"
   },

--- a/container-images/mds-audit/tsconfig.build.json
+++ b/container-images/mds-audit/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-audit/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-compliance/index.ts
+++ b/container-images/mds-compliance/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-compliance'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4004 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4004), ApiServer(api))

--- a/container-images/mds-compliance/package.json
+++ b/container-images/mds-compliance/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-compliance": "0.1.27"
   },

--- a/container-images/mds-compliance/tsconfig.build.json
+++ b/container-images/mds-compliance/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-compliance/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-config/index.ts
+++ b/container-images/mds-config/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-config'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4008 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4008), ApiServer(api))

--- a/container-images/mds-config/package.json
+++ b/container-images/mds-config/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-config": "0.0.2"
   },

--- a/container-images/mds-config/tsconfig.build.json
+++ b/container-images/mds-config/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-config/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-daily/index.ts
+++ b/container-images/mds-daily/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-daily'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4005 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4005), ApiServer(api))

--- a/container-images/mds-daily/package.json
+++ b/container-images/mds-daily/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-daily": "0.0.27"
   },

--- a/container-images/mds-daily/tsconfig.build.json
+++ b/container-images/mds-daily/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-daily/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-metrics/index.ts
+++ b/container-images/mds-metrics/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-metrics'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4005 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4005), ApiServer(api))

--- a/container-images/mds-metrics/package.json
+++ b/container-images/mds-metrics/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-metrics": "0.0.8"
   },

--- a/container-images/mds-metrics/tsconfig.build.json
+++ b/container-images/mds-metrics/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-metrics/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-native/index.ts
+++ b/container-images/mds-native/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-native'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4006 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4006), ApiServer(api))

--- a/container-images/mds-native/package.json
+++ b/container-images/mds-native/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-native": "0.0.24"
   },

--- a/container-images/mds-native/tsconfig.build.json
+++ b/container-images/mds-native/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-native/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-policy-author/index.ts
+++ b/container-images/mds-policy-author/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy-author'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4007 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4007), ApiServer(api))

--- a/container-images/mds-policy-author/package.json
+++ b/container-images/mds-policy-author/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-policy-author": "0.0.23"
   },

--- a/container-images/mds-policy-author/tsconfig.build.json
+++ b/container-images/mds-policy-author/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-policy-author/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]

--- a/container-images/mds-policy/index.ts
+++ b/container-images/mds-policy/index.ts
@@ -14,15 +14,8 @@
     limitations under the License.
  */
 
-// Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy'
-import { env } from '@container-images/env-inject'
+import { HttpServer } from '@container-images/http-server'
 
-const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4003 } = env()
-
-ApiServer(api).listen(PORT, () =>
-  /* eslint-reason avoids import of logger */
-  /* eslint-disable-next-line no-console */
-  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
-)
+HttpServer(Number(process.env.PORT ?? 4003), ApiServer(api))

--- a/container-images/mds-policy/package.json
+++ b/container-images/mds-policy/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "City of Los Angeles",
   "dependencies": {
-    "@container-images/env-inject": "0.1.25",
+    "@container-images/http-server": "0.1.0",
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-policy": "0.0.27"
   },

--- a/container-images/mds-policy/tsconfig.build.json
+++ b/container-images/mds-policy/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../container-images/env-inject/tsconfig.build.json" },
+    { "path": "../../container-images/http-server/tsconfig.build.json" },
     { "path": "../../packages/mds-policy/tsconfig.build.json" },
     { "path": "../../packages/mds-api-server/tsconfig.build.json" }
   ]


### PR DESCRIPTION
Increasing the keep alive timeout value for all Express http servers to mitigate the spurious 503 errors being observed from Istio