### PR TITLE
Enable ES2019 features in node:12.14.1-alpine

### DIFF
--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2019",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Node.js has 100% support for ES2019 in v12.14.1

<img width="779" alt="Screen Shot 2020-04-10 at 9 08 48 AM" src="https://user-images.githubusercontent.com/3439869/78993386-98678800-7b0b-11ea-8dc9-b56439c514c5.png">

Enabling the new 2019 features by updating the TypeScript target. Here are some of the more useful bits now available:

<img width="880" alt="Screen Shot 2020-04-10 at 9 12 28 AM" src="https://user-images.githubusercontent.com/3439869/78993465-bcc36480-7b0b-11ea-8ca1-2f5eae8c2dda.png">

 