### PR TITLE
carve out exception to jwt auth for websockets api 

### DIFF
--- a/helm/mds/templates/auth.yaml
+++ b/helm/mds/templates/auth.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.jwt.enabled }}
 {{- range $name, $api := .Values.apis }}
 {{- if $api.enabled }}
+{{ if (ne $name "mds-web-sockets") }}
 ---
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
@@ -25,6 +26,7 @@ spec:
         - exact: {{ $api.pathPrefix }}/health
         - exact: /health
   principalBinding: USE_ORIGIN
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Auth is done internally by mds-web-socketrs due to different headers for ws protocol

