### PR TITLE
Metrics Model Changes

### DIFF
--- a/packages/mds-jurisdiction-service/service/repository/mappers.ts
+++ b/packages/mds-jurisdiction-service/service/repository/mappers.ts
@@ -28,20 +28,21 @@ export const JurisdictionEntityToDomain = ModelMapper<
   JurisdictionEntityModel,
   Nullable<JurisdictionDomainModel>,
   MapJurisdictionEntityToDomainModelOptions
->((model, options) => {
+>((entity, options) => {
   const { effective = Date.now() } = options ?? {}
-  const { jurisdiction_id, agency_key, versions } = model
+  const { jurisdiction_id, agency_key, versions } = entity
   const version = versions.find(properties => effective >= properties.timestamp)
   if (version) {
     const { agency_name, geography_id, timestamp } = version
     if (geography_id !== null) {
-      return {
+      const domain = {
         jurisdiction_id,
         agency_key,
         agency_name,
         geography_id,
         timestamp
       }
+      return domain
     }
   }
   return null
@@ -55,13 +56,14 @@ export const JurisdictionDomainToEntityCreate = ModelMapper<
   CreateJurisdictionDomainModel,
   RecordedEntityCreateModel<IdentityEntityCreateModel<JurisdictionEntityModel>>,
   JurisdictionDomainToEntityCreateOptions
->((model, options) => {
+>((domain, options) => {
   const { recorded } = options ?? {}
-  const { jurisdiction_id = uuid(), agency_key, agency_name, geography_id, timestamp = Date.now() } = model
-  return {
+  const { jurisdiction_id = uuid(), agency_key, agency_name, geography_id, timestamp = Date.now() } = domain
+  const entity = {
     jurisdiction_id,
     agency_key,
     versions: [{ timestamp, agency_name, geography_id }],
     recorded
   }
+  return entity
 })

--- a/packages/mds-metrics-service/@types/index.ts
+++ b/packages/mds-metrics-service/@types/index.ts
@@ -38,9 +38,9 @@ export interface ReadMetricsTimeOptions {
 }
 
 export interface ReadMetricsFilterOptions {
-  provider_id: SingleOrArray<UUID>
-  geography_id: SingleOrArray<UUID>
-  vehicle_type: SingleOrArray<VEHICLE_TYPE>
+  provider_id: SingleOrArray<Nullable<UUID>>
+  geography_id: SingleOrArray<Nullable<UUID>>
+  vehicle_type: SingleOrArray<Nullable<VEHICLE_TYPE>>
 }
 
 export interface ReadMetricsOptions extends ReadMetricsTimeOptions, Partial<ReadMetricsFilterOptions> {

--- a/packages/mds-metrics-service/@types/index.ts
+++ b/packages/mds-metrics-service/@types/index.ts
@@ -38,9 +38,9 @@ export interface ReadMetricsTimeOptions {
 }
 
 export interface ReadMetricsFilterOptions {
-  provider_id: SingleOrArray<Nullable<UUID>>
-  geography_id: SingleOrArray<Nullable<UUID>>
-  vehicle_type: SingleOrArray<Nullable<VEHICLE_TYPE>>
+  provider_id: Nullable<SingleOrArray<UUID>>
+  geography_id: Nullable<SingleOrArray<UUID>>
+  vehicle_type: Nullable<SingleOrArray<VEHICLE_TYPE>>
 }
 
 export interface ReadMetricsOptions extends ReadMetricsTimeOptions, Partial<ReadMetricsFilterOptions> {

--- a/packages/mds-metrics-service/service/repository/entities/metric-entity.ts
+++ b/packages/mds-metrics-service/service/repository/entities/metric-entity.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import { Entity, Column } from 'typeorm'
+import { Entity, Column, Index } from 'typeorm'
 import { UUID, Timestamp, Nullable, VEHICLE_TYPE } from '@mds-core/mds-types'
 import {
   BigintTransformer,
@@ -39,7 +39,13 @@ export interface MetricEntityModel extends IdentityEntityModel, RecordedEntityMo
 }
 
 @Entity('metrics')
-export class MetricEntity extends IdentityEntity(RecordedEntity(class {})) implements MetricEntityModel {
+@Index(
+  'idx_dimensions_metrics',
+  ['name', 'time_bin_size', 'time_bin_start', 'provider_id', 'vehicle_type', 'geography_id'],
+  { unique: true }
+)
+export class MetricEntity extends IdentityEntity(RecordedEntity(class {}), { primary: true })
+  implements MetricEntityModel {
   @Column('varchar', { primary: true, length: 255 })
   name: string
 
@@ -49,13 +55,13 @@ export class MetricEntity extends IdentityEntity(RecordedEntity(class {})) imple
   @Column('bigint', { primary: true, transformer: BigintTransformer })
   time_bin_start: Timestamp
 
-  @Column('uuid', { primary: true, nullable: true })
+  @Column('uuid', { nullable: true })
   provider_id: Nullable<UUID>
 
-  @Column('uuid', { primary: true, nullable: true })
+  @Column('uuid', { nullable: true })
   geography_id: Nullable<UUID>
 
-  @Column('varchar', { primary: true, length: 31, nullable: true })
+  @Column('varchar', { length: 31, nullable: true })
   vehicle_type: Nullable<VEHICLE_TYPE>
 
   @Column('bigint', { transformer: BigintTransformer, nullable: true })

--- a/packages/mds-metrics-service/service/repository/mappers.ts
+++ b/packages/mds-metrics-service/service/repository/mappers.ts
@@ -19,8 +19,8 @@ import { IdentityEntityCreateModel, ModelMapper, RecordedEntityCreateModel } fro
 import { MetricEntityModel } from './entities/metric-entity'
 import { MetricDomainModel } from '../../@types'
 
-export const MetricEntityToDomain = ModelMapper<MetricEntityModel, MetricDomainModel>((model, options) => {
-  const { id, recorded, ...domain } = model
+export const MetricEntityToDomain = ModelMapper<MetricEntityModel, MetricDomainModel>((entity, options) => {
+  const { id, recorded, ...domain } = entity
   return domain
 })
 
@@ -32,8 +32,8 @@ export const MetricDomainToEntityCreate = ModelMapper<
   MetricDomainModel,
   RecordedEntityCreateModel<IdentityEntityCreateModel<MetricEntityModel>>,
   MetricDomainToEntityCreateOptions
->((model, options) => {
+>((domain, options) => {
   const { recorded } = options ?? {}
-  const entity = { ...model, recorded }
+  const entity = { ...domain, recorded }
   return entity
 })

--- a/packages/mds-metrics-service/service/repository/migrations/1588016731204-CreateMetricsTable.ts
+++ b/packages/mds-metrics-service/service/repository/migrations/1588016731204-CreateMetricsTable.ts
@@ -5,14 +5,19 @@ export class CreateMetricsTable1588016731204 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE IF NOT EXISTS "metrics" ("recorded" bigint NOT NULL DEFAULT (extract(epoch from now()) * 1000)::bigint, "id" bigint GENERATED ALWAYS AS IDENTITY, "name" character varying(255) NOT NULL, "time_bin_size" bigint NOT NULL, "time_bin_start" bigint NOT NULL, "provider_id" uuid, "geography_id" uuid, "vehicle_type" character varying(31), "count" bigint, "sum" double precision, "min" double precision, "max" double precision, "avg" double precision, CONSTRAINT "metrics_pkey" PRIMARY KEY ("name", "time_bin_size", "time_bin_start", "provider_id", "geography_id", "vehicle_type"))`,
+      `CREATE TABLE "metrics" ("recorded" bigint NOT NULL DEFAULT (extract(epoch from now()) * 1000)::bigint, "id" bigint GENERATED ALWAYS AS IDENTITY, "name" character varying(255) NOT NULL, "time_bin_size" bigint NOT NULL, "time_bin_start" bigint NOT NULL, "provider_id" uuid, "geography_id" uuid, "vehicle_type" character varying(31), "count" bigint, "sum" double precision, "min" double precision, "max" double precision, "avg" double precision, CONSTRAINT "metrics_pkey" PRIMARY KEY ("name", "time_bin_size", "time_bin_start", "id"))`,
       undefined
     )
-    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_recorded_metrics" ON "metrics" ("recorded") `, undefined)
-    await queryRunner.query(`CREATE UNIQUE INDEX IF NOT EXISTS "idx_id_metrics" ON "metrics" ("id") `, undefined)
+    await queryRunner.query(`CREATE INDEX "idx_recorded_metrics" ON "metrics" ("recorded") `, undefined)
+    await queryRunner.query(`CREATE UNIQUE INDEX "idx_id_metrics" ON "metrics" ("id") `, undefined)
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "idx_dimensions_metrics" ON "metrics" ("name", "time_bin_size", "time_bin_start", "provider_id", "vehicle_type", "geography_id") `,
+      undefined
+    )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_dimensions_metrics"`, undefined)
     await queryRunner.query(`DROP INDEX "idx_id_metrics"`, undefined)
     await queryRunner.query(`DROP INDEX "idx_recorded_metrics"`, undefined)
     await queryRunner.query(`DROP TABLE "metrics"`, undefined)

--- a/packages/mds-metrics-service/tests/index.spec.ts
+++ b/packages/mds-metrics-service/tests/index.spec.ts
@@ -16,7 +16,7 @@
 
 import test from 'unit.js'
 import { uuid, minutes, timeframe, days, pluralize } from '@mds-core/mds-utils'
-import { VEHICLE_TYPE } from '@mds-core/mds-types'
+import { VEHICLE_TYPE, Nullable, UUID } from '@mds-core/mds-types'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { MetricsServiceProvider } from '../service/provider'
 import { MetricDomainModel, ReadMetricsOptions, ReadMetricsFilterOptions } from '../@types'
@@ -26,11 +26,11 @@ const TEST_METRIC_NAME = 'test.metric'
 const TEST_TIME_BIN_SIZE = minutes(5)
 const TEST_TIMESTAMP = Date.now() - days(1)
 const { start_time: TEST_TIME_BIN_START, end_time: TEST_TIME_BIN_END } = timeframe(TEST_TIME_BIN_SIZE, TEST_TIMESTAMP)
-const TEST_PROVIDER_IDS = Array.from({ length: 6 }, () => uuid())
+const TEST_PROVIDER_IDS: Nullable<UUID>[] = [...Array.from({ length: 6 }, () => uuid()), null]
 const [TEST_PROVIDER_ID1, TEST_PROVIDER_ID2, TEST_PROVIDER_ID3] = TEST_PROVIDER_IDS
-const TEST_GEOGRAPHY_IDS = Array.from({ length: 10 }, () => uuid())
+const TEST_GEOGRAPHY_IDS: Nullable<UUID>[] = [...Array.from({ length: 10 }, () => uuid()), null]
 const [TEST_GEOGRAPHY_ID1, TEST_GEOGRAPHY_ID2, TEST_GEOGRAPHY_ID3] = TEST_GEOGRAPHY_IDS
-const TEST_VEHICLE_TYPES: VEHICLE_TYPE[] = ['scooter', 'bicycle', 'moped']
+const TEST_VEHICLE_TYPES: Nullable<VEHICLE_TYPE>[] = ['scooter', 'bicycle', 'moped', null]
 const [TEST_VEHICLE_TYPE1, TEST_VEHICLE_TYPE2, TEST_VEHICLE_TYPE3] = TEST_VEHICLE_TYPES
 
 function* GenerateValues(maxLength: number, maxValue: number): Generator<number> {

--- a/packages/mds-metrics-service/tests/index.spec.ts
+++ b/packages/mds-metrics-service/tests/index.spec.ts
@@ -16,7 +16,7 @@
 
 import test from 'unit.js'
 import { uuid, minutes, timeframe, days, pluralize } from '@mds-core/mds-utils'
-import { VEHICLE_TYPE, Nullable, UUID } from '@mds-core/mds-types'
+import { VEHICLE_TYPE, UUID } from '@mds-core/mds-types'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { MetricsServiceProvider } from '../service/provider'
 import { MetricDomainModel, ReadMetricsOptions, ReadMetricsFilterOptions } from '../@types'
@@ -26,11 +26,11 @@ const TEST_METRIC_NAME = 'test.metric'
 const TEST_TIME_BIN_SIZE = minutes(5)
 const TEST_TIMESTAMP = Date.now() - days(1)
 const { start_time: TEST_TIME_BIN_START, end_time: TEST_TIME_BIN_END } = timeframe(TEST_TIME_BIN_SIZE, TEST_TIMESTAMP)
-const TEST_PROVIDER_IDS: Nullable<UUID>[] = [...Array.from({ length: 6 }, () => uuid()), null]
+const TEST_PROVIDER_IDS: UUID[] = Array.from({ length: 6 }, () => uuid())
 const [TEST_PROVIDER_ID1, TEST_PROVIDER_ID2, TEST_PROVIDER_ID3] = TEST_PROVIDER_IDS
-const TEST_GEOGRAPHY_IDS: Nullable<UUID>[] = [...Array.from({ length: 10 }, () => uuid()), null]
+const TEST_GEOGRAPHY_IDS: UUID[] = Array.from({ length: 10 }, () => uuid())
 const [TEST_GEOGRAPHY_ID1, TEST_GEOGRAPHY_ID2, TEST_GEOGRAPHY_ID3] = TEST_GEOGRAPHY_IDS
-const TEST_VEHICLE_TYPES: Nullable<VEHICLE_TYPE>[] = ['scooter', 'bicycle', 'moped', null]
+const TEST_VEHICLE_TYPES: VEHICLE_TYPE[] = ['scooter', 'bicycle', 'moped']
 const [TEST_VEHICLE_TYPE1, TEST_VEHICLE_TYPE2, TEST_VEHICLE_TYPE3] = TEST_VEHICLE_TYPES
 
 function* GenerateValues(maxLength: number, maxValue: number): Generator<number> {
@@ -65,9 +65,9 @@ function* GenerateMetrics(): Generator<MetricDomainModel> {
     { length: 12 },
     (_, index) => TEST_TIME_BIN_START + TEST_TIME_BIN_SIZE * index
   )) {
-    for (const provider_id of TEST_PROVIDER_IDS) {
-      for (const geography_id of TEST_GEOGRAPHY_IDS) {
-        for (const vehicle_type of TEST_VEHICLE_TYPES) {
+    for (const provider_id of [...TEST_PROVIDER_IDS, null]) {
+      for (const geography_id of [...TEST_GEOGRAPHY_IDS, null]) {
+        for (const vehicle_type of [...TEST_VEHICLE_TYPES, null]) {
           yield {
             name: TEST_METRIC_NAME,
             time_bin_size: TEST_TIME_BIN_SIZE,
@@ -91,7 +91,13 @@ const testQuery = (query: () => ReadMetricsOptions & { expected: MetricDomainMod
   return it(`Query Metrics Filters: [${
     filters
       ? `${Object.keys(filters)
-          .map(key => (Array.isArray(filters[key as keyof ReadMetricsFilterOptions]) ? `${key}[]` : key))
+          .map(key => {
+            const filter = filters[key as keyof ReadMetricsFilterOptions]
+            if (Array.isArray(filter)) {
+              return `${key}[]`
+            }
+            return filter === null ? `NULL ${key}` : key
+          })
           .join(', ')}`
       : ''
   }] (Expect ${expected.length} ${pluralize(expected.length, 'Match', 'Matches')})`, async () =>
@@ -195,6 +201,25 @@ describe('Metrics Service', () => {
         [TEST_GEOGRAPHY_ID2, TEST_GEOGRAPHY_ID3].includes(metric.geography_id) &&
         metric.vehicle_type &&
         [TEST_VEHICLE_TYPE2, TEST_VEHICLE_TYPE3].includes(metric.vehicle_type)
+    )
+  }))
+
+  testQuery(() => ({
+    name: TEST_METRIC_NAME,
+    time_bin_size: TEST_TIME_BIN_SIZE,
+    time_bin_start: TEST_TIMESTAMP,
+    time_bin_end: TEST_TIMESTAMP + days(1),
+    provider_id: null,
+    geography_id: null,
+    vehicle_type: null,
+    expected: TEST_METRICS.filter(
+      metric =>
+        metric.time_bin_size === TEST_TIME_BIN_SIZE &&
+        metric.time_bin_start >= TEST_TIME_BIN_START &&
+        metric.time_bin_start <= TEST_TIME_BIN_START + days(1) &&
+        metric.provider_id === null &&
+        metric.geography_id === null &&
+        metric.vehicle_type === null
     )
   }))
 

--- a/packages/mds-repository/naming-strategies/mds-naming-strategy.ts
+++ b/packages/mds-repository/naming-strategies/mds-naming-strategy.ts
@@ -26,4 +26,8 @@ export class MdsNamingStrategy extends DefaultNamingStrategy implements NamingSt
   indexName(tableOrName: Table | string, columnNames: string[], where?: string): string {
     return ['idx', ...columnNames, tableName(tableOrName)].join('_')
   }
+
+  uniqueConstraintName(tableOrName: Table | string, columnNames: string[]): string {
+    return ['uc', ...columnNames, tableName(tableOrName)].join('_')
+  }
 }

--- a/packages/mds-repository/tests/naming-strategies.spec.ts
+++ b/packages/mds-repository/tests/naming-strategies.spec.ts
@@ -29,4 +29,9 @@ describe('Test Naming Strategy', () => {
     test.value(strategy.indexName('table', ['column'])).is('idx_column_table')
     done()
   })
+
+  it('Unique Constraint Naming Strategy', done => {
+    test.value(strategy.uniqueConstraintName('table', ['column'])).is('uc_column_table')
+    done()
+  })
 })

--- a/packages/mds-repository/utils.ts
+++ b/packages/mds-repository/utils.ts
@@ -14,20 +14,20 @@
     limitations under the License.
  */
 
-import { SingleOrArray } from '@mds-core/mds-types'
-import { In } from 'typeorm'
+import { SingleOrArray, Nullable } from '@mds-core/mds-types'
+import { In, IsNull } from 'typeorm'
 
 export const entityPropertyFilter = <T extends object, TProperty extends keyof T>(
   property: TProperty,
-  value: SingleOrArray<T[TProperty]> | undefined
+  value?: Nullable<SingleOrArray<T[TProperty]>>
 ) => {
-  if (value) {
+  if (value !== undefined) {
     if (Array.isArray(value)) {
       if (value.length) {
         return value.length === 1 ? { [property]: value[0] } : { [property]: In(value) }
       }
     } else {
-      return { [property]: value }
+      return { [property]: value ?? IsNull() }
     }
   }
   return {}


### PR DESCRIPTION
Add support for storing and querying null dimensions/aggregates. Not all dimensions will be applicable to all metrics and not all aggregates will be calculated for all metrics. This requires creating a new unique index as Postgres does not support null values columns used in primary keys.