### PR TITLE
Make the parser part of an options object

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -122,7 +122,7 @@ export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiRespon
 export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const PAGE_SIZE = 1000
 
-  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, Number).query('skip', 'take')
+  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { using: Number }).query('skip', 'take')
 
   const url = urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -122,7 +122,7 @@ export const getVehicleById = async (req: AgencyApiRequest, res: AgencyApiRespon
 export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   const PAGE_SIZE = 1000
 
-  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { using: Number }).query('skip', 'take')
+  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')
 
   const url = urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -41,7 +41,7 @@ export const wipeDevice = async (req: AgencyApiRequest, res: AgencyApiResponse) 
 
 export const refreshCache = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
-  const { skip = 0, take = 10000000000 } = parseRequest(req, { using: Number }).query('skip', 'take')
+  const { skip = 0, take = 10000000000 } = parseRequest(req, { parser: Number }).query('skip', 'take')
 
   try {
     const rows = await db.readDeviceIds()

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -41,7 +41,7 @@ export const wipeDevice = async (req: AgencyApiRequest, res: AgencyApiResponse) 
 
 export const refreshCache = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
-  const { skip = 0, take = 10000000000 } = parseRequest(req, Number).query('skip', 'take')
+  const { skip = 0, take = 10000000000 } = parseRequest(req, { using: Number }).query('skip', 'take')
 
   try {
     const rows = await db.readDeviceIds()

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -16,7 +16,7 @@
 
 import urls from 'url'
 import express from 'express'
-import { parseObjectProperties } from '@mds-core/mds-utils'
+import { parseObjectProperties, ParseObjectPropertiesOptions } from '@mds-core/mds-utils'
 
 interface PagingParams {
   skip: number
@@ -56,8 +56,8 @@ export const asJsonApiLinks = (req: express.Request, skip: number, take: number,
   return undefined
 }
 
-export const parseRequest = <T = string>(req: express.Request, parser?: (value: string) => T) => {
-  const { keys: query } = parseObjectProperties<T>(req.query, parser)
-  const { keys: params } = parseObjectProperties<T>(req.params, parser)
+export const parseRequest = <T = string>(req: express.Request, options?: ParseObjectPropertiesOptions<T>) => {
+  const { keys: query } = parseObjectProperties<T>(req.query, options)
+  const { keys: params } = parseObjectProperties<T>(req.params, options)
   return { params, query }
 }

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -511,9 +511,9 @@ function api(app: express.Express): express.Express {
                 }
               }, {})
 
-            const { event_viewport_adjustment = seconds(30) } = parseRequest(req, x => seconds(Number(x))).query(
-              'event_viewport_adjustment'
-            )
+            const { event_viewport_adjustment = seconds(30) } = parseRequest(req, {
+              using: x => seconds(Number(x))
+            }).query('event_viewport_adjustment')
 
             const start_time = audit_start && audit_start - event_viewport_adjustment
             const end_time = (end => end && end + event_viewport_adjustment)(audit_end || last_event)
@@ -652,7 +652,7 @@ function api(app: express.Express): express.Express {
     async (req, res) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const { strict = true, bbox, provider_id } = {
-        ...parseRequest(req, JSON.parse).query('strict', 'bbox'),
+        ...parseRequest(req, { using: JSON.parse }).query('strict', 'bbox'),
         ...parseRequest(req).query('provider_id')
       }
 

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -512,7 +512,7 @@ function api(app: express.Express): express.Express {
               }, {})
 
             const { event_viewport_adjustment = seconds(30) } = parseRequest(req, {
-              using: x => seconds(Number(x))
+              parser: x => seconds(Number(x))
             }).query('event_viewport_adjustment')
 
             const start_time = audit_start && audit_start - event_viewport_adjustment
@@ -652,7 +652,7 @@ function api(app: express.Express): express.Express {
     async (req, res) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const { strict = true, bbox, provider_id } = {
-        ...parseRequest(req, { using: JSON.parse }).query('strict', 'bbox'),
+        ...parseRequest(req, { parser: JSON.parse }).query('strict', 'bbox'),
         ...parseRequest(req).query('provider_id')
       }
 

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -80,7 +80,7 @@ function api(app: express.Express): express.Express {
     const { provider_id } = res.locals
     const { provider_id: queried_provider_id, end_date: query_end_date } = {
       ...parseRequest(req).query('provider_id'),
-      ...parseRequest(req, Number).query('end_date')
+      ...parseRequest(req, { using: Number }).query('end_date')
     }
 
     /* istanbul ignore next */

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -80,7 +80,7 @@ function api(app: express.Express): express.Express {
     const { provider_id } = res.locals
     const { provider_id: queried_provider_id, end_date: query_end_date } = {
       ...parseRequest(req).query('provider_id'),
-      ...parseRequest(req, { using: Number }).query('end_date')
+      ...parseRequest(req, { parser: Number }).query('end_date')
     }
 
     /* istanbul ignore next */

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -17,7 +17,7 @@ function api(app: express.Express): express.Express {
       const { scopes } = res.locals
       const params = {
         ...{ get_published: null, get_unpublished: null },
-        ...parseRequest(req, x => (x ? x === 'true' : null)).query('get_published', 'get_unpublished')
+        ...parseRequest(req, { using: x => (x ? x === 'true' : null) }).query('get_published', 'get_unpublished')
       }
 
       /* If the user can only read published geos, and all they want is the unpublished metadata,

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -17,7 +17,7 @@ function api(app: express.Express): express.Express {
       const { scopes } = res.locals
       const params = {
         ...{ get_published: null, get_unpublished: null },
-        ...parseRequest(req, { using: x => (x ? x === 'true' : null) }).query('get_published', 'get_unpublished')
+        ...parseRequest(req, { parser: x => (x ? x === 'true' : null) }).query('get_published', 'get_unpublished')
       }
 
       /* If the user can only read published geos, and all they want is the unpublished metadata,

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -30,7 +30,7 @@ type GetJurisdictionResponse = JurisdictionApiResponse<{
 
 export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-  const { effective } = parseRequest(req, Number).query('effective')
+  const { effective } = parseRequest(req, { using: Number }).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective }),
     error => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -30,7 +30,7 @@ type GetJurisdictionResponse = JurisdictionApiResponse<{
 
 export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
   const { jurisdiction_id } = req.params
-  const { effective } = parseRequest(req, { using: Number }).query('effective')
+  const { effective } = parseRequest(req, { parser: Number }).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective }),
     error => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -27,7 +27,7 @@ type GetJurisdictionsResponse = JurisdictionApiResponse<{
 }>
 
 export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
-  const { effective } = parseRequest(req, { using: Number }).query('effective')
+  const { effective } = parseRequest(req, { parser: Number }).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdictions({ effective }),
     error => {

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -27,7 +27,7 @@ type GetJurisdictionsResponse = JurisdictionApiResponse<{
 }>
 
 export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
-  const { effective } = parseRequest(req, Number).query('effective')
+  const { effective } = parseRequest(req, { using: Number }).query('effective')
   HandleServiceResponse(
     await JurisdictionServiceClient.getJurisdictions({ effective }),
     error => {

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -599,12 +599,12 @@ const getEnvVar = <TProps extends { [name: string]: string }>(props: TProps): TP
   }, {} as TProps)
 
 export type ParseObjectPropertiesOptions<T> = Partial<{
-  using: (value: string) => T
+  parser: (value: string) => T
 }>
 
 const parseObjectProperties = <T = string>(
   obj: { [k: string]: unknown },
-  { using: parser }: ParseObjectPropertiesOptions<T> = {}
+  { parser }: ParseObjectPropertiesOptions<T> = {}
 ) => {
   return {
     keys: <TKey extends string>(first: TKey, ...rest: TKey[]): Partial<{ [P in TKey]: T }> =>

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -598,7 +598,14 @@ const getEnvVar = <TProps extends { [name: string]: string }>(props: TProps): TP
     }
   }, {} as TProps)
 
-const parseObjectProperties = <T = string>(obj: { [k: string]: unknown }, parser?: (value: string) => T) => {
+export type ParseObjectPropertiesOptions<T> = Partial<{
+  using: (value: string) => T
+}>
+
+const parseObjectProperties = <T = string>(
+  obj: { [k: string]: unknown },
+  { using: parser }: ParseObjectPropertiesOptions<T> = {}
+) => {
   return {
     keys: <TKey extends string>(first: TKey, ...rest: TKey[]): Partial<{ [P in TKey]: T }> =>
       [first, ...rest]


### PR DESCRIPTION
This will allow for additional options/functionality without changing the signature since this will eventually be used in many places.