### PR TITLE
Move jurisdiction types/utils to service package

### DIFF
--- a/packages/mds-jurisdiction-service/@types/index.ts
+++ b/packages/mds-jurisdiction-service/@types/index.ts
@@ -15,14 +15,21 @@
  */
 
 import { ServiceResponse } from '@mds-core/mds-service-helpers'
-import { Jurisdiction, UUID, Timestamp } from '@mds-core/mds-types'
+import { UUID, Timestamp } from '@mds-core/mds-types'
 import { ValidationError, ConflictError, NotFoundError, ServerError } from '@mds-core/mds-utils'
 import { DeepPartial } from 'typeorm'
+import {
+  JurisdictionEntityModel,
+  JurisdictionVersionedProperties
+} from '../server/repository/entities/jurisdiction-entity'
 
-export type CreateJurisdictionType = Partial<Pick<Jurisdiction, 'jurisdiction_id' | 'timestamp'>> &
-  Pick<Jurisdiction, 'agency_key' | 'agency_name' | 'geography_id'>
+export type JurisdictionDomainModel = Omit<JurisdictionEntityModel, 'id' | 'recorded' | 'versions'> &
+  JurisdictionVersionedProperties
 
-export type UpdateJurisdictionType = DeepPartial<Jurisdiction>
+export type CreateJurisdictionType = Partial<Pick<JurisdictionDomainModel, 'jurisdiction_id' | 'timestamp'>> &
+  Pick<JurisdictionDomainModel, 'agency_key' | 'agency_name' | 'geography_id'>
+
+export type UpdateJurisdictionType = DeepPartial<JurisdictionDomainModel>
 
 export interface GetJurisdictionsOptions {
   effective: Timestamp
@@ -31,22 +38,22 @@ export interface GetJurisdictionsOptions {
 export interface JurisdictionServiceInterface {
   createJurisdiction: (
     jurisdiction: CreateJurisdictionType
-  ) => Promise<ServiceResponse<Jurisdiction, ValidationError | ConflictError>>
+  ) => Promise<ServiceResponse<JurisdictionDomainModel, ValidationError | ConflictError>>
   createJurisdictions: (
     jurisdictions: CreateJurisdictionType[]
-  ) => Promise<ServiceResponse<Jurisdiction[], ValidationError | ConflictError>>
+  ) => Promise<ServiceResponse<JurisdictionDomainModel[], ValidationError | ConflictError>>
   updateJurisdiction: (
     jurisdiction_id: UUID,
     update: UpdateJurisdictionType
-  ) => Promise<ServiceResponse<Jurisdiction, ValidationError | NotFoundError>>
+  ) => Promise<ServiceResponse<JurisdictionDomainModel, ValidationError | NotFoundError>>
   deleteJurisdiction: (
     jurisdiction_id: UUID
-  ) => Promise<ServiceResponse<Pick<Jurisdiction, 'jurisdiction_id'>, NotFoundError>>
+  ) => Promise<ServiceResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>, NotFoundError>>
   getJurisdictions: (
     options?: Partial<GetJurisdictionsOptions>
-  ) => Promise<ServiceResponse<Jurisdiction[], ServerError>>
+  ) => Promise<ServiceResponse<JurisdictionDomainModel[], ServerError>>
   getJurisdiction: (
     jurisdiction_id: UUID,
     options?: Partial<GetJurisdictionsOptions>
-  ) => Promise<ServiceResponse<Jurisdiction, NotFoundError>>
+  ) => Promise<ServiceResponse<JurisdictionDomainModel, NotFoundError>>
 }

--- a/packages/mds-jurisdiction-service/server/handlers/create-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/create-jurisdiction-handler.ts
@@ -15,14 +15,13 @@
  */
 
 import { ServiceResponse, ServiceError, ServiceResult } from '@mds-core/mds-service-helpers'
-import { Jurisdiction } from '@mds-core/mds-types'
 import { ValidationError, ConflictError, ServerError } from '@mds-core/mds-utils'
