### PR TITLE
Export processors as functions instead of values

### DIFF
--- a/container-images/mds-event-processor/index.ts
+++ b/container-images/mds-event-processor/index.ts
@@ -20,7 +20,8 @@ import logger from '@mds-core/mds-logger'
 
 const { npm_package_name, npm_package_version, npm_package_git_commit, KAFKA_HOST } = env()
 
-VehicleEventProcessor.start()
+VehicleEventProcessor()
+  .start()
   .then(() => {
     logger.info(
       `Running ${npm_package_name} v${npm_package_version} (${

--- a/container-images/mds-telemetry-processor/index.ts
+++ b/container-images/mds-telemetry-processor/index.ts
@@ -20,7 +20,8 @@ import logger from '@mds-core/mds-logger'
 
 const { npm_package_name, npm_package_version, npm_package_git_commit, KAFKA_HOST } = env()
 
-VehicleTelemetryProcessor.start()
+VehicleTelemetryProcessor()
+  .start()
   .then(() => {
     logger.info(
       `Running ${npm_package_name} v${npm_package_version} (${

--- a/packages/mds-stream-processor/labelers/device-labeler.ts
+++ b/packages/mds-stream-processor/labelers/device-labeler.ts
@@ -30,7 +30,6 @@ const MemCache = <TKey extends keyof T, T>(
   { size = 1000 }: Partial<MemCacheOptions> = {}
 ) => {
   const memcache = new Map<T[TKey], T>()
-  logger.info('MapCache Initialized', { size })
   return async (key: T[TKey]): Promise<T | undefined> => {
     const value = memcache.get(key) ?? (await load(key))
     if (value) {

--- a/packages/mds-stream-processor/processors/vehicle-event-processor.ts
+++ b/packages/mds-stream-processor/processors/vehicle-event-processor.ts
@@ -107,8 +107,9 @@ const processVehicleEvent: StreamTransform<VehicleEvent, LabeledVehicleEvent> = 
   return null
 }
 
-export const VehicleEventProcessor = StreamProcessor(
-  KafkaSource<VehicleEvent>(`${TENANT_ID}.event`, { groupId: 'mds-event-processor' }),
-  processVehicleEvent,
-  KafkaSink<LabeledVehicleEvent>(`${TENANT_ID}.event.annotated`, { clientId: 'mds-event-processor' })
-)
+export const VehicleEventProcessor = () =>
+  StreamProcessor(
+    KafkaSource<VehicleEvent>(`${TENANT_ID}.event`, { groupId: 'mds-event-processor' }),
+    processVehicleEvent,
+    KafkaSink<LabeledVehicleEvent>(`${TENANT_ID}.event.annotated`, { clientId: 'mds-event-processor' })
+  )

--- a/packages/mds-stream-processor/processors/vehicle-event-processor.ts
+++ b/packages/mds-stream-processor/processors/vehicle-event-processor.ts
@@ -40,10 +40,6 @@ import {
 import { StreamTransform, StreamProcessor } from './index'
 import { KafkaSource, KafkaSink } from '../connectors/kafka-connector'
 
-const { TENANT_ID } = getEnvVar({
-  TENANT_ID: 'mds'
-})
-
 interface LabeledVehicleEvent
   extends DeviceLabel,
     GeographyLabel,
@@ -59,57 +55,62 @@ interface LabeledVehicleEvent
   trip_id: Nullable<UUID>
 }
 
-const [deviceLabeler, geographyLabeler, latencyLabeler, telemetryLabeler, vehicleStateLabeler] = [
-  DeviceLabeler(),
-  GeographyLabeler(),
-  LatencyLabeler(),
-  TelemetryLabeler(),
-  VehicleStateLabeler()
-]
+export const VehicleEventProcessor = () => {
+  const { TENANT_ID } = getEnvVar({
+    TENANT_ID: 'mds'
+  })
 
-const processVehicleEvent: StreamTransform<VehicleEvent, LabeledVehicleEvent> = async event => {
-  const { device_id, provider_id, event_type, event_type_reason, timestamp, recorded, trip_id, telemetry } = event
-  try {
-    const [deviceLabel, geographyLabel, latencyLabel, telemetryLabel, vehicleStateLabel] = await Promise.all([
-      deviceLabeler({ device_id }),
-      geographyLabeler({ telemetry }),
-      latencyLabeler({ timestamp, recorded }),
-      telemetry ? telemetryLabeler({ telemetry }) : null,
-      vehicleStateLabeler({ event_type })
-    ])
-    const transformed: LabeledVehicleEvent = {
-      device_id,
-      provider_id,
-      event_type,
-      event_type_reason: event_type_reason ?? null,
-      event_timestamp: timestamp,
-      event_recorded: recorded,
-      trip_id: trip_id ?? null,
-      ...deviceLabel,
-      ...geographyLabel,
-      ...latencyLabel,
-      ...(telemetryLabel ?? {
-        telemetry_timestamp: null,
-        telemetry_lat: null,
-        telemetry_lng: null,
-        telemetry_altitude: null,
-        telemetry_heading: null,
-        telemetry_speed: null,
-        telemetry_accuracy: null,
-        telemetry_charge: null
-      }),
-      ...vehicleStateLabel
+  const [deviceLabeler, geographyLabeler, latencyLabeler, telemetryLabeler, vehicleStateLabeler] = [
+    DeviceLabeler(),
+    GeographyLabeler(),
+    LatencyLabeler(),
+    TelemetryLabeler(),
+    VehicleStateLabeler()
+  ]
+
+  const processVehicleEvent: StreamTransform<VehicleEvent, LabeledVehicleEvent> = async event => {
+    const { device_id, provider_id, event_type, event_type_reason, timestamp, recorded, trip_id, telemetry } = event
+    try {
+      const [deviceLabel, geographyLabel, latencyLabel, telemetryLabel, vehicleStateLabel] = await Promise.all([
+        deviceLabeler({ device_id }),
+        geographyLabeler({ telemetry }),
+        latencyLabeler({ timestamp, recorded }),
+        telemetry ? telemetryLabeler({ telemetry }) : null,
+        vehicleStateLabeler({ event_type })
+      ])
+      const transformed: LabeledVehicleEvent = {
+        device_id,
+        provider_id,
+        event_type,
+        event_type_reason: event_type_reason ?? null,
+        event_timestamp: timestamp,
+        event_recorded: recorded,
+        trip_id: trip_id ?? null,
+        ...deviceLabel,
+        ...geographyLabel,
+        ...latencyLabel,
+        ...(telemetryLabel ?? {
+          telemetry_timestamp: null,
+          telemetry_lat: null,
+          telemetry_lng: null,
+          telemetry_altitude: null,
+          telemetry_heading: null,
+          telemetry_speed: null,
+          telemetry_accuracy: null,
+          telemetry_charge: null
+        }),
+        ...vehicleStateLabel
+      }
+      return transformed
+    } catch (error) {
+      logger.error('Error processing event', event)
     }
-    return transformed
-  } catch (error) {
-    logger.error('Error processing event', event)
+    return null
   }
-  return null
-}
 
-export const VehicleEventProcessor = () =>
-  StreamProcessor(
+  return StreamProcessor(
     KafkaSource<VehicleEvent>(`${TENANT_ID}.event`, { groupId: 'mds-event-processor' }),
     processVehicleEvent,
     KafkaSink<LabeledVehicleEvent>(`${TENANT_ID}.event.annotated`, { clientId: 'mds-event-processor' })
   )
+}

--- a/packages/mds-stream-processor/processors/vehicle-telemetry-processor.ts
+++ b/packages/mds-stream-processor/processors/vehicle-telemetry-processor.ts
@@ -30,56 +30,57 @@ import {
 import { StreamTransform, StreamProcessor } from './index'
 import { KafkaSource, KafkaSink } from '../connectors/kafka-connector'
 
-const { TENANT_ID } = getEnvVar({
-  TENANT_ID: 'mds'
-})
-
 interface LabeledVehicleTelemetry extends DeviceLabel, GeographyLabel, LatencyLabel, TelemetryLabel {
   device_id: UUID
   provider_id: UUID
   telemetry_recorded: Timestamp
 }
 
-const [deviceLabeler, geographyLabeler, latencyLabeler, telemetryLabeler] = [
-  DeviceLabeler(),
-  GeographyLabeler(),
-  LatencyLabeler(),
-  TelemetryLabeler()
-]
+export const VehicleTelemetryProcessor = () => {
+  const { TENANT_ID } = getEnvVar({
+    TENANT_ID: 'mds'
+  })
 
-const processVehicleTelemetry: StreamTransform<
-  Telemetry & { recorded: Timestamp },
-  LabeledVehicleTelemetry
-> = async telemetry => {
-  const { device_id, provider_id, timestamp, recorded } = telemetry
-  try {
-    const [deviceLabel, latencyLabel, geographyLabel, telemetryLabel] = await Promise.all([
-      deviceLabeler({ device_id }),
-      geographyLabeler({ telemetry }),
-      latencyLabeler({ timestamp, recorded }),
-      telemetryLabeler({ telemetry })
-    ])
-    const transformed: LabeledVehicleTelemetry = {
-      device_id,
-      provider_id,
-      telemetry_recorded: recorded,
-      ...deviceLabel,
-      ...geographyLabel,
-      ...latencyLabel,
-      ...telemetryLabel
+  const [deviceLabeler, geographyLabeler, latencyLabeler, telemetryLabeler] = [
+    DeviceLabeler(),
+    GeographyLabeler(),
+    LatencyLabeler(),
+    TelemetryLabeler()
+  ]
+
+  const processVehicleTelemetry: StreamTransform<
+    Telemetry & { recorded: Timestamp },
+    LabeledVehicleTelemetry
+  > = async telemetry => {
+    const { device_id, provider_id, timestamp, recorded } = telemetry
+    try {
+      const [deviceLabel, latencyLabel, geographyLabel, telemetryLabel] = await Promise.all([
+        deviceLabeler({ device_id }),
+        geographyLabeler({ telemetry }),
+        latencyLabeler({ timestamp, recorded }),
+        telemetryLabeler({ telemetry })
+      ])
+      const transformed: LabeledVehicleTelemetry = {
+        device_id,
+        provider_id,
+        telemetry_recorded: recorded,
+        ...deviceLabel,
+        ...geographyLabel,
+        ...latencyLabel,
+        ...telemetryLabel
+      }
+      return transformed
+    } catch (error) {
+      logger.error('Error processing telemetry', telemetry)
     }
-    return transformed
-  } catch (error) {
-    logger.error('Error processing telemetry', telemetry)
+    return null
   }
-  return null
-}
 
-export const VehicleTelemetryProcessor = () =>
-  StreamProcessor(
+  return StreamProcessor(
     KafkaSource<Telemetry & { gps: TelemetryData } & { recorded: Timestamp }>(`${TENANT_ID}.telemetry`, {
       groupId: 'mds-telemetry-processor'
     }),
     processVehicleTelemetry,
     KafkaSink<LabeledVehicleTelemetry>(`${TENANT_ID}.telemetry.annotated`, { clientId: 'mds-telemetry-processor' })
   )
+}

--- a/packages/mds-stream-processor/processors/vehicle-telemetry-processor.ts
+++ b/packages/mds-stream-processor/processors/vehicle-telemetry-processor.ts
@@ -75,10 +75,11 @@ const processVehicleTelemetry: StreamTransform<
   return null
 }
 
-export const VehicleTelemetryProcessor = StreamProcessor(
-  KafkaSource<Telemetry & { gps: TelemetryData } & { recorded: Timestamp }>(`${TENANT_ID}.telemetry`, {
-    groupId: 'mds-telemetry-processor'
-  }),
-  processVehicleTelemetry,
-  KafkaSink<LabeledVehicleTelemetry>(`${TENANT_ID}.telemetry.annotated`, { clientId: 'mds-telemetry-processor' })
-)
+export const VehicleTelemetryProcessor = () =>
+  StreamProcessor(
+    KafkaSource<Telemetry & { gps: TelemetryData } & { recorded: Timestamp }>(`${TENANT_ID}.telemetry`, {
+      groupId: 'mds-telemetry-processor'
+    }),
+    processVehicleTelemetry,
+    KafkaSink<LabeledVehicleTelemetry>(`${TENANT_ID}.telemetry.annotated`, { clientId: 'mds-telemetry-processor' })
+  )

--- a/packages/mds-stream-processor/server.ts
+++ b/packages/mds-stream-processor/server.ts
@@ -22,7 +22,9 @@ const {
   env: { npm_package_name, npm_package_version, npm_package_git_commit, KAFKA_HOST }
 } = process
 
-Promise.all([VehicleEventProcessor.start(), VehicleTelemetryProcessor.start()])
+const processors = [VehicleEventProcessor(), VehicleTelemetryProcessor()]
+
+Promise.all(processors.map(processor => processor.start()))
   .then(() => {
     logger.info(
       `Running ${npm_package_name} v${npm_package_version} (${


### PR DESCRIPTION
I noticed this in the k8s logs for both `mds-event-processor` and `mds-telemetry-processor` pods. Each container should only be referencing one processor. This was due to the stream processors being initialized on export. Changed processors to export a factory function that can be used to initialize them instead.
```                                                                        │
│ INFO "Creating KafkaStreamSink" "mds.event.annotated" {"clientId":"mds-event-processor"}                             │
│ INFO "Creating KafkaStreamSource" "mds.event" {"groupId":"mds-event-processor"}                                      │                                                                         │
│ INFO "Creating KafkaStreamSink" "mds.telemetry.annotated" {"clientId":"mds-telemetry-processor"}                     │
│ INFO "Creating KafkaStreamSource" "mds.telemetry" {"groupId":"mds-telemetry-processor"}
```