### PR TITLE
Improved service error/result types and handling

### DIFF
--- a/packages/mds-agency/agency-candidate-request-handlers.ts
+++ b/packages/mds-agency/agency-candidate-request-handlers.ts
@@ -7,7 +7,7 @@ import { parseQuery } from '@mds-core/mds-api-helpers'
 
 export const readAllVehicleIds = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // read all the devices
-  const { provider_id: query_provider_id } = parseQuery(req.query).keys('provider_id')
+  const { provider_id: query_provider_id } = parseQuery(req).keys('provider_id')
 
   if (query_provider_id && !isUUID(query_provider_id)) {
     return res.status(400).send({

--- a/packages/mds-agency/agency-candidate-request-handlers.ts
+++ b/packages/mds-agency/agency-candidate-request-handlers.ts
@@ -3,11 +3,11 @@ import logger from '@mds-core/mds-logger'
 import { isUUID } from '@mds-core/mds-utils'
 import db from '@mds-core/mds-db'
 import { providerName } from '@mds-core/mds-providers'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 
 export const readAllVehicleIds = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // read all the devices
-  const { provider_id: query_provider_id } = parseQuery(req).keys('provider_id')
+  const { provider_id: query_provider_id } = parseRequest(req).query('provider_id')
 
   if (query_provider_id && !isUUID(query_provider_id)) {
     return res.status(400).send({

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -103,9 +103,7 @@ export const registerVehicle = async (req: AgencyApiRequest, res: AgencyApiRespo
 export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const { device_id } = req.params
 
-  const { provider_id } = res.locals.scopes.includes('vehicles:read')
-    ? parseQuery(req.query).keys('provider_id')
-    : res.locals
+  const { provider_id } = res.locals.scopes.includes('vehicles:read') ? parseQuery(req).keys('provider_id') : res.locals
 
   const payload = await readPayload(device_id)
 
@@ -122,7 +120,7 @@ export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiRespon
 export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const PAGE_SIZE = 1000
 
-  const { skip = 0, take = PAGE_SIZE } = parseQuery(req.query, Number).keys('skip', 'take')
+  const { skip = 0, take = PAGE_SIZE } = parseQuery(req, Number).keys('skip', 'take')
 
   const url = urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,
@@ -131,9 +129,7 @@ export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyAp
   })
 
   // TODO: Replace with express middleware
-  const { provider_id } = res.locals.scopes.includes('vehicles:read')
-    ? parseQuery(req.query).keys('provider_id')
-    : res.locals
+  const { provider_id } = res.locals.scopes.includes('vehicles:read') ? parseQuery(req).keys('provider_id') : res.locals
 
   try {
     const response = await getVehicles(skip, take, url, req.query, provider_id)

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -19,7 +19,7 @@ import {
   UUID
 } from '@mds-core/mds-types'
 import urls from 'url'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 import {
   badDevice,
   getVehicles,
@@ -103,7 +103,9 @@ export const registerVehicle = async (req: AgencyApiRequest, res: AgencyApiRespo
 export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const { device_id } = req.params
 
-  const { provider_id } = res.locals.scopes.includes('vehicles:read') ? parseQuery(req).keys('provider_id') : res.locals
+  const { provider_id } = res.locals.scopes.includes('vehicles:read')
+    ? parseRequest(req).query('provider_id')
+    : res.locals
 
   const payload = await readPayload(device_id)
 
@@ -120,7 +122,7 @@ export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiRespon
 export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const PAGE_SIZE = 1000
 
-  const { skip = 0, take = PAGE_SIZE } = parseQuery(req, Number).keys('skip', 'take')
+  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, Number).query('skip', 'take')
 
   const url = urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,
@@ -129,7 +131,9 @@ export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyAp
   })
 
   // TODO: Replace with express middleware
-  const { provider_id } = res.locals.scopes.includes('vehicles:read') ? parseQuery(req).keys('provider_id') : res.locals
+  const { provider_id } = res.locals.scopes.includes('vehicles:read')
+    ? parseRequest(req).query('provider_id')
+    : res.locals
 
   try {
     const response = await getVehicles(skip, take, url, req.query, provider_id)

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -41,7 +41,7 @@ export const wipeDevice = async (req: AgencyApiRequest, res: AgencyApiResponse) 
 
 export const refreshCache = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
-  const { skip = 0, take = 10000000000 } = parseQuery(req.query, Number).keys('skip', 'take')
+  const { skip = 0, take = 10000000000 } = parseQuery(req, Number).keys('skip', 'take')
 
   try {
     const rows = await db.readDeviceIds()

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -3,7 +3,7 @@ import logger from '@mds-core/mds-logger'
 import cache from '@mds-core/mds-cache'
 import db from '@mds-core/mds-db'
 import { ServerError } from '@mds-core/mds-utils'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 import { refresh } from './utils'
 
 export const getCacheInfo = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
@@ -41,7 +41,7 @@ export const wipeDevice = async (req: AgencyApiRequest, res: AgencyApiResponse) 
 
 export const refreshCache = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
-  const { skip = 0, take = 10000000000 } = parseQuery(req, Number).keys('skip', 'take')
+  const { skip = 0, take = 10000000000 } = parseRequest(req, Number).query('skip', 'take')
 
   try {
     const rows = await db.readDeviceIds()

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -55,11 +55,11 @@ export const asJsonApiLinks = (req: express.Request, skip: number, take: number,
   return undefined
 }
 
-export const parseQuery = <T = string>(query: { [k: string]: unknown }, parser?: (val: string) => T) => {
+export const parseQuery = <T = string>(req: express.Request, parser?: (val: string) => T) => {
   return {
     keys: <TKey extends string>(first: TKey, ...rest: TKey[]): Partial<{ [P in TKey]: T }> =>
       [first, ...rest]
-        .map(key => ({ key, value: query[key] }))
+        .map(key => ({ key, value: req.query[key] }))
         .filter((param): param is { key: TKey; value: string } => typeof param.value === 'string')
         .reduce((params, { key, value }) => ({ ...params, [key]: parser ? parser(value) : value }), {})
   }

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -58,6 +58,6 @@ export const asJsonApiLinks = (req: express.Request, skip: number, take: number,
 
 export const parseRequest = <T = string>(req: express.Request, parser?: (value: string) => T) => {
   const { keys: query } = parseObjectProperties<T>(req.query, parser)
-  const { keys: params } = parseObjectProperties<T>(req.query, parser)
+  const { keys: params } = parseObjectProperties<T>(req.params, parser)
   return { params, query }
 }

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -16,6 +16,7 @@
 
 import urls from 'url'
 import express from 'express'
+import { parseObjectProperties } from '@mds-core/mds-utils'
 
 interface PagingParams {
   skip: number
@@ -55,12 +56,8 @@ export const asJsonApiLinks = (req: express.Request, skip: number, take: number,
   return undefined
 }
 
-export const parseQuery = <T = string>(req: express.Request, parser?: (val: string) => T) => {
-  return {
-    keys: <TKey extends string>(first: TKey, ...rest: TKey[]): Partial<{ [P in TKey]: T }> =>
-      [first, ...rest]
-        .map(key => ({ key, value: req.query[key] }))
-        .filter((param): param is { key: TKey; value: string } => typeof param.value === 'string')
-        .reduce((params, { key, value }) => ({ ...params, [key]: parser ? parser(value) : value }), {})
-  }
+export const parseRequest = <T = string>(req: express.Request, parser?: (value: string) => T) => {
+  const { keys: query } = parseObjectProperties<T>(req.query, parser)
+  const { keys: params } = parseObjectProperties<T>(req.query, parser)
+  return { params, query }
 }

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -55,7 +55,7 @@ import {
   TelemetryData,
   VEHICLE_EVENT
 } from '@mds-core/mds-types'
-import { asPagingParams, asJsonApiLinks, parseQuery } from '@mds-core/mds-api-helpers'
+import { asPagingParams, asJsonApiLinks, parseRequest } from '@mds-core/mds-api-helpers'
 import { checkAccess } from '@mds-core/mds-api-server'
 import {
   AuditApiAuditEndRequest,
@@ -511,7 +511,7 @@ function api(app: express.Express): express.Express {
                 }
               }, {})
 
-            const { event_viewport_adjustment = seconds(30) } = parseQuery(req, x => seconds(Number(x))).keys(
+            const { event_viewport_adjustment = seconds(30) } = parseRequest(req, x => seconds(Number(x))).query(
               'event_viewport_adjustment'
             )
 
@@ -652,8 +652,8 @@ function api(app: express.Express): express.Express {
     async (req, res) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const { strict = true, bbox, provider_id } = {
-        ...parseQuery(req, JSON.parse).keys('strict', 'bbox'),
-        ...parseQuery(req).keys('provider_id')
+        ...parseRequest(req, JSON.parse).query('strict', 'bbox'),
+        ...parseRequest(req).query('provider_id')
       }
 
       const url = urls.format({

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -511,7 +511,7 @@ function api(app: express.Express): express.Express {
                 }
               }, {})
 
-            const { event_viewport_adjustment = seconds(30) } = parseQuery(req.query, x => seconds(Number(x))).keys(
+            const { event_viewport_adjustment = seconds(30) } = parseQuery(req, x => seconds(Number(x))).keys(
               'event_viewport_adjustment'
             )
 
@@ -652,8 +652,8 @@ function api(app: express.Express): express.Express {
     async (req, res) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const { strict = true, bbox, provider_id } = {
-        ...parseQuery(req.query, JSON.parse).keys('strict', 'bbox'),
-        ...parseQuery(req.query).keys('provider_id')
+        ...parseQuery(req, JSON.parse).keys('strict', 'bbox'),
+        ...parseQuery(req).keys('provider_id')
       }
 
       const url = urls.format({

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -31,7 +31,7 @@ import {
 import { Geography, Device, UUID, VehicleEvent } from '@mds-core/mds-types'
 import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID, BLUE_SYSTEMS_PROVIDER_ID, providerName } from '@mds-core/mds-providers'
 import { Geometry, FeatureCollection } from 'geojson'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 import * as compliance_engine from './mds-compliance-engine'
 import { ComplianceApiRequest, ComplianceApiResponse } from './types'
 
@@ -79,8 +79,8 @@ function api(app: express.Express): express.Express {
   app.get(pathsFor('/snapshot/:policy_uuid'), async (req: ComplianceApiRequest, res: ComplianceApiResponse) => {
     const { provider_id } = res.locals
     const { provider_id: queried_provider_id, end_date: query_end_date } = {
-      ...parseQuery(req).keys('provider_id'),
-      ...parseQuery(req, Number).keys('end_date')
+      ...parseRequest(req).query('provider_id'),
+      ...parseRequest(req, Number).query('end_date')
     }
 
     /* istanbul ignore next */

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -79,8 +79,8 @@ function api(app: express.Express): express.Express {
   app.get(pathsFor('/snapshot/:policy_uuid'), async (req: ComplianceApiRequest, res: ComplianceApiResponse) => {
     const { provider_id } = res.locals
     const { provider_id: queried_provider_id, end_date: query_end_date } = {
-      ...parseQuery(req.query).keys('provider_id'),
-      ...parseQuery(req.query, Number).keys('end_date')
+      ...parseQuery(req).keys('provider_id'),
+      ...parseQuery(req, Number).keys('end_date')
     }
 
     /* istanbul ignore next */

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -5,7 +5,7 @@ import { pathsFor, ServerError, NotFoundError, InsufficientPermissionsError, Bad
 import logger from '@mds-core/mds-logger'
 
 import { checkAccess } from '@mds-core/mds-api-server'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 
 function api(app: express.Express): express.Express {
   app.get(
@@ -17,7 +17,7 @@ function api(app: express.Express): express.Express {
       const { scopes } = res.locals
       const params = {
         ...{ get_published: null, get_unpublished: null },
-        ...parseQuery(req, x => (x ? x === 'true' : null)).keys('get_published', 'get_unpublished')
+        ...parseRequest(req, x => (x ? x === 'true' : null)).query('get_published', 'get_unpublished')
       }
 
       /* If the user can only read published geos, and all they want is the unpublished metadata,

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -17,7 +17,7 @@ function api(app: express.Express): express.Express {
       const { scopes } = res.locals
       const params = {
         ...{ get_published: null, get_unpublished: null },
-        ...parseQuery(req.query, x => (x ? x === 'true' : null)).keys('get_published', 'get_unpublished')
+        ...parseQuery(req, x => (x ? x === 'true' : null)).keys('get_published', 'get_unpublished')
       }
 
       /* If the user can only read published geos, and all they want is the unpublished metadata,

--- a/packages/mds-jurisdiction-service/service/repository/index.ts
+++ b/packages/mds-jurisdiction-service/service/repository/index.ts
@@ -91,7 +91,7 @@ const RepositoryUpdateJurisdiction = CreateRepositoryMethod(
 )
 
 export const JurisdictionRepository = CreateRepository(
-  'jurisdiction-repository',
+  'jurisdictions',
   connect => {
     return {
       readJurisdiction: RepositoryReadJurisdiction(connect),
@@ -102,7 +102,6 @@ export const JurisdictionRepository = CreateRepository(
   },
   {
     entities: [JurisdictionEntity],
-    migrations: Object.values(migrations),
-    migrationsTableName: 'migrations_jurisdictions'
+    migrations: Object.values(migrations)
   }
 )

--- a/packages/mds-jurisdiction-service/tests/index.spec.ts
+++ b/packages/mds-jurisdiction-service/tests/index.spec.ts
@@ -17,7 +17,7 @@
 import test from 'unit.js'
 import { v4 as uuid } from 'uuid'
 import { days } from '@mds-core/mds-utils'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionServiceProvider } from '../service/provider'
 
 const records = 5_000
@@ -33,7 +33,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it(`Write ${records} Jurisdiction${records > 1 ? 's' : ''}`, async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.createJurisdictions(
         Array.from({ length: records }, (_, index) => ({
           jurisdiction_id: index ? uuid() : JURISDICTION_ID,
@@ -49,7 +49,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it(`Read ${records} Jurisdiction${records > 1 ? 's' : ''}`, async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.getJurisdictions(),
       error => test.value(error).is(null),
       jurisdictions => {
@@ -60,7 +60,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Write One Jurisdiction', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.createJurisdiction({
         agency_key: 'agency-key-one',
         agency_name: 'Agency Name One',
@@ -76,7 +76,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Write One Jurisdiction (duplicate id)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.createJurisdiction({
         jurisdiction_id: JURISDICTION_ID,
         agency_key: 'agency-key-two',
@@ -89,7 +89,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Write One Jurisdiction (duplicate key)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.createJurisdiction({
         agency_key: 'agency-key-one',
         agency_name: 'Agency Name One',
@@ -101,7 +101,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Write One Jurisdiction (validation error)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.createJurisdiction({
         agency_key: '',
         agency_name: 'Agency Name One',
@@ -113,7 +113,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Update One Jurisdiction (invalid jurisdiction_id)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
         jurisdiction_id: uuid(),
         agency_name: 'Some New Name',
@@ -125,7 +125,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Update One Jurisdiction (invalid timestamp)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
         agency_name: 'Some New Name',
         timestamp: LAST_WEEK
@@ -136,7 +136,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Update One Jurisdiction (not found)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.updateJurisdiction(uuid(), {
         agency_name: 'Some New Name',
         timestamp: TODAY
@@ -147,7 +147,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Update One Jurisdiction', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
         agency_name: 'Some New Name',
         timestamp: TODAY
@@ -162,7 +162,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Read Specific Jurisdiction (current version)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID),
       error => test.value(error).is(null),
       jurisdiction => {
@@ -174,7 +174,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Read Specific Jurisdiction (prior version)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
         effective: YESTERDAY
       }),
@@ -188,7 +188,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Read Specific Jurisdiction (no version)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
         effective: LAST_WEEK
       }),
@@ -198,7 +198,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Read Missing Jurisdiction', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.getJurisdiction(uuid()),
       error => test.value(error.type).is('NotFoundError'),
       result => test.value(result).is(null)
@@ -206,7 +206,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Delete One Jurisdiction', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID),
       error => test.value(error).is(null),
       jurisdiction => {
@@ -217,7 +217,7 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it('Delete One Jurisdiction (not found)', async () => {
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID),
       error => test.value(error.type).is('NotFoundError'),
       result => test.value(result).is(null)

--- a/packages/mds-jurisdiction-service/tests/index.spec.ts
+++ b/packages/mds-jurisdiction-service/tests/index.spec.ts
@@ -17,6 +17,7 @@
 import test from 'unit.js'
 import { v4 as uuid } from 'uuid'
 import { days } from '@mds-core/mds-utils'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionServiceProvider } from '../service/provider'
 
 const records = 5_000
@@ -32,162 +33,195 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   it(`Write ${records} Jurisdiction${records > 1 ? 's' : ''}`, async () => {
-    const [error, jurisdictions] = await JurisdictionServiceProvider.createJurisdictions(
-      Array.from({ length: records }, (_, index) => ({
-        jurisdiction_id: index ? uuid() : JURISDICTION_ID,
-        agency_key: `agency-key-${index}`,
-        agency_name: `Agency Name ${index}`,
-        timestamp: YESTERDAY,
-        geography_id: uuid()
-      }))
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.createJurisdictions(
+        Array.from({ length: records }, (_, index) => ({
+          jurisdiction_id: index ? uuid() : JURISDICTION_ID,
+          agency_key: `agency-key-${index}`,
+          agency_name: `Agency Name ${index}`,
+          timestamp: YESTERDAY,
+          geography_id: uuid()
+        }))
+      ),
+      error => test.value(error).is(null),
+      jurisdictions => test.value(jurisdictions[0].jurisdiction_id).is(JURISDICTION_ID)
     )
-    test.value(jurisdictions).isNot(null)
-    test.value(jurisdictions?.[0].jurisdiction_id).is(JURISDICTION_ID)
-    test.value(error).is(null)
   })
 
   it(`Read ${records} Jurisdiction${records > 1 ? 's' : ''}`, async () => {
-    const [error, jurisdictions] = await JurisdictionServiceProvider.getJurisdictions()
-    test.value(jurisdictions).isNot(null)
-    test.value(jurisdictions?.length).is(records)
-    test.value(jurisdictions?.[0].jurisdiction_id).is(JURISDICTION_ID)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.getJurisdictions(),
+      error => test.value(error).is(null),
+      jurisdictions => {
+        test.value(jurisdictions.length).is(records)
+        test.value(jurisdictions[0].jurisdiction_id).is(JURISDICTION_ID)
+      }
+    )
   })
 
   it('Write One Jurisdiction', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.createJurisdiction({
-      agency_key: 'agency-key-one',
-      agency_name: 'Agency Name One',
-      geography_id: uuid()
-    })
-    test.value(jurisdiction).isNot(null)
-    test.value(jurisdiction?.jurisdiction_id).isNot(null)
-    test.value(jurisdiction?.timestamp).isNot(null)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.createJurisdiction({
+        agency_key: 'agency-key-one',
+        agency_name: 'Agency Name One',
+        geography_id: uuid()
+      }),
+      error => test.value(error).is(null),
+      jurisdiction => {
+        test.value(jurisdiction).isNot(null)
+        test.value(jurisdiction.jurisdiction_id).isNot(null)
+        test.value(jurisdiction.timestamp).isNot(null)
+      }
+    )
   })
 
   it('Write One Jurisdiction (duplicate id)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.createJurisdiction({
-      jurisdiction_id: JURISDICTION_ID,
-      agency_key: 'agency-key-two',
-      agency_name: 'Agency Name One',
-      geography_id: uuid()
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ConflictError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.createJurisdiction({
+        jurisdiction_id: JURISDICTION_ID,
+        agency_key: 'agency-key-two',
+        agency_name: 'Agency Name One',
+        geography_id: uuid()
+      }),
+      error => test.value(error.type).is('ConflictError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Write One Jurisdiction (duplicate key)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.createJurisdiction({
-      agency_key: 'agency-key-one',
-      agency_name: 'Agency Name One',
-      geography_id: uuid()
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ConflictError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.createJurisdiction({
+        agency_key: 'agency-key-one',
+        agency_name: 'Agency Name One',
+        geography_id: uuid()
+      }),
+      error => test.value(error.type).is('ConflictError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Write One Jurisdiction (validation error)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.createJurisdiction({
-      agency_key: '',
-      agency_name: 'Agency Name One',
-      geography_id: uuid()
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ValidationError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.createJurisdiction({
+        agency_key: '',
+        agency_name: 'Agency Name One',
+        geography_id: uuid()
+      }),
+      error => test.value(error.type).is('ValidationError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Update One Jurisdiction (invalid jurisdiction_id)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
-      jurisdiction_id: uuid(),
-      agency_name: 'Some New Name',
-      timestamp: TODAY
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ConflictError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
+        jurisdiction_id: uuid(),
+        agency_name: 'Some New Name',
+        timestamp: TODAY
+      }),
+      error => test.value(error.type).is('ConflictError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Update One Jurisdiction (invalid timestamp)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
-      agency_name: 'Some New Name',
-      timestamp: LAST_WEEK
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ValidationError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
+        agency_name: 'Some New Name',
+        timestamp: LAST_WEEK
+      }),
+      error => test.value(error.type).is('ValidationError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Update One Jurisdiction (not found)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.updateJurisdiction(uuid(), {
-      agency_name: 'Some New Name',
-      timestamp: TODAY
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('NotFoundError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.updateJurisdiction(uuid(), {
+        agency_name: 'Some New Name',
+        timestamp: TODAY
+      }),
+      error => test.value(error.type).is('NotFoundError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Update One Jurisdiction', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
-      agency_name: 'Some New Name',
-      timestamp: TODAY
-    })
-    test.value(jurisdiction).isNot(null)
-    test.value(jurisdiction?.jurisdiction_id).is(JURISDICTION_ID)
-    test.value(jurisdiction?.timestamp).is(TODAY)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.updateJurisdiction(JURISDICTION_ID, {
+        agency_name: 'Some New Name',
+        timestamp: TODAY
+      }),
+      error => test.value(error).is(null),
+      jurisdiction => {
+        test.value(jurisdiction).isNot(null)
+        test.value(jurisdiction.jurisdiction_id).is(JURISDICTION_ID)
+        test.value(jurisdiction.timestamp).is(TODAY)
+      }
+    )
   })
 
   it('Read Specific Jurisdiction (current version)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID)
-    test.value(jurisdiction).isNot(null)
-    test.value(jurisdiction?.jurisdiction_id).is(JURISDICTION_ID)
-    test.value(jurisdiction?.timestamp).is(TODAY)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID),
+      error => test.value(error).is(null),
+      jurisdiction => {
+        test.value(jurisdiction).isNot(null)
+        test.value(jurisdiction.jurisdiction_id).is(JURISDICTION_ID)
+        test.value(jurisdiction.timestamp).is(TODAY)
+      }
+    )
   })
 
   it('Read Specific Jurisdiction (prior version)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
-      effective: YESTERDAY
-    })
-    test.value(jurisdiction).isNot(null)
-    test.value(jurisdiction?.jurisdiction_id).is(JURISDICTION_ID)
-    test.value(jurisdiction?.timestamp).is(YESTERDAY)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
+        effective: YESTERDAY
+      }),
+      error => test.value(error).is(null),
+      jurisdiction => {
+        test.value(jurisdiction).isNot(null)
+        test.value(jurisdiction.jurisdiction_id).is(JURISDICTION_ID)
+        test.value(jurisdiction.timestamp).is(YESTERDAY)
+      }
+    )
   })
 
   it('Read Specific Jurisdiction (no version)', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
-      effective: LAST_WEEK
-    })
-    test.value(error).isNot(null)
-    test.value(error?.type).is('NotFoundError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.getJurisdiction(JURISDICTION_ID, {
+        effective: LAST_WEEK
+      }),
+      error => test.value(error.type).is('NotFoundError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Read Missing Jurisdiction', async () => {
-    const [error, jurisdiction] = await JurisdictionServiceProvider.getJurisdiction(uuid())
-    test.value(error).isNot(null)
-    test.value(error?.type).is('NotFoundError')
-    test.value(jurisdiction).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.getJurisdiction(uuid()),
+      error => test.value(error.type).is('NotFoundError'),
+      result => test.value(result).is(null)
+    )
   })
 
   it('Delete One Jurisdiction', async () => {
-    const [error, result] = await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID)
-    test.value(result).isNot(null)
-    test.value(result?.jurisdiction_id).is(JURISDICTION_ID)
-    test.value(error).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID),
+      error => test.value(error).is(null),
+      jurisdiction => {
+        test.value(jurisdiction).isNot(null)
+        test.value(jurisdiction.jurisdiction_id).is(JURISDICTION_ID)
+      }
+    )
   })
 
   it('Delete One Jurisdiction (not found)', async () => {
-    const [error, result] = await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID)
-    test.value(error).isNot(null)
-    test.value(error?.type).is('NotFoundError')
-    test.value(result).is(null)
+    ProcessServiceResponse(
+      await JurisdictionServiceProvider.deleteJurisdiction(JURISDICTION_ID),
+      error => test.value(error.type).is('NotFoundError'),
+      result => test.value(result).is(null)
+    )
   })
 
   after(async () => {

--- a/packages/mds-jurisdiction/api.ts
+++ b/packages/mds-jurisdiction/api.ts
@@ -21,8 +21,8 @@ import { JurisdictionApiVersionMiddleware } from './middleware'
 import {
   CreateJurisdictionHandler,
   DeleteJurisdictionHandler,
-  GetAllJurisdictionsHandler,
-  GetOneJurisdictionHandler,
+  GetJurisdictionsHandler,
+  GetJurisdictionHandler,
   UpdateJurisdictionHandler
 } from './handlers'
 
@@ -32,12 +32,12 @@ export const api = (app: express.Express): express.Express =>
     .get(
       pathsFor('/jurisdictions'),
       checkAccess(scopes => scopes.includes('jurisdictions:read') || scopes.includes('jurisdictions:read:claim')),
-      GetAllJurisdictionsHandler
+      GetJurisdictionsHandler
     )
     .get(
       pathsFor('/jurisdictions/:jurisdiction_id'),
       checkAccess(scopes => scopes.includes('jurisdictions:read') || scopes.includes('jurisdictions:read:claim')),
-      GetOneJurisdictionHandler
+      GetJurisdictionHandler
     )
     .post(
       pathsFor('/jurisdictions'),

--- a/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
@@ -19,7 +19,7 @@ import {
   CreateJurisdictionType,
   JurisdictionDomainModel
 } from '@mds-core/mds-jurisdiction-service'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
 interface CreateJurisdictionRequest extends JurisdictionApiRequest {
@@ -36,7 +36,7 @@ type CreateJurisdictionResponse = JurisdictionApiResponse<
 >
 
 export const CreateJurisdictionHandler = async (req: CreateJurisdictionRequest, res: CreateJurisdictionResponse) => {
-  ProcessServiceResponse(
+  HandleServiceResponse(
     await JurisdictionServiceClient.createJurisdictions(Array.isArray(req.body) ? req.body : [req.body]),
     error => {
       if (error.type === 'ValidationError') {

--- a/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
@@ -19,8 +19,8 @@ import {
   CreateJurisdictionType,
   JurisdictionDomainModel
 } from '@mds-core/mds-jurisdiction-service'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
-import { UnexpectedServiceError } from './utils'
 
 interface CreateJurisdictionRequest extends JurisdictionApiRequest {
   body: CreateJurisdictionType | CreateJurisdictionType[]
@@ -36,29 +36,24 @@ type CreateJurisdictionResponse = JurisdictionApiResponse<
 >
 
 export const CreateJurisdictionHandler = async (req: CreateJurisdictionRequest, res: CreateJurisdictionResponse) => {
-  const [error, jurisdictions] = await JurisdictionServiceClient.createJurisdictions(
-    Array.isArray(req.body) ? req.body : [req.body]
+  ProcessServiceResponse(
+    await JurisdictionServiceClient.createJurisdictions(Array.isArray(req.body) ? req.body : [req.body]),
+    error => {
+      if (error.type === 'ValidationError') {
+        return res.status(400).send({ error })
+      }
+      if (error.type === 'ConflictError') {
+        return res.status(409).send({ error })
+      }
+      return res.status(500).send({ error })
+    },
+    jurisdictions => {
+      const { version } = res.locals
+      if (!Array.isArray(req.body)) {
+        const [jurisdiction] = jurisdictions
+        return res.status(201).send({ version, jurisdiction })
+      }
+      return res.status(201).send({ version, jurisdictions })
+    }
   )
-
-  // Handle result
-  if (jurisdictions) {
-    if (!Array.isArray(req.body)) {
-      const [jurisdiction] = jurisdictions
-      return res.status(201).send({ version: res.locals.version, jurisdiction })
-    }
-    return res.status(201).send({ version: res.locals.version, jurisdictions })
-  }
-
-  // Handle errors
-  if (error) {
-    if (error.type === 'ValidationError') {
-      return res.status(400).send({ error })
-    }
-    if (error.type === 'ConflictError') {
-      return res.status(409).send({ error })
-    }
-    return res.status(500).send({ error })
-  }
-
-  return res.status(500).send(UnexpectedServiceError)
 }

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -16,7 +16,7 @@
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { UUID } from '@mds-core/mds-types'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
 type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }>
@@ -25,7 +25,7 @@ type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<JurisdictionDomai
 
 export const DeleteJurisdictionHandler = async (req: DeleteJurisdictionRequest, res: DeleteJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-  ProcessServiceResponse(
+  HandleServiceResponse(
     await JurisdictionServiceClient.deleteJurisdiction(jurisdiction_id),
     error => {
       if (error.type === 'NotFoundError') {

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -16,28 +16,26 @@
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { UUID } from '@mds-core/mds-types'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
-import { UnexpectedServiceError } from './utils'
 
 type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }>
 
 type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
 
 export const DeleteJurisdictionHandler = async (req: DeleteJurisdictionRequest, res: DeleteJurisdictionResponse) => {
-  const [error, result] = await JurisdictionServiceClient.deleteJurisdiction(req.params.jurisdiction_id)
-
-  // Handle result
-  if (result) {
-    return res.status(200).send({ version: res.locals.version, ...result })
-  }
-
-  // Handle errors
-  if (error) {
-    if (error.type === 'NotFoundError') {
-      return res.status(404).send({ error })
+  const { jurisdiction_id } = req.params
+  ProcessServiceResponse(
+    await JurisdictionServiceClient.deleteJurisdiction(jurisdiction_id),
+    error => {
+      if (error.type === 'NotFoundError') {
+        return res.status(404).send({ error })
+      }
+      return res.status(500).send({ error })
+    },
+    result => {
+      const { version } = res.locals
+      return res.status(200).send({ version, ...result })
     }
-    return res.status(500).send({ error })
-  }
-
-  return res.status(500).send(UnexpectedServiceError)
+  )
 }

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -17,7 +17,7 @@
 import { UUID } from '@mds-core/mds-types'
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError } from '@mds-core/mds-utils'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { parseQuery } from '@mds-core/mds-api-helpers'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../types'
 import { HasJurisdictionClaim } from './utils'
@@ -31,7 +31,7 @@ type GetJurisdictionResponse = JurisdictionApiResponse<{
 export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
   const { effective } = parseQuery(req, Number).keys('effective')
-  ProcessServiceResponse(
+  HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective }),
     error => {
       if (error.type === 'NotFoundError') {

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -18,7 +18,7 @@ import { UUID } from '@mds-core/mds-types'
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError } from '@mds-core/mds-utils'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../types'
 import { HasJurisdictionClaim } from './utils'
 
@@ -30,7 +30,7 @@ type GetJurisdictionResponse = JurisdictionApiResponse<{
 
 export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-  const { effective } = parseQuery(req, Number).keys('effective')
+  const { effective } = parseRequest(req, Number).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective }),
     error => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -17,8 +17,10 @@
 import { UUID } from '@mds-core/mds-types'
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError } from '@mds-core/mds-utils'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { parseQuery } from '@mds-core/mds-api-helpers'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../types'
-import { HasJurisdictionClaim, UnexpectedServiceError } from './utils'
+import { HasJurisdictionClaim } from './utils'
 
 type GetJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }, Partial<'effective'>>
 
@@ -26,31 +28,22 @@ type GetJurisdictionResponse = JurisdictionApiResponse<{
   jurisdiction: JurisdictionDomainModel
 }>
 
-export const GetOneJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
-  const { effective } = req.query
+export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-
-  const [error, jurisdiction] = await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, {
-    effective: effective ? Number(effective) : undefined
-  })
-
-  // Handle result
-  if (jurisdiction) {
-    return HasJurisdictionClaim(res)(jurisdiction)
-      ? res.status(200).send({
-          version: res.locals.version,
-          jurisdiction
-        })
-      : res.status(403).send({ error: new AuthorizationError('Access Denied', { jurisdiction_id }) })
-  }
-
-  // Handle errors
-  if (error) {
-    if (error.type === 'NotFoundError') {
-      return res.status(404).send({ error })
+  const { effective } = parseQuery(req, Number).keys('effective')
+  ProcessServiceResponse(
+    await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective }),
+    error => {
+      if (error.type === 'NotFoundError') {
+        return res.status(404).send({ error })
+      }
+      return res.status(500).send({ error })
+    },
+    jurisdiction => {
+      const { version } = res.locals
+      return HasJurisdictionClaim(res)(jurisdiction)
+        ? res.status(200).send({ version, jurisdiction })
+        : res.status(403).send({ error: new AuthorizationError('Access Denied', { jurisdiction_id }) })
     }
-    return res.status(500).send({ error })
-  }
-
-  return res.status(500).send(UnexpectedServiceError)
+  )
 }

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -15,7 +15,7 @@
  */
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { parseQuery } from '@mds-core/mds-api-helpers'
 import { HasJurisdictionClaim } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
@@ -28,7 +28,7 @@ type GetJurisdictionsResponse = JurisdictionApiResponse<{
 
 export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
   const { effective } = parseQuery(req, Number).keys('effective')
-  ProcessServiceResponse(
+  HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdictions({ effective }),
     error => {
       return res.status(500).send({ error })

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -16,7 +16,7 @@
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
-import { parseQuery } from '@mds-core/mds-api-helpers'
+import { parseRequest } from '@mds-core/mds-api-helpers'
 import { HasJurisdictionClaim } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
@@ -27,7 +27,7 @@ type GetJurisdictionsResponse = JurisdictionApiResponse<{
 }>
 
 export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
-  const { effective } = parseQuery(req, Number).keys('effective')
+  const { effective } = parseRequest(req, Number).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdictions({ effective }),
     error => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -15,7 +15,9 @@
  */
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
-import { HasJurisdictionClaim, UnexpectedServiceError } from './utils'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { parseQuery } from '@mds-core/mds-api-helpers'
+import { HasJurisdictionClaim } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
 type GetJurisdictionsRequest = JurisdictionApiRequest<{}, Partial<'effective'>>
@@ -24,25 +26,16 @@ type GetJurisdictionsResponse = JurisdictionApiResponse<{
   jurisdictions: JurisdictionDomainModel[]
 }>
 
-export const GetAllJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
-  const { effective } = req.query
-
-  const [error, jurisdictions] = await JurisdictionServiceClient.getJurisdictions({
-    effective: effective ? Number(effective) : undefined
-  })
-
-  // Handle result
-  if (jurisdictions) {
-    return res.status(200).send({
-      version: res.locals.version,
-      jurisdictions: jurisdictions.filter(HasJurisdictionClaim(res))
-    })
-  }
-
-  // Handle errors
-  if (error) {
-    return res.status(500).send({ error })
-  }
-
-  return res.status(500).send(UnexpectedServiceError)
+export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
+  const { effective } = parseQuery(req, Number).keys('effective')
+  ProcessServiceResponse(
+    await JurisdictionServiceClient.getJurisdictions({ effective }),
+    error => {
+      return res.status(500).send({ error })
+    },
+    jurisdictions => {
+      const { version } = res.locals
+      return res.status(200).send({ version, jurisdictions: jurisdictions.filter(HasJurisdictionClaim(res)) })
+    }
+  )
 }

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -20,8 +20,8 @@ import {
   JurisdictionDomainModel
 } from '@mds-core/mds-jurisdiction-service'
 import { UUID } from '@mds-core/mds-types'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
-import { UnexpectedServiceError } from './utils'
 
 interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_id: UUID }> {
   body: UpdateJurisdictionType
@@ -32,26 +32,24 @@ type UpdateJurisdictionResponse = JurisdictionApiResponse<{
 }>
 
 export const UpdateJurisdictionHandler = async (req: UpdateJurisdictionRequest, res: UpdateJurisdictionResponse) => {
-  const [error, jurisdiction] = await JurisdictionServiceClient.updateJurisdiction(req.params.jurisdiction_id, req.body)
-
-  // Handle result
-  if (jurisdiction) {
-    return res.status(200).send({ version: res.locals.version, jurisdiction })
-  }
-
-  // Handle errors
-  if (error) {
-    if (error.type === 'ValidationError') {
-      return res.status(400).send({ error })
+  const { jurisdiction_id } = req.params
+  ProcessServiceResponse(
+    await JurisdictionServiceClient.updateJurisdiction(jurisdiction_id, req.body),
+    error => {
+      if (error.type === 'ValidationError') {
+        return res.status(400).send({ error })
+      }
+      if (error.type === 'NotFoundError') {
+        return res.status(404).send({ error })
+      }
+      if (error.type === 'ConflictError') {
+        return res.status(409).send({ error })
+      }
+      return res.status(500).send({ error })
+    },
+    jurisdiction => {
+      const { version } = res.locals
+      return res.status(200).send({ version, jurisdiction })
     }
-    if (error.type === 'NotFoundError') {
-      return res.status(404).send({ error })
-    }
-    if (error.type === 'ConflictError') {
-      return res.status(409).send({ error })
-    }
-    return res.status(500).send({ error })
-  }
-
-  return res.status(500).send(UnexpectedServiceError)
+  )
 }

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -20,7 +20,7 @@ import {
   JurisdictionDomainModel
 } from '@mds-core/mds-jurisdiction-service'
 import { UUID } from '@mds-core/mds-types'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
 interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_id: UUID }> {
@@ -33,7 +33,7 @@ type UpdateJurisdictionResponse = JurisdictionApiResponse<{
 
 export const UpdateJurisdictionHandler = async (req: UpdateJurisdictionRequest, res: UpdateJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-  ProcessServiceResponse(
+  HandleServiceResponse(
     await JurisdictionServiceClient.updateJurisdiction(jurisdiction_id, req.body),
     error => {
       if (error.type === 'ValidationError') {

--- a/packages/mds-jurisdiction/handlers/utils.ts
+++ b/packages/mds-jurisdiction/handlers/utils.ts
@@ -17,8 +17,6 @@
 import { JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { JurisdictionApiResponse } from '../types'
 
-export const UnexpectedServiceError = { error: 'Unexected Service Error' }
-
 export const HasJurisdictionClaim = <TBody extends {}>(res: JurisdictionApiResponse<TBody>) => (
   jurisdiction: JurisdictionDomainModel
 ): boolean =>

--- a/packages/mds-jurisdiction/package.json
+++ b/packages/mds-jurisdiction/package.json
@@ -23,6 +23,7 @@
     "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-jurisdiction-service": "0.1.0",
     "@mds-core/mds-logger": "0.1.24",
+    "@mds-core/mds-service-helpers": "0.1.0",
     "express": "4.17.1"
   },
   "devDependencies": {

--- a/packages/mds-jurisdiction/tsconfig.build.json
+++ b/packages/mds-jurisdiction/tsconfig.build.json
@@ -8,6 +8,7 @@
     { "path": "../../packages/mds-api-server/tsconfig.build.json" },
     { "path": "../../packages/mds-jurisdiction-service/tsconfig.build.json" },
     { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-service-helpers/tsconfig.build.json" },
     { "path": "../../packages/mds-test-data/tsconfig.build.json" }
   ]
 }

--- a/packages/mds-metrics-service/service/repository/index.ts
+++ b/packages/mds-metrics-service/service/repository/index.ts
@@ -72,7 +72,7 @@ const RepositoryWriteMetrics = CreateRepositoryMethod(connect => async (metrics:
 })
 
 export const MetricsRepository = CreateRepository(
-  'metrics-repository',
+  'metrics',
   connect => {
     return {
       readMetrics: RepositoryReadMetrics(connect),
@@ -81,7 +81,6 @@ export const MetricsRepository = CreateRepository(
   },
   {
     entities: [MetricEntity],
-    migrations: Object.values(migrations),
-    migrationsTableName: 'migrations_metrics'
+    migrations: Object.values(migrations)
   }
 )

--- a/packages/mds-metrics-service/service/repository/migrations/1585847425124-CreateMetricsTable.ts
+++ b/packages/mds-metrics-service/service/repository/migrations/1585847425124-CreateMetricsTable.ts
@@ -21,11 +21,11 @@ export class CreateMetricsTable1585847425124 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "metrics" ("id" bigint GENERATED ALWAYS AS IDENTITY, "recorded" bigint NOT NULL, "name" character varying(255) NOT NULL, "time_bin_size" bigint NOT NULL, "time_bin_start" bigint NOT NULL, "provider_id" uuid NOT NULL, "geography_id" uuid, "vehicle_type" character varying(31) NOT NULL, "count" bigint NOT NULL, "sum" double precision NOT NULL, "min" double precision NOT NULL, "max" double precision NOT NULL, "avg" double precision NOT NULL, CONSTRAINT "metrics_pkey" PRIMARY KEY ("name", "time_bin_size", "time_bin_start", "provider_id", "geography_id", "vehicle_type"))`,
+      `CREATE TABLE IF NOT EXISTS "metrics" ("id" bigint GENERATED ALWAYS AS IDENTITY, "recorded" bigint NOT NULL, "name" character varying(255) NOT NULL, "time_bin_size" bigint NOT NULL, "time_bin_start" bigint NOT NULL, "provider_id" uuid NOT NULL, "geography_id" uuid, "vehicle_type" character varying(31) NOT NULL, "count" bigint NOT NULL, "sum" double precision NOT NULL, "min" double precision NOT NULL, "max" double precision NOT NULL, "avg" double precision NOT NULL, CONSTRAINT "metrics_pkey" PRIMARY KEY ("name", "time_bin_size", "time_bin_start", "provider_id", "geography_id", "vehicle_type"))`,
       undefined
     )
-    await queryRunner.query(`CREATE UNIQUE INDEX "idx_id_metrics" ON "metrics" ("id") `, undefined)
-    await queryRunner.query(`CREATE INDEX "idx_recorded_metrics" ON "metrics" ("recorded") `, undefined)
+    await queryRunner.query(`CREATE UNIQUE INDEX IF NOT EXISTS "idx_id_metrics" ON "metrics" ("id") `, undefined)
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_recorded_metrics" ON "metrics" ("recorded") `, undefined)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/mds-metrics-service/tests/index.spec.ts
+++ b/packages/mds-metrics-service/tests/index.spec.ts
@@ -18,6 +18,7 @@ import test from 'unit.js'
 import { v4 as uuid } from 'uuid'
 import { minutes, timeframe, days } from '@mds-core/mds-utils'
 import { VEHICLE_TYPE } from '@mds-core/mds-types'
+import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
 import { MetricsServiceProvider } from '../service/provider'
 import { MetricDomainModel, ReadMetricsOptions, ReadMetricsFilterOptions } from '../@types'
 
@@ -94,12 +95,12 @@ const testQuery = (query: () => ReadMetricsOptions & { expected: MetricDomainMod
           .map(key => (Array.isArray(filters[key as keyof ReadMetricsFilterOptions]) ? `${key}[]` : key))
           .join(', ')}`
       : ''
-  }] (Expect ${expected.length} Match${expected.length === 1 ? '' : 'es'})`, async () => {
-    const [error, metrics] = await MetricsServiceProvider.readMetrics(options)
-    test.value(metrics).isNot(null)
-    test.value(metrics?.length).is(expected.length)
-    test.value(error).is(null)
-  })
+  }] (Expect ${expected.length} Match${expected.length === 1 ? '' : 'es'})`, async () =>
+    ProcessServiceResponse(
+      await MetricsServiceProvider.readMetrics(options),
+      error => test.value(error).is(null),
+      metrics => test.value(metrics.length).is(expected.length)
+    ))
 }
 
 describe('Metrics Service', () => {
@@ -107,12 +108,12 @@ describe('Metrics Service', () => {
     await MetricsServiceProvider.initialize()
   })
 
-  it(`Generate ${TEST_METRICS.length} Metric${TEST_METRICS.length === 1 ? '' : 's'}`, async () => {
-    const [error, metrics] = await MetricsServiceProvider.writeMetrics(TEST_METRICS)
-    test.value(metrics).isNot(null)
-    test.value(metrics?.length).is(TEST_METRICS.length)
-    test.value(error).is(null)
-  })
+  it(`Generate ${TEST_METRICS.length} Metric${TEST_METRICS.length === 1 ? '' : 's'}`, async () =>
+    ProcessServiceResponse(
+      await MetricsServiceProvider.writeMetrics(TEST_METRICS),
+      error => test.value(error).is(null),
+      metrics => test.value(metrics.length).is(TEST_METRICS.length)
+    ))
 
   testQuery(() => ({
     name: TEST_METRIC_NAME,

--- a/packages/mds-metrics-service/tests/index.spec.ts
+++ b/packages/mds-metrics-service/tests/index.spec.ts
@@ -18,7 +18,7 @@ import test from 'unit.js'
 import { v4 as uuid } from 'uuid'
 import { minutes, timeframe, days } from '@mds-core/mds-utils'
 import { VEHICLE_TYPE } from '@mds-core/mds-types'
-import { ProcessServiceResponse } from '@mds-core/mds-service-helpers'
+import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { MetricsServiceProvider } from '../service/provider'
 import { MetricDomainModel, ReadMetricsOptions, ReadMetricsFilterOptions } from '../@types'
 
@@ -96,7 +96,7 @@ const testQuery = (query: () => ReadMetricsOptions & { expected: MetricDomainMod
           .join(', ')}`
       : ''
   }] (Expect ${expected.length} Match${expected.length === 1 ? '' : 'es'})`, async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await MetricsServiceProvider.readMetrics(options),
       error => test.value(error).is(null),
       metrics => test.value(metrics.length).is(expected.length)
@@ -109,7 +109,7 @@ describe('Metrics Service', () => {
   })
 
   it(`Generate ${TEST_METRICS.length} Metric${TEST_METRICS.length === 1 ? '' : 's'}`, async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       await MetricsServiceProvider.writeMetrics(TEST_METRICS),
       error => test.value(error).is(null),
       metrics => test.value(metrics.length).is(TEST_METRICS.length)

--- a/packages/mds-repository/repository.ts
+++ b/packages/mds-repository/repository.ts
@@ -23,14 +23,14 @@ export const CreateRepositoryMethod: <TMethod>(
   method: RepositoryMethod<TMethod>
 ) => RepositoryMethod<TMethod> = method => method
 
-export type RepositoryOptions = Pick<ConnectionManagerOptions, 'entities' | 'migrations' | 'migrationsTableName'>
+export type RepositoryOptions = Pick<ConnectionManagerOptions, 'entities' | 'migrations'>
 
 export const CreateRepository = <TRepositoryMethods>(
   name: string,
   methods: (connect: (mode: ConnectionMode) => Promise<Connection>) => TRepositoryMethods,
   options: RepositoryOptions = {}
 ) => {
-  const { connect, ...manager } = ConnectionManager(name, options)
+  const { connect, ...manager } = ConnectionManager(name, { migrationsTableName: `${name}-migrations`, ...options })
   return {
     ...manager,
     ...methods(connect)

--- a/packages/mds-service-helpers/index.ts
+++ b/packages/mds-service-helpers/index.ts
@@ -36,10 +36,10 @@ export const ServiceResult = <R>(result: R): ServiceResultType<R> => ({ error: n
 export const ServiceError = (error: ServiceErrorDescriptor): ServiceErrorType => ({ error })
 
 export const ProcessServiceResponse = <R>(
-  result: ServiceResponse<R>,
+  response: ServiceResponse<R>,
   onerror: (error: ServiceErrorDescriptor) => void,
   onresult: (result: R) => void
-) => (result.error ? onerror(result.error) : onresult(result.result))
+) => (response.error ? onerror(response.error) : onresult(response.result))
 
 export const ServiceException = (message: string, error?: Error) =>
   ServiceError({

--- a/packages/mds-service-helpers/index.ts
+++ b/packages/mds-service-helpers/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*
     Copyright 2019-2020 City of Los Angeles.
 
@@ -35,7 +36,7 @@ export const ServiceResult = <R>(result: R): ServiceResultType<R> => ({ error: n
 
 export const ServiceError = (error: ServiceErrorDescriptor): ServiceErrorType => ({ error })
 
-export const ProcessServiceResponse = <R>(
+export const HandleServiceResponse = <R>(
   response: ServiceResponse<R>,
   onerror: (error: ServiceErrorDescriptor) => void,
   onresult: (result: R) => void

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -15,18 +15,18 @@
  */
 
 import test from 'unit.js'
-import { ServiceResult, ServiceError, ServiceException, ProcessServiceResponse } from '../index'
+import { ServiceResult, ServiceError, ServiceException, HandleServiceResponse } from '../index'
 
 describe('Tests Service Helpers', () => {
   it('Test ServiceResult', async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       ServiceResult('success'),
       error => test.value(error).is(null),
       result => test.value(result).is('success')
     ))
 
   it('Test ServiceError', async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       ServiceError({ type: 'ValidationError', message: 'Validation Error' }),
       error => {
         test.value(error.type).is('ValidationError')
@@ -37,7 +37,7 @@ describe('Tests Service Helpers', () => {
     ))
 
   it('Test ServiceException', async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       ServiceException('Validation Error'),
       error => {
         test.value(error.type).is('ServiceException')
@@ -48,7 +48,7 @@ describe('Tests Service Helpers', () => {
     ))
 
   it('Test ServiceException (with Error)', async () =>
-    ProcessServiceResponse(
+    HandleServiceResponse(
       ServiceException('Validation Error', Error('Error Message')),
       error => {
         test.value(error.type).is('ServiceException')

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -18,31 +18,22 @@ import test from 'unit.js'
 import { ServiceResult, ServiceError, ServiceException } from '../index'
 
 describe('Tests Service Helpers', () => {
-  it('Test ServiceResult', done => {
-    const [failure, result] = ServiceResult('success')
-    test.value(failure).is(null)
+  it('Test ServiceResult', async () => {
+    const { result } = ServiceResult('success')
     test.value(result).is('success')
-    done()
   })
 
-  it('Test ServiceError', done => {
-    const [error, result] = ServiceError({ type: 'ValidationError', message: 'Validation Error' })
-    test.value(result).is(null)
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ValidationError')
-    test.value(error?.message).is('Validation Error')
-    test.value(error?.details).is(undefined)
-    done()
+  it('Test ServiceError', async () => {
+    const { error } = ServiceError({ type: 'ValidationError', message: 'Validation Error' })
+    test.value(error.type).is('ValidationError')
+    test.value(error.message).is('Validation Error')
+    test.value(error.details).is(undefined)
   })
 
-  it('Test ServiceException', done => {
-    const exception = Error('Error Message')
-    const [error, result] = ServiceException('Validation Error', exception)
-    test.value(result).is(null)
-    test.value(error).isNot(null)
-    test.value(error?.type).is('ServiceException')
-    test.value(error?.message).is('Validation Error')
-    test.value(error?.details).is(exception.message)
-    done()
+  it('Test ServiceException', async () => {
+    const { error } = ServiceException('Validation Error', Error('Error Message'))
+    test.value(error.type).is('ServiceException')
+    test.value(error.message).is('Validation Error')
+    test.value(error.details).is('Error Message')
   })
 })

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -15,25 +15,46 @@
  */
 
 import test from 'unit.js'
-import { ServiceResult, ServiceError, ServiceException } from '../index'
+import { ServiceResult, ServiceError, ServiceException, ProcessServiceResponse } from '../index'
 
 describe('Tests Service Helpers', () => {
-  it('Test ServiceResult', async () => {
-    const { result } = ServiceResult('success')
-    test.value(result).is('success')
-  })
+  it('Test ServiceResult', async () =>
+    ProcessServiceResponse(
+      ServiceResult('success'),
+      error => test.value(error).is(null),
+      result => test.value(result).is('success')
+    ))
 
-  it('Test ServiceError', async () => {
-    const { error } = ServiceError({ type: 'ValidationError', message: 'Validation Error' })
-    test.value(error.type).is('ValidationError')
-    test.value(error.message).is('Validation Error')
-    test.value(error.details).is(undefined)
-  })
+  it('Test ServiceError', async () =>
+    ProcessServiceResponse(
+      ServiceError({ type: 'ValidationError', message: 'Validation Error' }),
+      error => {
+        test.value(error.type).is('ValidationError')
+        test.value(error.message).is('Validation Error')
+        test.value(error.details).is(undefined)
+      },
+      result => test.value(result).is(null)
+    ))
 
-  it('Test ServiceException', async () => {
-    const { error } = ServiceException('Validation Error', Error('Error Message'))
-    test.value(error.type).is('ServiceException')
-    test.value(error.message).is('Validation Error')
-    test.value(error.details).is('Error Message')
-  })
+  it('Test ServiceException', async () =>
+    ProcessServiceResponse(
+      ServiceException('Validation Error'),
+      error => {
+        test.value(error.type).is('ServiceException')
+        test.value(error.message).is('Validation Error')
+        test.value(error.details).is(undefined)
+      },
+      result => test.value(result).is(null)
+    ))
+
+  it('Test ServiceException (with Error)', async () =>
+    ProcessServiceResponse(
+      ServiceException('Validation Error', Error('Error Message')),
+      error => {
+        test.value(error.type).is('ServiceException')
+        test.value(error.message).is('Validation Error')
+        test.value(error.details).is('Error Message')
+      },
+      result => test.value(result).is(null)
+    ))
 })

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -598,6 +598,16 @@ const getEnvVar = <TProps extends { [name: string]: string }>(props: TProps): TP
     }
   }, {} as TProps)
 
+const parseObjectProperties = <T = string>(obj: { [k: string]: unknown }, parser?: (value: string) => T) => {
+  return {
+    keys: <TKey extends string>(first: TKey, ...rest: TKey[]): Partial<{ [P in TKey]: T }> =>
+      [first, ...rest]
+        .map(key => ({ key, value: obj[key] }))
+        .filter((param): param is { key: TKey; value: string } => typeof param.value === 'string')
+        .reduce((params, { key, value }) => ({ ...params, [key]: parser ? parser(value) : value }), {})
+  }
+}
+
 export {
   UUID_REGEX,
   isUUID,
@@ -644,5 +654,6 @@ export {
   normalizeToArray,
   parseRelative,
   getCurrentDate,
-  getEnvVar
+  getEnvVar,
+  parseObjectProperties
 }


### PR DESCRIPTION
Converted `ServiceResponse` from a typed tuple to a discriminated type union. This provides enhanced type-checking when processing service responses by forcing consumers (e.g. an API) to handle the error before accessing the result.

<img width="581" alt="Screen Shot 2020-04-18 at 1 39 43 PM" src="https://user-images.githubusercontent.com/3439869/79644914-ff271a00-8179-11ea-829d-2b6b5f639e13.png">

Alternatively,  consumers can use a service response handler that invokes typed error/result methods. 

<img width="550" alt="Screen Shot 2020-04-18 at 1 40 37 PM" src="https://user-images.githubusercontent.com/3439869/79644927-182fcb00-817a-11ea-87d7-12c24fca3289.png">
