### PR TITLE
[mds-stream-processor] Add geo labeling for mds-stream-processor

### DIFF
--- a/packages/mds-stream-processor/labelers/geography-labeler.ts
+++ b/packages/mds-stream-processor/labelers/geography-labeler.ts
@@ -31,7 +31,7 @@ export const GeographyLabeler: () => MessageLabeler<
   if (gps) {
     const { lat, lng } = gps
 
-    const geographies = await db.readGeographies()
+    const geographies = await db.readGeographies({ get_published: true })
 
     const geography_ids = geographies
       .filter(({ geography_json }) => pointInShape({ lat, lng }, geography_json))

--- a/packages/mds-stream-processor/labelers/geography-labeler.ts
+++ b/packages/mds-stream-processor/labelers/geography-labeler.ts
@@ -16,7 +16,7 @@
 
 import db from '@mds-core/mds-db'
 import { UUID, Nullable, Telemetry } from '@mds-core/mds-types'
-import { pointInShape, filterEmptyHelper } from '@mds-core/mds-utils'
+import { pointInShape } from '@mds-core/mds-utils'
 import { MessageLabeler } from './types'
 
 export interface GeographyLabel {

--- a/packages/mds-stream-processor/labelers/geography-labeler.ts
+++ b/packages/mds-stream-processor/labelers/geography-labeler.ts
@@ -34,11 +34,8 @@ export const GeographyLabeler: () => MessageLabeler<
     const geographies = await db.readGeographies()
 
     const geography_ids = geographies
-      .map(geography => {
-        const { geography_id, geography_json } = geography
-        return pointInShape({ lat, lng }, geography_json) ? geography_id : null
-      })
-      .filter(filterEmptyHelper())
+      .filter(({ geography_json }) => pointInShape({ lat, lng }, geography_json))
+      .map(({ geography_id }) => geography_id)
 
     return { geography_ids }
   }

--- a/packages/mds-stream-processor/package.json
+++ b/packages/mds-stream-processor/package.json
@@ -28,5 +28,8 @@
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26"
   },
+  "devDependencies": {
+    "sinon": "7.5.0"
+  },
   "license": "Apache-2.0"
 }

--- a/packages/mds-stream-processor/tests/labelers/geograpy-labelers.spec.ts
+++ b/packages/mds-stream-processor/tests/labelers/geograpy-labelers.spec.ts
@@ -6,7 +6,7 @@ import { Geography } from '@mds-core/mds-types'
 import { v4 as uuid } from 'uuid'
 import assert from 'assert'
 
-const mockGeographies: Geography[] = Array.from({ length: 100 }, (_, index) => ({
+const mockGeographies: Geography[] = Array.from({ length: 100 }, () => ({
   geography_id: uuid(),
   geography_json: {
     type: 'FeatureCollection',

--- a/packages/mds-stream-processor/tests/labelers/geograpy-labelers.spec.ts
+++ b/packages/mds-stream-processor/tests/labelers/geograpy-labelers.spec.ts
@@ -1,0 +1,41 @@
+import { GeographyLabeler } from '@mds-core/mds-stream-processor/labelers/geography-labeler'
+import * as utils from '@mds-core/mds-utils'
+import db from '@mds-core/mds-db'
+import Sinon from 'sinon'
+import { Geography } from '@mds-core/mds-types'
+import { v4 as uuid } from 'uuid'
+import assert from 'assert'
+
+const mockGeographies: Geography[] = Array.from({ length: 100 }, (_, index) => ({
+  geography_id: uuid(),
+  geography_json: {
+    type: 'FeatureCollection',
+    features: []
+  },
+  name: uuid() // Usually intended to be a human readable name, but we just need a random string here.
+}))
+
+const mockTelemetry = {
+  provider_id: uuid(),
+  device_id: uuid(),
+  timestamp: utils.now(),
+  gps: { lat: 34.0522, lng: 118.2437 }
+}
+
+describe('GeographyLabeler tests', async () => {
+  it('Tests all matched geographies are included in list', async () => {
+    Sinon.replace(utils, 'pointInShape', () => true)
+    Sinon.replace(db, 'readGeographies', async () => mockGeographies)
+
+    const { geography_ids } = await GeographyLabeler()({ telemetry: mockTelemetry })
+
+    geography_ids.forEach(geography_id =>
+      assert(mockGeographies.find(geography => geography.geography_id === geography_id))
+    )
+  })
+
+  it('Tests that absent gps in telemetry elicits no matches', async () => {
+    const { geography_ids } = await GeographyLabeler()({})
+    assert(geography_ids.length === [].length)
+  })
+})

--- a/packages/mds-stream-processor/tests/labelers/latency-labeler.spec.ts
+++ b/packages/mds-stream-processor/tests/labelers/latency-labeler.spec.ts
@@ -1,0 +1,22 @@
+import { LatencyLabeler } from '@mds-core/mds-stream-processor/labelers/latency-labeler'
+import assert from 'assert'
+
+describe('LatencyLabeler Tests', async () => {
+  it('Tests LatencyLabeler detects latency > 0', async () => {
+    const mockTimeChunks = Array.from({ length: 100 }, (_, index) => ({
+      timestamp: 1000 * index,
+      recorded: 1000 * (index + 1)
+    }))
+    const latencyLabels = await Promise.all(mockTimeChunks.map(chunk => LatencyLabeler()(chunk)))
+    latencyLabels.forEach(({ latency_ms }) => assert(latency_ms === 1000))
+  })
+
+  it('Tests LatencyLabeler returns latency == 0', async () => {
+    const mockTimeChunks = Array.from({ length: 100 }, (_, index) => ({
+      timestamp: 1000 * index,
+      recorded: 1000 * index
+    }))
+    const latencyLabels = await Promise.all(mockTimeChunks.map(chunk => LatencyLabeler()(chunk)))
+    latencyLabels.forEach(({ latency_ms }) => assert(latency_ms === 0))
+  })
+})


### PR DESCRIPTION
There are future improvements in the pipeline for this logic (calculating surrounding bbox to speed up worst-case PIP checks, only read from db on init and then read incoming geos from stream, etc)...


## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author