-import { CreateJurisdictionType } from '../../@types'
+import { CreateJurisdictionType, JurisdictionDomainModel } from '../../@types'
 import { CreateJurisdictionsHandler } from './create-jurisdictions-handler'
 
 export const CreateJurisdictionHandler = async (
   jurisdiction: CreateJurisdictionType
-): Promise<ServiceResponse<Jurisdiction, ValidationError | ConflictError>> => {
+): Promise<ServiceResponse<JurisdictionDomainModel, ValidationError | ConflictError>> => {
   const [error, jurisdictions] = await CreateJurisdictionsHandler([jurisdiction])
   return error || !jurisdictions ? ServiceError(error ?? new ServerError()) : ServiceResult(jurisdictions[0])
 }

--- a/packages/mds-jurisdiction-service/server/handlers/create-jurisdictions-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/create-jurisdictions-handler.ts
@@ -15,21 +15,18 @@
  */
 
 import { ServiceResponse, ServiceResult, ServiceError } from '@mds-core/mds-service-helpers'
-import { Jurisdiction } from '@mds-core/mds-types'
 import { ValidationError, ConflictError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
-import { CreateJurisdictionType } from '../../@types'
-import { AsJurisdictionEntity, AsJurisdiction } from './utils'
+import { CreateJurisdictionType, JurisdictionDomainModel } from '../../@types'
+import { AsJurisdictionEntity, AsJurisdiction, isJurisdiction } from './utils'
 import { JurisdictionRepository } from '../repository'
 
 export const CreateJurisdictionsHandler = async (
   jurisdictions: CreateJurisdictionType[]
-): Promise<ServiceResponse<Jurisdiction[], ValidationError | ConflictError>> => {
+): Promise<ServiceResponse<JurisdictionDomainModel[], ValidationError | ConflictError>> => {
   try {
     const entities = await JurisdictionRepository.writeJurisdictions(jurisdictions.map(AsJurisdictionEntity))
-    return ServiceResult(
-      entities.map(AsJurisdiction()).filter((jurisdiction): jurisdiction is Jurisdiction => jurisdiction !== null)
-    )
+    return ServiceResult(entities.map(AsJurisdiction()).filter(isJurisdiction))
   } catch (error) /* istanbul ignore next */ {
     logger.error('Error Creating Jurisdictions', error)
     return ServiceError(error instanceof ValidationError ? error : new ConflictError(error))

--- a/packages/mds-jurisdiction-service/server/handlers/delete-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/delete-jurisdiction-handler.ts
@@ -14,16 +14,17 @@
     limitations under the License.
  */
 
-import { UUID, Jurisdiction } from '@mds-core/mds-types'
+import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceResult, ServiceError } from '@mds-core/mds-service-helpers'
 import { NotFoundError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 import { AsJurisdiction } from './utils'
 import { JurisdictionRepository } from '../repository'
+import { JurisdictionDomainModel } from '../../@types'
 
 export const DeleteJurisdictionHandler = async (
   jurisdiction_id: UUID
-): Promise<ServiceResponse<Pick<Jurisdiction, 'jurisdiction_id'>, NotFoundError>> => {
+): Promise<ServiceResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>, NotFoundError>> => {
   try {
     const entity = await JurisdictionRepository.readJurisdiction(jurisdiction_id)
     if (entity) {

--- a/packages/mds-jurisdiction-service/server/handlers/get-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/get-jurisdiction-handler.ts
@@ -14,18 +14,18 @@
     limitations under the License.
  */
 
-import { UUID, Jurisdiction } from '@mds-core/mds-types'
+import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceResult, ServiceError } from '@mds-core/mds-service-helpers'
 import { NotFoundError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
-import { GetJurisdictionsOptions } from '../../@types'
+import { GetJurisdictionsOptions, JurisdictionDomainModel } from '../../@types'
 import { AsJurisdiction } from './utils'
 import { JurisdictionRepository } from '../repository'
 
 export const GetJurisdictionHandler = async (
   jurisdiction_id: UUID,
   { effective = Date.now() }: Partial<GetJurisdictionsOptions> = {}
-): Promise<ServiceResponse<Jurisdiction, NotFoundError>> => {
+): Promise<ServiceResponse<JurisdictionDomainModel, NotFoundError>> => {
   try {
     const entity = await JurisdictionRepository.readJurisdiction(jurisdiction_id)
     const [jurisdiction] = [entity].map(AsJurisdiction(effective))

--- a/packages/mds-jurisdiction-service/server/handlers/get-jurisdictions-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/get-jurisdictions-handler.ts
@@ -15,21 +15,18 @@
  */
 
 import { ServiceResponse, ServiceResult, ServiceError } from '@mds-core/mds-service-helpers'
-import { Jurisdiction } from '@mds-core/mds-types'
 import { ServerError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
-import { GetJurisdictionsOptions } from '../../@types'
-import { AsJurisdiction } from './utils'
+import { GetJurisdictionsOptions, JurisdictionDomainModel } from '../../@types'
+import { AsJurisdiction, isJurisdiction } from './utils'
 import { JurisdictionRepository } from '../repository'
 
 export const GetJurisdictionsHandler = async ({
   effective = Date.now()
-}: Partial<GetJurisdictionsOptions> = {}): Promise<ServiceResponse<Jurisdiction[], ServerError>> => {
+}: Partial<GetJurisdictionsOptions> = {}): Promise<ServiceResponse<JurisdictionDomainModel[], ServerError>> => {
   try {
     const entities = await JurisdictionRepository.readJurisdictions()
-    const jurisdictions = entities
-      .map(AsJurisdiction(effective))
-      .filter((jurisdiction): jurisdiction is Jurisdiction => jurisdiction !== null)
+    const jurisdictions = entities.map(AsJurisdiction(effective)).filter(isJurisdiction)
     return ServiceResult(jurisdictions)
   } catch (error) /* istanbul ignore next */ {
     logger.error('Error Reading Jurisdicitons', error)

--- a/packages/mds-jurisdiction-service/server/handlers/schemas.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/schemas.ts
@@ -1,0 +1,27 @@
+/*
+    Copyright 2019-2020 City of Los Angeles.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import { SchemaBuilder, uuidSchema, stringSchema, timestampSchema } from '@mds-core/mds-schema-validators'
+import { Timestamp } from '@mds-core/mds-types'
+
+export const jurisdictionSchema = (max: Timestamp = Date.now()) =>
+  SchemaBuilder.object().keys({
+    jurisdiction_id: uuidSchema,
+    agency_key: stringSchema,
+    agency_name: stringSchema,
+    geography_id: uuidSchema,
+    timestamp: timestampSchema.max(max)
+  })

--- a/packages/mds-jurisdiction-service/server/handlers/update-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/update-jurisdiction-handler.ts
@@ -14,18 +14,18 @@
     limitations under the License.
  */
 
-import { UUID, Jurisdiction } from '@mds-core/mds-types'
+import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceError, ServiceResult } from '@mds-core/mds-service-helpers'
 import { ValidationError, NotFoundError, ServerError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
-import { UpdateJurisdictionType } from '../../@types'
+import { UpdateJurisdictionType, JurisdictionDomainModel } from '../../@types'
 import { AsJurisdiction } from './utils'
 import { JurisdictionRepository } from '../repository'
 
 export const UpdateJurisdictionHandler = async (
   jurisdiction_id: UUID,
   update: UpdateJurisdictionType
-): Promise<ServiceResponse<Jurisdiction, ValidationError | NotFoundError>> => {
+): Promise<ServiceResponse<JurisdictionDomainModel, ValidationError | NotFoundError>> => {
   if (update.jurisdiction_id && update.jurisdiction_id !== jurisdiction_id) {
     return ServiceError(new ValidationError('Invalid jurisdiction_id for update'))
   }

--- a/packages/mds-jurisdiction-service/server/handlers/utils.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/utils.ts
@@ -16,26 +16,12 @@
 
 import { Timestamp } from '@mds-core/mds-types'
 import { DeepPartial } from 'typeorm'
-import {
-  ValidateSchema,
-  SchemaBuilder,
-  uuidSchema,
-  stringSchema,
-  timestampSchema
-} from '@mds-core/mds-schema-validators'
 import { v4 as uuid } from 'uuid'
 import { filterEmptyHelper } from '@mds-core/mds-utils'
+import { ValidateSchema } from 'packages/mds-schema-validators'
 import { CreateJurisdictionType, JurisdictionDomainModel } from '../../@types'
 import { JurisdictionEntity } from '../repository/entities'
-
-const jurisdictionSchema = (max: Timestamp = Date.now()) =>
-  SchemaBuilder.object().keys({
-    jurisdiction_id: uuidSchema,
-    agency_key: stringSchema,
-    agency_name: stringSchema,
-    geography_id: uuidSchema,
-    timestamp: timestampSchema.max(max)
-  })
+import { jurisdictionSchema } from './schemas'
 
 export const AsJurisdiction = (effective: Timestamp = Date.now()) => (
   entity: JurisdictionEntity | undefined
@@ -62,7 +48,10 @@ export const AsJurisdiction = (effective: Timestamp = Date.now()) => (
 export const AsJurisdictionEntity = (jurisdiction: CreateJurisdictionType): DeepPartial<JurisdictionEntity> => {
   const recorded = Date.now()
   const { jurisdiction_id = uuid(), agency_key, agency_name, geography_id, timestamp = recorded } = jurisdiction
-  ValidateSchema({ jurisdiction_id, agency_key, agency_name, geography_id, timestamp }, jurisdictionSchema())
+  ValidateSchema<JurisdictionDomainModel>(
+    { jurisdiction_id, agency_key, agency_name, geography_id, timestamp },
+    jurisdictionSchema()
+  )
   const entity: DeepPartial<JurisdictionEntity> = {
     jurisdiction_id,
     agency_key,

--- a/packages/mds-jurisdiction-service/server/handlers/utils.ts
+++ b/packages/mds-jurisdiction-service/server/handlers/utils.ts
@@ -24,6 +24,7 @@ import {
   timestampSchema
 } from '@mds-core/mds-schema-validators'
 import { v4 as uuid } from 'uuid'
+import { filterEmptyHelper } from '@mds-core/mds-utils'
 import { CreateJurisdictionType, JurisdictionDomainModel } from '../../@types'
 import { JurisdictionEntity } from '../repository/entities'
 
@@ -71,5 +72,4 @@ export const AsJurisdictionEntity = (jurisdiction: CreateJurisdictionType): Deep
   return entity
 }
 
-export const isJurisdiction = (jurisdiction: JurisdictionDomainModel | null): jurisdiction is JurisdictionDomainModel =>
-  jurisdiction !== null
+export const isJurisdiction = filterEmptyHelper<JurisdictionDomainModel>()

--- a/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
@@ -14,8 +14,11 @@
     limitations under the License.
  */
 
-import { JurisdictionServiceClient, CreateJurisdictionType } from '@mds-core/mds-jurisdiction-service'
-import { Jurisdiction } from '@mds-core/mds-types'
+import {
+  JurisdictionServiceClient,
+  CreateJurisdictionType,
+  JurisdictionDomainModel
+} from '@mds-core/mds-jurisdiction-service'
 import { ValidationError, ConflictError } from '@mds-core/mds-utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 import { UnexpectedServiceError } from './utils'
@@ -26,10 +29,10 @@ interface CreateJurisdictionRequest extends JurisdictionApiRequest {
 
 type CreateJurisdictionResponse = JurisdictionApiResponse<
   | {
-      jurisdiction: Jurisdiction
+      jurisdiction: JurisdictionDomainModel
     }
   | {
-      jurisdictions: Jurisdiction[]
+      jurisdictions: JurisdictionDomainModel[]
     }
 >
 

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -14,15 +14,15 @@
     limitations under the License.
  */
 
-import { JurisdictionServiceClient } from '@mds-core/mds-jurisdiction-service'
-import { Jurisdiction, UUID } from '@mds-core/mds-types'
+import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
+import { UUID } from '@mds-core/mds-types'
 import { NotFoundError } from '@mds-core/mds-utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 import { UnexpectedServiceError } from './utils'
 
 type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }>
 
-type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<Jurisdiction, 'jurisdiction_id'>>
+type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
 
 export const DeleteJurisdictionHandler = async (req: DeleteJurisdictionRequest, res: DeleteJurisdictionResponse) => {
   const [error, result] = await JurisdictionServiceClient.deleteJurisdiction(req.params.jurisdiction_id)

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -14,8 +14,8 @@
     limitations under the License.
  */
 
-import { Jurisdiction, UUID } from '@mds-core/mds-types'
-import { JurisdictionServiceClient } from '@mds-core/mds-jurisdiction-service'
+import { UUID } from '@mds-core/mds-types'
+import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError, NotFoundError } from '@mds-core/mds-utils'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../types'
 import { HasJurisdictionClaim, UnexpectedServiceError } from './utils'
@@ -30,7 +30,7 @@ interface GetJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_i
 }
 
 type GetJurisdictionResponse = JurisdictionApiResponse<{
-  jurisdiction: Jurisdiction
+  jurisdiction: JurisdictionDomainModel
 }>
 
 export const GetOneJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -14,8 +14,7 @@
     limitations under the License.
  */
 
-import { JurisdictionServiceClient } from '@mds-core/mds-jurisdiction-service'
-import { Jurisdiction } from '@mds-core/mds-types'
+import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { HasJurisdictionClaim, UnexpectedServiceError } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
@@ -29,7 +28,7 @@ interface GetJurisdictionsRequest extends JurisdictionApiRequest {
 }
 
 type GetJurisdictionsResponse = JurisdictionApiResponse<{
-  jurisdictions: Jurisdiction[]
+  jurisdictions: JurisdictionDomainModel[]
 }>
 
 export const GetAllJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -14,8 +14,12 @@
     limitations under the License.
  */
 
-import { UpdateJurisdictionType, JurisdictionServiceClient } from '@mds-core/mds-jurisdiction-service'
-import { Jurisdiction, UUID } from '@mds-core/mds-types'
+import {
+  UpdateJurisdictionType,
+  JurisdictionServiceClient,
+  JurisdictionDomainModel
+} from '@mds-core/mds-jurisdiction-service'
+import { UUID } from '@mds-core/mds-types'
 import { ValidationError, NotFoundError } from '@mds-core/mds-utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 import { UnexpectedServiceError } from './utils'
@@ -25,7 +29,7 @@ interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdictio
 }
 
 type UpdateJurisdictionResponse = JurisdictionApiResponse<{
-  jurisdiction: Jurisdiction
+  jurisdiction: JurisdictionDomainModel
 }>
 
 export const UpdateJurisdictionHandler = async (req: UpdateJurisdictionRequest, res: UpdateJurisdictionResponse) => {

--- a/packages/mds-jurisdiction/handlers/utils.ts
+++ b/packages/mds-jurisdiction/handlers/utils.ts
@@ -15,14 +15,14 @@
  */
 
 import { ServerError } from '@mds-core/mds-utils'
-import { Jurisdiction } from '@mds-core/mds-types'
+import { JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { JurisdictionApiResponse } from '../types'
 
 export const UnexpectedServiceError = (error: ServerError | null) =>
   error instanceof ServerError ? error : new ServerError('Unexected Service Error', { error })
 
 export const HasJurisdictionClaim = <TBody extends {}>(res: JurisdictionApiResponse<TBody>) => (
-  jurisdiction: Jurisdiction
+  jurisdiction: JurisdictionDomainModel
 ): boolean =>
   res.locals.scopes.includes('jurisdictions:read') ||
   (res.locals.claims?.jurisdictions?.split(' ') ?? []).includes(jurisdiction.agency_key)

--- a/packages/mds-jurisdiction/tests/api.spec.ts
+++ b/packages/mds-jurisdiction/tests/api.spec.ts
@@ -20,7 +20,7 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { v4 as uuid } from 'uuid'
 import { JurisdictionServiceProvider } from '@mds-core/mds-jurisdiction-service/server'
 import { SCOPED_AUTH } from '@mds-core/mds-test-data'
-import { Jurisdiction } from '@mds-core/mds-types'
+import { JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { api } from '../api'
 import { JURISDICTION_API_DEFAULT_VERSION } from '../types'
 
@@ -79,7 +79,7 @@ describe('', () => {
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
     test.object(result.body.jurisdictions).hasProperty('length', 2)
     test
-      .value(result.body.jurisdictions.map((jurisdiction: Jurisdiction) => jurisdiction.jurisdiction_id))
+      .value(result.body.jurisdictions.map((jurisdiction: JurisdictionDomainModel) => jurisdiction.jurisdiction_id))
       .is([JURISDICTION1.jurisdiction_id, JURISDICTION2.jurisdiction_id])
   })
 
@@ -147,7 +147,7 @@ describe('', () => {
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
     test
       .value(
-        (result.body.jurisdictions as Jurisdiction[])
+        (result.body.jurisdictions as JurisdictionDomainModel[])
           .map(jurisdiction => jurisdiction.jurisdiction_id)
           .filter(jurisdiction_id =>
             [JURISDICTION0, JURISDICTION1, JURISDICTION2]
@@ -168,7 +168,7 @@ describe('', () => {
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim']))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
-    test.value((result.body.jurisdictions as Jurisdiction[]).length).is(0)
+    test.value((result.body.jurisdictions as JurisdictionDomainModel[]).length).is(0)
   })
 
   it('Get Multiple Jurisdictions (jurisdictions claim)', async () => {
@@ -177,7 +177,7 @@ describe('', () => {
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim'], JURISDICTION2.agency_key))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
-    test.value((result.body.jurisdictions as Jurisdiction[]).length).is(1)
+    test.value((result.body.jurisdictions as JurisdictionDomainModel[]).length).is(1)
   })
 
   it('Delete One Jurisdiction', async () => {

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -30,7 +30,6 @@ import {
   Timestamp,
   Telemetry,
   Stop,
-  Jurisdiction,
   PROPULSION_TYPES,
   VEHICLE_STATUSES,
   Device
@@ -54,16 +53,16 @@ interface ValidatorOptions {
 }
 
 // Convert empty string to undefined so required/optional works as expected
-const stringSchema = Joi.string().empty('')
+export const stringSchema = Joi.string().empty('')
 
 // Don't allow type conversion
-const numberSchema = Joi.number().options({ convert: false })
+export const numberSchema = Joi.number().options({ convert: false })
 
-const uuidSchema = stringSchema.guid()
+export const uuidSchema = stringSchema.guid()
 
-const timestampSchema = numberSchema.min(1420099200000)
+export const timestampSchema = numberSchema.min(1420099200000)
 
-const providerIdSchema = uuidSchema.valid(Object.keys(providers))
+export const providerIdSchema = uuidSchema.valid(Object.keys(providers))
 
 const vehicleIdSchema = stringSchema.max(255)
 
@@ -229,15 +228,6 @@ const stopSchema = Joi.object().keys({
   reservation_cost: vehicleTypesCountMapSchema.optional()
 })
 
-const jurisdictionSchema = (max: Timestamp = Date.now()) =>
-  Joi.object().keys({
-    jurisdiction_id: uuidSchema,
-    agency_key: stringSchema,
-    agency_name: stringSchema,
-    geography_id: uuidSchema,
-    timestamp: timestampSchema.max(max)
-  })
-
 const deviceSchema = Joi.object().keys({
   device_id: uuidSchema.required(),
   provider_id: uuidSchema.required(),
@@ -257,7 +247,11 @@ const Format = (property: string, error: Joi.ValidationError): string => {
   return `${[property, ...path].join('.')} ${details.join(' ')}`
 }
 
-const Validate = <T = unknown>(value: unknown, schema: Joi.Schema, options: Partial<ValidatorOptions>): value is T => {
+export const ValidateSchema = <T = unknown>(
+  value: unknown,
+  schema: Joi.Schema,
+  options: Partial<ValidatorOptions> = {}
+): value is T => {
   const { assert = true, required = true, property = 'value', allowUnknown = false } = options
   const { error } = Joi.validate(value, schema, { presence: required ? 'required' : 'optional', allowUnknown })
   if (error && assert) {
@@ -275,7 +269,7 @@ interface NumberValidatorOptions extends ValidatorOptions {
 }
 
 export const isValidNumber = (value: unknown, options: Partial<NumberValidatorOptions> = {}): value is number =>
-  Validate(
+  ValidateSchema(
     value,
     numberSchema
       .min(options.min === undefined ? Number.MIN_SAFE_INTEGER : options.min)
@@ -286,7 +280,7 @@ export const isValidNumber = (value: unknown, options: Partial<NumberValidatorOp
 export const isValidAuditTripId = (
   audit_trip_id: unknown,
   options: Partial<ValidatorOptions> = {}
-): audit_trip_id is UUID => Validate(audit_trip_id, uuidSchema, { property: 'audit_trip_id', ...options })
+): audit_trip_id is UUID => ValidateSchema(audit_trip_id, uuidSchema, { property: 'audit_trip_id', ...options })
 
 interface AuditEventValidatorOptions extends ValidatorOptions {
   accept: AUDIT_EVENT_TYPE[]
@@ -304,48 +298,49 @@ export const isValidStop = (value: unknown): value is Stop => {
 }
 
 export const isValidDeviceId = (value: unknown, options: Partial<ValidatorOptions> = {}): value is UUID =>
-  Validate(value, uuidSchema, { property: 'device_id', ...options })
+  ValidateSchema(value, uuidSchema, { property: 'device_id', ...options })
 
 export const isValidAuditEventType = (
   value: unknown,
   { accept, ...options }: Partial<AuditEventValidatorOptions> = {}
 ): value is AUDIT_EVENT_TYPE =>
-  Validate(value, auditEventTypeSchema(accept), { property: 'audit_event_type', ...options })
+  ValidateSchema(value, auditEventTypeSchema(accept), { property: 'audit_event_type', ...options })
 
 export const isValidTimestamp = (value: unknown, options: Partial<ValidatorOptions> = {}): value is Timestamp =>
-  Validate(value, timestampSchema, { property: 'timestamp', ...options })
+  ValidateSchema(value, timestampSchema, { property: 'timestamp', ...options })
 
 export const isValidProviderId = (value: unknown, options: Partial<ValidatorOptions> = {}): value is UUID =>
-  Validate(value, providerIdSchema, { property: 'provider_id', ...options })
+  ValidateSchema(value, providerIdSchema, { property: 'provider_id', ...options })
 
 export const isValidProviderVehicleId = (value: unknown, options: Partial<ValidatorOptions> = {}): value is string =>
-  Validate(value, vehicleIdSchema, { property: 'provider_vehicle_id', ...options })
+  ValidateSchema(value, vehicleIdSchema, { property: 'provider_vehicle_id', ...options })
 
 export const isValidAuditEventId = (value: unknown, options: Partial<ValidatorOptions> = {}): value is UUID =>
-  Validate(value, uuidSchema, { property: 'audit_event_id', ...options })
+  ValidateSchema(value, uuidSchema, { property: 'audit_event_id', ...options })
 
 export const isValidAuditDeviceId = (value: unknown, options: Partial<ValidatorOptions> = {}): value is UUID =>
-  Validate(value, uuidSchema, { property: 'audit_device_id', ...options })
+  ValidateSchema(value, uuidSchema, { property: 'audit_device_id', ...options })
 
 export const isValidTelemetry = (value: unknown, options: Partial<ValidatorOptions> = {}): value is Telemetry =>
-  Validate(value, telemetrySchema, { property: 'telemetry', ...options })
+  ValidateSchema(value, telemetrySchema, { property: 'telemetry', ...options })
 
 export const isValidDevice = (value: unknown, options: Partial<ValidatorOptions> = {}): value is Device =>
-  Validate(value, deviceSchema, options)
+  ValidateSchema(value, deviceSchema, options)
 
 export const isValidEvent = (value: unknown, options: Partial<ValidatorOptions> = {}): value is VehicleEvent =>
-  Validate(value, eventSchema, options)
+  ValidateSchema(value, eventSchema, options)
 
 export const isValidVehicleEventType = (
   value: unknown,
   options: Partial<ValidatorOptions> = {}
-): value is VEHICLE_EVENT => Validate(value, vehicleEventTypeSchema, { property: 'vehicle_event_type', ...options })
+): value is VEHICLE_EVENT =>
+  ValidateSchema(value, vehicleEventTypeSchema, { property: 'vehicle_event_type', ...options })
 
 export const isValidAuditIssueCode = (value: unknown, options: Partial<ValidatorOptions> = {}): value is string =>
-  Validate(value, auditIssueCodeSchema, { property: 'audit_issue_code', ...options })
+  ValidateSchema(value, auditIssueCodeSchema, { property: 'audit_issue_code', ...options })
 
 export const isValidAuditNote = (value: unknown, options: Partial<ValidatorOptions> = {}): value is string =>
-  Validate(value, auditNoteSchema, { property: 'note', ...options })
+  ValidateSchema(value, auditNoteSchema, { property: 'note', ...options })
 
 const HasPropertyAssertion = <T>(obj: unknown, ...props: (keyof T)[]): obj is T =>
   typeof obj === 'object' && obj !== null && props.every(prop => prop in obj)
@@ -358,13 +353,6 @@ export const isStringifiedEventWithTelemetry = (event: unknown): event is String
 
 export const isStringifiedCacheReadDeviceResult = (device: unknown): device is StringifiedCacheReadDeviceResult =>
   HasPropertyAssertion<StringifiedCacheReadDeviceResult>(device, 'device_id', 'provider_id', 'type', 'propulsion')
-
-export const isValidJurisdiction = (value: unknown, options: Partial<ValidatorOptions> = {}): value is Jurisdiction =>
-  Validate(value, jurisdictionSchema(), { property: 'jurisdiction', ...options })
-
-export const validateJurisdiction = (value: unknown, options: Partial<ValidatorOptions> = {}): void => {
-  isValidJurisdiction(value, options)
-}
 
 export function validatePolicies(policies: unknown): policies is Policy[] {
   const { error } = Joi.validate(policies, policiesSchema)
@@ -419,13 +407,13 @@ export function rawValidatePolicy(policy: Policy): Joi.ValidationResult<Policy> 
   return Joi.validate(policy, policySchema)
 }
 
-const validateTripEvent = (event: VehicleEvent) => Validate(event, tripEventSchema, {})
+const validateTripEvent = (event: VehicleEvent) => ValidateSchema(event, tripEventSchema, {})
 
-const validateProviderPickUpEvent = (event: VehicleEvent) => Validate(event, providerPickUpEventSchema, {})
+const validateProviderPickUpEvent = (event: VehicleEvent) => ValidateSchema(event, providerPickUpEventSchema, {})
 
-const validateServiceEndEvent = (event: VehicleEvent) => Validate(event, serviceEndEventSchema, {})
+const validateServiceEndEvent = (event: VehicleEvent) => ValidateSchema(event, serviceEndEventSchema, {})
 
-const validateDeregisterEvent = (event: VehicleEvent) => Validate(event, deregisterEventSchema, {})
+const validateDeregisterEvent = (event: VehicleEvent) => ValidateSchema(event, deregisterEventSchema, {})
 
 export const validateEvent = (event: unknown) => {
   if (isValidEvent(event, { allowUnknown: true })) {
@@ -451,8 +439,10 @@ export const validateEvent = (event: unknown) => {
       return validateDeregisterEvent(event)
     }
 
-    return Validate(event, eventSchema, {})
+    return ValidateSchema(event, eventSchema, {})
   }
 }
 
 export const policySchemaJson = joiToJsonSchema(policySchema)
+
+export const SchemaBuilder = Joi

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -464,11 +464,3 @@ export interface Stop {
   wheelchair_boarding?: boolean
   reservation_cost?: Partial<{ [S in VEHICLE_TYPE]: number }> // Cost to reserve a spot per vehicle_type
 }
-
-export interface Jurisdiction {
-  jurisdiction_id: UUID
-  agency_key: string
-  agency_name: string
-  geography_id: UUID
-  timestamp: Timestamp
-}


### PR DESCRIPTION
With the new service pattern I have been working on, I am trying to constrain functionality to the service layer resulting in less polluting of the global scope. In this PR, I basically move the type declarations for Jurisdictions from `mds-core` to `mds-jurisdiction-service/@types` ... also, I moved the schema definition/validation as well which required some minor changes to `mds-schema-validators` (basically exporting the _ValidateSchema_ function and a reference to `Joi` called _SchemaBuilder_

Eventually, I would like `mds-types` to include only things like _UUID_, _Timestamp_, etc and move the models to their respective service packages.