### PR TITLE
Fix failing compliance test

### DIFF
--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -210,7 +210,7 @@ const COUNT_POLICY_JSON_5: Policy = {
   ],
   end_date: null,
   policy_id: '25851571-b53f-4426-a033-f375be0e7957',
-  start_date: 1552678594428,
+  start_date: Date.now(),
   description:
     'Prohibited areas for dockless vehicles within the City of Los Angeles for the LADOT Dockless On-Demand Personal Mobility Program',
   prev_policies: null


### PR DESCRIPTION
This test was destined to fail starting yesterday...
<img width="669" alt="Screen Shot 2020-03-16 at 11 46 54 AM" src="https://user-images.githubusercontent.com/3439869/76775572-ed69e580-677b-11ea-94f2-9b5a2bde5012.png">
