### PR TITLE
[mds-repository] connection manager improvements

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "@istanbuljs/nyc-config-typescript",
+  "check-coverage": true,
   "lines": 80,
   "reporter": ["text", "html"],
   "temp-directory": "./coverage/.nyc_output"

--- a/packages/mds-metrics-service/service/repository/mappers.ts
+++ b/packages/mds-metrics-service/service/repository/mappers.ts
@@ -19,11 +19,11 @@ import { CreateIdentityEntityModel } from '@mds-core/mds-repository'
 import { MetricEntityModel } from './entities/metric-entity'
 import { MetricDomainModel } from '../../@types'
 
-type MapMertricEntityToDomainModelOptions = Partial<{}>
+type MapMetricEntityToDomainModelOptions = Partial<{}>
 
 const MapMetricEntityToDomainModel = (
   model: MetricEntityModel,
-  options: MapMertricEntityToDomainModelOptions = {}
+  options: MapMetricEntityToDomainModelOptions = {}
 ): MetricDomainModel => {
   const { id, recorded, ...domain } = model
   return domain
@@ -31,7 +31,7 @@ const MapMetricEntityToDomainModel = (
 
 export const MetricEntityToDomainModel = {
   map: MapMetricEntityToDomainModel,
-  mapper: (options: MapMertricEntityToDomainModelOptions = {}) => (model: MetricEntityModel) =>
+  mapper: (options: MapMetricEntityToDomainModelOptions = {}) => (model: MetricEntityModel) =>
     MapMetricEntityToDomainModel(model, options)
 }
 

--- a/packages/mds-repository/connection-manager.ts
+++ b/packages/mds-repository/connection-manager.ts
@@ -104,16 +104,13 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
     try {
       const [, rw] = await Promise.all(ConnectionModes.map(mode => connect(mode)))
       /* istanbul ignore if */
-      if (options.migrationsTableName && PG_MIGRATIONS === 'true') {
-        logger.info(`Checking ${options.migrationsTableName} for pending migrations`)
+      if (PG_MIGRATIONS === 'true' && options.migrationsTableName) {
         const migrations = await rw.runMigrations({ transaction: 'all' })
         logger.info(
-          `Ran ${migrations.length} ${migrations.length === 1 ? 'migration' : 'migrations'}${
-            migrations.length ? `: ${migrations.map(migration => migration.name).join(', ')}` : ''
-          }`
+          `Ran ${migrations.length} ${migrations.length === 1 ? 'migration' : 'migrations'} (${
+            options.migrationsTableName
+          })${migrations.length ? `: ${migrations.map(migration => migration.name).join(', ')}` : ''}`
         )
-      } else {
-        logger.info('Skipping pending migrations check')
       }
     } catch (error) /* istanbul ignore next */ {
       throw RepositoryError(error)

--- a/packages/mds-repository/connection-manager.ts
+++ b/packages/mds-repository/connection-manager.ts
@@ -103,6 +103,7 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
   const initialize = async () => {
     try {
       const [, rw] = await Promise.all(ConnectionModes.map(mode => connect(mode)))
+      /* istanbul ignore if */
       if (options.migrationsTableName && PG_MIGRATIONS === 'true') {
         logger.info(`Checking ${options.migrationsTableName} for pending migrations`)
         const migrations = await rw.runMigrations({ transaction: 'all' })

--- a/packages/mds-repository/connection-manager.ts
+++ b/packages/mds-repository/connection-manager.ts
@@ -104,7 +104,7 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
     try {
       const [, rw] = await Promise.all(ConnectionModes.map(mode => connect(mode)))
       /* istanbul ignore if */
-      if (PG_MIGRATIONS === 'true' && options.migrationsTableName) {
+      if (PG_MIGRATIONS === 'true' && rw.options.migrationsTableName) {
         const migrations = await rw.runMigrations({ transaction: 'all' })
         logger.info(
           `Ran ${migrations.length} ${migrations.length === 1 ? 'migration' : 'migrations'} (${

--- a/packages/mds-repository/connection-manager.ts
+++ b/packages/mds-repository/connection-manager.ts
@@ -14,10 +14,14 @@
     limitations under the License.
  */
 
-import { Connection, createConnections, ConnectionOptions } from 'typeorm'
+import { Connection, ConnectionOptions, createConnection } from 'typeorm'
 import { types as PostgresTypes } from 'pg'
 import { LoggerOptions } from 'typeorm/logger/LoggerOptions'
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions'
+import { Nullable, UUID } from '@mds-core/mds-types'
+import { uuid } from '@mds-core/mds-utils'
+import logger from '@mds-core/mds-logger'
+import AwaitLock from 'await-lock'
 import { MdsNamingStrategy } from './naming-strategies'
 import { RepositoryError } from './exceptions'
 
@@ -42,15 +46,16 @@ const {
   PG_MIGRATIONS = 'true' // Enable migrations by default
 } = process.env
 
-const connectionName = (prefix: string, mode: ConnectionMode) => `${prefix}-${mode}`
-
 export type ConnectionManagerOptions = Partial<PostgresConnectionOptions>
 
 export const ConnectionManager = (prefix: string, options: Omit<ConnectionManagerOptions, 'cli'> = {}) => {
-  let connections: Connection[] | null = null
+  const lock = new AwaitLock()
+  const connections: { [mode in ConnectionMode]: Nullable<Connection> } = { ro: null, rw: null }
 
-  const [ro, rw]: ConnectionOptions[] = ConnectionModes.map(mode => ({
-    name: connectionName(prefix, mode),
+  const connectionName = ((instance: UUID) => (mode: ConnectionMode) => `${prefix}-${mode}-${instance}`)(uuid())
+
+  const connectionOptions = (mode: ConnectionMode): ConnectionOptions => ({
+    name: connectionName(mode),
     type: 'postgres',
     host: (mode === 'rw' ? PG_HOST : PG_HOST_READER) || PG_HOST || 'localhost',
     port: Number(PG_PORT) || 5432,
@@ -61,33 +66,29 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
     maxQueryExecutionTime: 3000,
     logger: 'simple-console',
     synchronize: false,
-    migrationsRun: PG_MIGRATIONS === 'true' && mode === 'rw',
+    migrationsRun: false,
     namingStrategy: new MdsNamingStrategy(),
     ...options
-  }))
+  })
 
-  const initialize = async () => {
-    if (!connections) {
-      try {
-        connections = await createConnections([ro, rw])
-      } catch (error) /* istanbul ignore next */ {
-        throw RepositoryError(error)
+  const getConnection = async (mode: ConnectionMode) => {
+    await lock.acquireAsync()
+    try {
+      if (!connections[mode]) {
+        connections[mode] = await createConnection(connectionOptions(mode))
+        logger.info(`Created ${mode} connection: ${connections[mode]?.options.name}`)
       }
+    } finally {
+      lock.release()
     }
+    return connections[mode]
   }
 
   const connect = async (mode: ConnectionMode) => {
-    if (!connections) {
-      await initialize()
-      if (!connections) {
-        /* istanbul ignore next */
-        throw RepositoryError(Error('Connection manager not initialized'))
-      }
-    }
-    const connection = connections.find(c => c.name === connectionName(prefix, mode))
+    const connection = await getConnection(mode)
     if (!connection) {
       /* istanbul ignore next */
-      throw RepositoryError(Error(`Connection ${connectionName(prefix, mode)} not found`))
+      throw RepositoryError(Error(`Connection ${connectionName(mode)} not found`))
     }
     if (!connection.isConnected) {
       try {
@@ -99,15 +100,36 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
     return connection
   }
 
-  const shutdown = async () => {
-    if (connections) {
-      try {
-        await Promise.all(
-          connections.filter(connection => connection.isConnected).map(connection => connection.close())
+  const initialize = async () => {
+    try {
+      const [, rw] = await Promise.all(ConnectionModes.map(mode => connect(mode)))
+      if (options.migrationsTableName && PG_MIGRATIONS === 'true') {
+        logger.info(`Checking ${options.migrationsTableName} for pending migrations`)
+        const migrations = await rw.runMigrations({ transaction: 'all' })
+        logger.info(
+          `Ran ${migrations.length} ${migrations.length === 1 ? 'migration' : 'migrations'}${
+            migrations.length ? `: ${migrations.map(migration => migration.name).join(', ')}` : ''
+          }`
         )
-      } finally {
-        connections = null
+      } else {
+        logger.info('Skipping pending migrations check')
       }
+    } catch (error) /* istanbul ignore next */ {
+      throw RepositoryError(error)
+    }
+  }
+
+  const shutdown = async () => {
+    try {
+      if (connections.ro?.isConnected) {
+        await connections.ro.close()
+      }
+      if (connections.rw?.isConnected) {
+        await connections.rw.close()
+      }
+    } finally {
+      connections.ro = null
+      connections.rw = null
     }
   }
 
@@ -115,7 +137,7 @@ export const ConnectionManager = (prefix: string, options: Omit<ConnectionManage
     initialize,
     cli: (cli: Partial<ConnectionManagerOptions['cli']> = {}) => {
       // Make the "rw" connection the default for the TypeORM CLI by removing the connection name
-      const { name, ...ormconfig } = rw
+      const { name, ...ormconfig } = connectionOptions('rw')
       return { ...ormconfig, cli }
     },
     connect,

--- a/packages/mds-repository/migration.ts
+++ b/packages/mds-repository/migration.ts
@@ -1,0 +1,34 @@
+/*
+    Copyright 2019-2020 City of Los Angeles.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export const CreateRepositoryMigration = (migrationTableName: string) => {
+  return class CreateRepository0000000000001 implements MigrationInterface {
+    name = 'CreateRepository0000000000001'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `CREATE UNIQUE INDEX "idx_migration_table_name" ON "${migrationTableName}" ("name") `,
+        undefined
+      )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP INDEX "idx_migration_table_name"`, undefined)
+    }
+  }
+}

--- a/packages/mds-repository/package.json
+++ b/packages/mds-repository/package.json
@@ -24,6 +24,7 @@
     "@mds-core/mds-providers": "0.1.26",
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
+    "await-lock": "2.0.1",
     "pg": "8.0.3",
     "typeorm": "0.2.24"
   },

--- a/packages/mds-repository/repository.ts
+++ b/packages/mds-repository/repository.ts
@@ -16,6 +16,7 @@
 
 import { Connection } from 'typeorm'
 import { ConnectionManager, ConnectionManagerOptions, ConnectionMode } from './connection-manager'
+import { CreateRepositoryMigration } from './migration'
 
 type RepositoryMethod<TMethod> = (connect: (mode: ConnectionMode) => Promise<Connection>) => TMethod
 
@@ -28,9 +29,14 @@ export type RepositoryOptions = Pick<ConnectionManagerOptions, 'entities' | 'mig
 export const CreateRepository = <TRepositoryMethods>(
   name: string,
   methods: (connect: (mode: ConnectionMode) => Promise<Connection>) => TRepositoryMethods,
-  options: RepositoryOptions = {}
+  { entities = [], migrations = [] }: RepositoryOptions = {}
 ) => {
-  const { connect, ...manager } = ConnectionManager(name, { migrationsTableName: `${name}-migrations`, ...options })
+  const migrationsTableName = `${name}-migrations`
+  const { connect, ...manager } = ConnectionManager(name, {
+    migrationsTableName,
+    entities,
+    migrations: [CreateRepositoryMigration(migrationsTableName), ...migrations]
+  })
   return {
     ...manager,
     ...methods(connect)

--- a/packages/mds-repository/tests/connection-manager.spec.ts
+++ b/packages/mds-repository/tests/connection-manager.spec.ts
@@ -28,7 +28,7 @@ describe('Test Connection Manager', () => {
 
   it('Create R/W Connection', async () => {
     const rw = await manager.connect('rw')
-    test.value(rw.name).is(`${TEST_REPOSITORY_NAME}-rw`)
+    test.value(rw.name).startsWith(`${TEST_REPOSITORY_NAME}-rw`)
     test.value(rw.isConnected).is(true)
     await rw.close()
     test.value(rw.isConnected).is(false)
@@ -40,7 +40,7 @@ describe('Test Connection Manager', () => {
 
   it('Create R/O Connection', async () => {
     const ro = await manager.connect('ro')
-    test.value(ro.name).is(`${TEST_REPOSITORY_NAME}-ro`)
+    test.value(ro.name).startsWith(`${TEST_REPOSITORY_NAME}-ro`)
     test.value(ro.isConnected).is(true)
     await ro.close()
     test.value(ro.isConnected).is(false)

--- a/packages/mds-service-helpers/index.ts
+++ b/packages/mds-service-helpers/index.ts
@@ -54,17 +54,21 @@ export const HandleServiceResponse = <R>(
 export const ServiceException = (message: string, error?: unknown) => {
   const details = (error instanceof Error && error.message) || undefined
 
+  /* istanbul ignore if */
   if (error instanceof NotFoundError) {
     return ServiceError({ type: 'NotFoundError', message, details })
   }
 
+  /* istanbul ignore if */
   if (error instanceof ValidationError) {
     return ServiceError({ type: 'ValidationError', message, details })
   }
 
+  /* istanbul ignore if */
   if (error instanceof ConflictError) {
     return ServiceError({ type: 'ConflictError', message, details })
   }
+
   return ServiceError({ type: 'ServiceException', message, details })
 }
 

--- a/packages/mds-utils/index.ts
+++ b/packages/mds-utils/index.ts
@@ -1,3 +1,7 @@
+import { v4 } from 'uuid'
+import { UUID } from '@mds-core/mds-types'
+
 export * from './exceptions'
 export * from './utils'
-export { v4 as uuid } from 'uuid'
+
+export const uuid = (): UUID => v4()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,6 +2484,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+await-lock@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.0.1.tgz#b3f65fdf66e08f7538260f79b46c15bcfc18cadd"
+  integrity sha512-ntLi9fzlMT/vWjC1wwVI11/cSRJ3nTS35qVekNc9WnaoMOP2eWH0RvIqwLQkDjX4a4YynsKEv+Ere2VONp9wxg==
+
 aws-sdk@2.663.0:
   version "2.663.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.663.0.tgz#003d8cc318635d1bf67deda586f5e5d583b7e384"


### PR DESCRIPTION
Resolving a couple of issues with the repository.

- Pending migrations are checked, run, and logged when a repository is initialized; not on each connect.
```
INFO "Created ro connection: metrics-ro-4991d246-d7cf-46f5-80af-52a6a393bb70"
INFO "Created rw connection: metrics-rw-4991d246-d7cf-46f5-80af-52a6a393bb70"
INFO "Ran 2 migrations (metrics-migrations): CreateRepository0000000000001, CreateMetricsTable1588016731204"
```

- Added a mutex lock on connection creation to avoid the chaos that results when multiple queries are initiated concurrently at startup.

Also:

- Re-enabled code-coverage checks