### PR TITLE
[mds-agency] [mds-web-sockets] Add NATS-Streaming consumption for mds-web-sockets

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,4 +1,4 @@
-name: mds-web-sockets
+name: mds-agency
 namespace: mds
 image: node:12.14.1
 command: ['bash']

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,6 +1,6 @@
-name: mds-agency
+name: mds-web-sockets
 namespace: mds
-image: node:12
+image: node:12.14.1
 command: ['bash']
 forward:
   - 9229:9229

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -14,7 +14,6 @@
     "@mds-core/mds-stream": "0.1.26",
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
-    "@mds-core/mds-web-sockets": "0.0.1",
     "express": "4.17.1",
     "ladot-service-areas": "0.1.9",
     "uuid": "7.0.1"

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -20,7 +20,6 @@ import {
   UUID
 } from '@mds-core/mds-types'
 import urls from 'url'
-import * as socket from '@mds-core/mds-web-sockets'
 import {
   badDevice,
   getVehicles,
@@ -345,19 +344,11 @@ export const submitVehicleEvent = async (req: AgencyApiRequest, res: AgencyApiRe
     }
 
     try {
-      await Promise.all([
-        cache.writeEvent(recorded_event),
-        stream.writeEvent(recorded_event),
-        socket.writeEvent(recorded_event)
-      ])
+      await Promise.all([cache.writeEvent(recorded_event), stream.writeEvent(recorded_event)])
 
       if (telemetry) {
         telemetry.recorded = recorded
-        await Promise.all([
-          cache.writeTelemetry([telemetry]),
-          stream.writeTelemetry([telemetry]),
-          socket.writeTelemetry([telemetry])
-        ])
+        await Promise.all([cache.writeTelemetry([telemetry]), stream.writeTelemetry([telemetry])])
       }
 
       await success()

--- a/packages/mds-event-server/index.ts
+++ b/packages/mds-event-server/index.ts
@@ -109,6 +109,10 @@ export const initializeStanSubscriber = async <TData, TResult>({
         })
       )
     })
+
+    nats.on('error', async err => {
+      await log.error(err)
+    })
   } catch (err) {
     await log.error(err)
   }

--- a/packages/mds-event-server/index.ts
+++ b/packages/mds-event-server/index.ts
@@ -110,6 +110,7 @@ export const initializeStanSubscriber = async <TData, TResult>({
       )
     })
 
+    /* eslint-ignore-next */
     nats.on('error', async err => {
       await log.error(err)
     })

--- a/packages/mds-event-server/index.ts
+++ b/packages/mds-event-server/index.ts
@@ -65,7 +65,7 @@ const initializeNatsClient = ({
   STAN_CLUSTER: string
   STAN_CREDS?: string
 }) => {
-  return stan.connect(STAN_CLUSTER, `mds-event-processor-${uuid()}`, {
+  return stan.connect(STAN_CLUSTER, `mds-event-consumer-${uuid()}`, {
     url: `nats://${NATS}:4222`,
     userCreds: STAN_CREDS,
     reconnect: true

--- a/packages/mds-event-server/index.ts
+++ b/packages/mds-event-server/index.ts
@@ -110,7 +110,7 @@ export const initializeStanSubscriber = async <TData, TResult>({
       )
     })
 
-    /* eslint-ignore-next */
+    /* istanbul ignore next */
     nats.on('error', async err => {
       await log.error(err)
     })

--- a/packages/mds-web-sockets/package.json
+++ b/packages/mds-web-sockets/package.json
@@ -14,6 +14,8 @@
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
   "dependencies": {
+    "@mds-core/mds-api-server": "0.1.26",
+    "@mds-core/mds-event-server": "0.1.0",
     "@mds-core/mds-logger": "0.1.24",
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
@@ -26,6 +28,7 @@
     "server": "yarn watch launch_server",
     "client": "yarn watch client",
     "test": "yarn test:eslint && yarn test:unit",
+    "start": "yarn watch launch_server",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --lines 50 ts-mocha --project ../../tsconfig.json --exit",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",

--- a/packages/mds-web-sockets/server.ts
+++ b/packages/mds-web-sockets/server.ts
@@ -4,6 +4,7 @@ import WebSocket from 'ws'
 import { setWsHeartbeat } from 'ws-heartbeat/server'
 import { Telemetry, VehicleEvent } from '@mds-core/mds-types'
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
+import { initializeStanSubscriber } from '@mds-core/mds-event-server'
 import { Clients } from './clients'
 import { ENTITY_TYPE } from './types'
 
@@ -65,6 +66,7 @@ export const WebSocketServer = () => {
         .split('%')
       const [header, ...args] = message
 
+      /* Testing message, also useful in a NATS-less environment */
       if (header === 'PUSH') {
         if (clients.isAuthenticated(ws)) {
           if (args.length === 2) {
@@ -104,4 +106,26 @@ export const WebSocketServer = () => {
       return ws.send('Invalid request!')
     })
   })
+
+  const {
+    env: { NATS = 'localhost', STAN_CLUSTER = 'nats-streaming', STAN_CREDS, TENANT_ID = 'mds' }
+  } = process
+
+  const processor = async (type: string, data: VehicleEvent | Telemetry) => {
+    switch (type) {
+      case 'event': {
+        await writeEvent(data as VehicleEvent)
+        return
+      }
+      case 'telemetry': {
+        await writeTelemetry(data as Telemetry)
+        return
+      }
+      default:
+        await log.error(`Unprocessable entity of type: ${type} and data: ${JSON.stringify(data)}`)
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  initializeStanSubscriber({ NATS, STAN_CLUSTER, STAN_CREDS, TENANT_ID, processor })
 }


### PR DESCRIPTION
This allows us to avoid having to create a direct connection between agency and the web-sockets server. Massively improves scalability options, and some operational headaches we've been experiencing recently.


## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [x] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author