### PR TITLE
[mds-native] Convert empty event.event_type_reason to null

### DIFF
--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -115,7 +115,10 @@ function api(app: express.Express): express.Express {
               last_id: events.length === 0 ? cursor.last_id : events[events.length - 1].id
             })
           ).toString('base64'),
-          events: events.map(({ id, service_area_id, ...event }) => event)
+          events: events.map(({ id, service_area_id, event_type_reason, ...event }) => ({
+            ...event,
+            event_type_reason: event_type_reason || null
+          }))
         })
       } catch (err) {
         if (err instanceof ValidationError) {


### PR DESCRIPTION
Mapping `event_type_reason` with empty string values to `null`. Merging hot fix to main branch.

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [x] Native
- [ ] Policy Author


