### PR TITLE
Remove undeclared mds-cache dependency

### DIFF
--- a/packages/mds-cache/package.json
+++ b/packages/mds-cache/package.json
@@ -15,6 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mds-core/mds-logger": "0.1.24",
+    "@mds-core/mds-schema-validators": "0.1.2",
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
     "bluebird": "3.7.2",

--- a/packages/mds-cache/tsconfig.build.json
+++ b/packages/mds-cache/tsconfig.build.json
@@ -5,6 +5,7 @@
   },
   "references": [
     { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-schema-validators/tsconfig.build.json" },
     { "path": "../../packages/mds-types/tsconfig.build.json" },
     { "path": "../../packages/mds-utils/tsconfig.build.json" }
   ]

--- a/packages/mds-cache/unflatteners.ts
+++ b/packages/mds-cache/unflatteners.ts
@@ -1,12 +1,14 @@
 import { VEHICLE_TYPE, VEHICLE_EVENT, VEHICLE_STATUS, Device, Telemetry, VehicleEvent } from '@mds-core/mds-types'
-import {
-  isStringifiedTelemetry,
-  isStringifiedEventWithTelemetry,
-  isStringifiedCacheReadDeviceResult
-} from '@mds-core/mds-schema-validators'
 
 import { ParseError } from '@mds-core/mds-utils'
-import { StringifiedEvent, StringifiedTelemetry, StringifiedCacheReadDeviceResult, CachedItem } from './types'
+import { HasPropertyAssertion } from '@mds-core/mds-schema-validators'
+import {
+  StringifiedEvent,
+  StringifiedEventWithTelemetry,
+  StringifiedTelemetry,
+  StringifiedCacheReadDeviceResult,
+  CachedItem
+} from './types'
 
 function parseTelemetry(telemetry: StringifiedTelemetry): Telemetry {
   try {
@@ -71,6 +73,15 @@ function parseDevice(device: StringifiedCacheReadDeviceResult): Device {
   }
   return device
 }
+
+const isStringifiedTelemetry = (telemetry: unknown): telemetry is StringifiedTelemetry =>
+  HasPropertyAssertion<StringifiedTelemetry>(telemetry, 'gps')
+
+const isStringifiedEventWithTelemetry = (event: unknown): event is StringifiedEventWithTelemetry =>
+  HasPropertyAssertion<StringifiedEventWithTelemetry>(event, 'event_type', 'telemetry')
+
+const isStringifiedCacheReadDeviceResult = (device: unknown): device is StringifiedCacheReadDeviceResult =>
+  HasPropertyAssertion<StringifiedCacheReadDeviceResult>(device, 'device_id', 'provider_id', 'type', 'propulsion')
 
 function parseCachedItem(item: CachedItem): Device | Telemetry | VehicleEvent {
   if (isStringifiedTelemetry(item)) {

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -36,11 +36,7 @@ import {
 } from '@mds-core/mds-types'
 import * as Joi from '@hapi/joi'
 import joiToJsonSchema from 'joi-to-json-schema'
-import {
-  StringifiedTelemetry,
-  StringifiedEventWithTelemetry,
-  StringifiedCacheReadDeviceResult
-} from '@mds-core/mds-cache/types'
+
 import { ValidationError } from '@mds-core/mds-utils'
 
 export { ValidationError }
@@ -342,17 +338,8 @@ export const isValidAuditIssueCode = (value: unknown, options: Partial<Validator
 export const isValidAuditNote = (value: unknown, options: Partial<ValidatorOptions> = {}): value is string =>
   ValidateSchema(value, auditNoteSchema, { property: 'note', ...options })
 
-const HasPropertyAssertion = <T>(obj: unknown, ...props: (keyof T)[]): obj is T =>
+export const HasPropertyAssertion = <T>(obj: unknown, ...props: (keyof T)[]): obj is T =>
   typeof obj === 'object' && obj !== null && props.every(prop => prop in obj)
-
-export const isStringifiedTelemetry = (telemetry: unknown): telemetry is StringifiedTelemetry =>
-  HasPropertyAssertion<StringifiedTelemetry>(telemetry, 'gps')
-
-export const isStringifiedEventWithTelemetry = (event: unknown): event is StringifiedEventWithTelemetry =>
-  HasPropertyAssertion<StringifiedEventWithTelemetry>(event, 'event_type', 'telemetry')
-
-export const isStringifiedCacheReadDeviceResult = (device: unknown): device is StringifiedCacheReadDeviceResult =>
-  HasPropertyAssertion<StringifiedCacheReadDeviceResult>(device, 'device_id', 'provider_id', 'type', 'propulsion')
 
 export function validatePolicies(policies: unknown): policies is Policy[] {
   const { error } = Joi.validate(policies, policiesSchema)


### PR DESCRIPTION
`mds-schema-validators` had an undeclared (and perhaps ill-advised) dependency on `mds-cache`