### PR TITLE
Implement an abstract repository class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,14 +19,15 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
-    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-parameter-properties": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "ignoreRestSiblings": true, "args": "none" }
     ],
+    "@typescript-eslint/no-useless-constructor": "error",
     "array-callback-return": "off",
     "class-methods-use-this": "off",
     "consistent-return": "off",
@@ -40,22 +41,23 @@
     "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-plusplus": "off",
     "no-restricted-syntax": "off",
+    "no-useless-constructor": "off",
     "no-var": "error",
     "prettier/prettier": "warn",
-    "radix": "off",
     "promise/always-return": "error",
-    "promise/no-return-wrap": "error",
-    "promise/param-names": "error",
+    "promise/avoid-new": "error",
     "promise/catch-or-return": "error",
+    "promise/no-callback-in-promise": "error",
     "promise/no-native": "off",
     "promise/no-nesting": "error",
-    "promise/no-promise-in-callback": "error",
-    "promise/no-callback-in-promise": "error",
-    "promise/avoid-new": "error",
     "promise/no-new-statics": "error",
+    "promise/no-promise-in-callback": "error",
     "promise/no-return-in-finally": "error",
-    "promise/valid-params": "error",
+    "promise/no-return-wrap": "error",
+    "promise/param-names": "error",
+    "promise/prefer-await-to-callbacks": "error",
     "promise/prefer-await-to-then": "error",
-    "promise/prefer-await-to-callbacks": "error"
+    "promise/valid-params": "error",
+    "radix": "off"
   }
 }

--- a/packages/mds-jurisdiction-service/@types/index.ts
+++ b/packages/mds-jurisdiction-service/@types/index.ts
@@ -25,6 +25,8 @@ export interface JurisdictionDomainModel {
   timestamp: Timestamp
 }
 
+export type JurisdictionIdType = JurisdictionDomainModel['jurisdiction_id']
+
 export type CreateJurisdictionDomainModel = Optional<JurisdictionDomainModel, 'jurisdiction_id' | 'timestamp'>
 
 export type UpdateJurisdictionDomainModel = Partial<JurisdictionDomainModel>
@@ -39,15 +41,15 @@ export interface JurisdictionServiceInterface {
     jurisdictions: CreateJurisdictionDomainModel[]
   ) => Promise<ServiceResponse<JurisdictionDomainModel[]>>
   updateJurisdiction: (
-    jurisdiction_id: UUID,
+    jurisdiction_id: JurisdictionIdType,
     update: UpdateJurisdictionDomainModel
   ) => Promise<ServiceResponse<JurisdictionDomainModel>>
   deleteJurisdiction: (
-    jurisdiction_id: UUID
+    jurisdiction_id: JurisdictionIdType
   ) => Promise<ServiceResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>>
   getJurisdictions: (options?: GetJurisdictionsOptions) => Promise<ServiceResponse<JurisdictionDomainModel[]>>
   getJurisdiction: (
-    jurisdiction_id: UUID,
+    jurisdiction_id: JurisdictionIdType,
     options?: GetJurisdictionsOptions
   ) => Promise<ServiceResponse<JurisdictionDomainModel>>
 }

--- a/packages/mds-jurisdiction-service/service/handlers/delete-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/delete-jurisdiction-handler.ts
@@ -14,15 +14,14 @@
     limitations under the License.
  */
 
-import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
 import { RepositoryError } from '@mds-core/mds-repository'
 import { JurisdictionRepository } from '../repository'
-import { JurisdictionDomainModel } from '../../@types'
+import { JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 
 export const DeleteJurisdictionHandler = async (
-  jurisdiction_id: UUID
+  jurisdiction_id: JurisdictionIdType
 ): Promise<ServiceResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>> => {
   try {
     const deleted = await JurisdictionRepository.deleteJurisdiction(jurisdiction_id)

--- a/packages/mds-jurisdiction-service/service/handlers/get-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/get-jurisdiction-handler.ts
@@ -14,15 +14,14 @@
     limitations under the License.
  */
 
-import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
 import { RepositoryError } from '@mds-core/mds-repository'
-import { GetJurisdictionsOptions, JurisdictionDomainModel } from '../../@types'
+import { GetJurisdictionsOptions, JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 
 export const GetJurisdictionHandler = async (
-  jurisdiction_id: UUID,
+  jurisdiction_id: JurisdictionIdType,
   options?: GetJurisdictionsOptions
 ): Promise<ServiceResponse<JurisdictionDomainModel>> => {
   try {

--- a/packages/mds-jurisdiction-service/service/handlers/update-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/update-jurisdiction-handler.ts
@@ -14,15 +14,14 @@
     limitations under the License.
  */
 
-import { UUID } from '@mds-core/mds-types'
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
 import { RepositoryError } from '@mds-core/mds-repository'
-import { UpdateJurisdictionDomainModel, JurisdictionDomainModel } from '../../@types'
+import { UpdateJurisdictionDomainModel, JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 
 export const UpdateJurisdictionHandler = async (
-  jurisdiction_id: UUID,
+  jurisdiction_id: JurisdictionIdType,
   jurisdiction: UpdateJurisdictionDomainModel
 ): Promise<ServiceResponse<JurisdictionDomainModel>> => {
   try {

--- a/packages/mds-jurisdiction-service/service/repository/entities/jurisdiction-entity.ts
+++ b/packages/mds-jurisdiction-service/service/repository/entities/jurisdiction-entity.ts
@@ -15,29 +15,30 @@
  */
 
 import { Entity, Column, Index } from 'typeorm'
-import { UUID, Timestamp, Nullable } from '@mds-core/mds-types'
+import { Nullable } from '@mds-core/mds-types'
 import { RecordedEntity, IdentityEntity, IdentityEntityModel, RecordedEntityModel } from '@mds-core/mds-repository'
+import { JurisdictionDomainModel } from '../../../@types'
 
 export interface JurisdictionVersionedProperties {
-  timestamp: Timestamp
-  agency_name: string
-  geography_id: Nullable<UUID>
+  timestamp: JurisdictionDomainModel['timestamp']
+  agency_name: JurisdictionDomainModel['agency_name']
+  geography_id: Nullable<JurisdictionDomainModel['geography_id']>
 }
 
 export interface JurisdictionEntityModel extends IdentityEntityModel, RecordedEntityModel {
-  jurisdiction_id: UUID
-  agency_key: string
+  jurisdiction_id: JurisdictionDomainModel['jurisdiction_id']
+  agency_key: JurisdictionDomainModel['agency_key']
   versions: JurisdictionVersionedProperties[]
 }
 
 @Entity('jurisdictions')
 export class JurisdictionEntity extends IdentityEntity(RecordedEntity(class {})) implements JurisdictionEntityModel {
   @Column('uuid', { primary: true })
-  jurisdiction_id: UUID
+  jurisdiction_id: JurisdictionEntityModel['jurisdiction_id']
 
   @Column('varchar', { length: 63 })
   @Index({ unique: true })
-  agency_key: string
+  agency_key: JurisdictionEntityModel['agency_key']
 
   @Column('json')
   versions: JurisdictionVersionedProperties[]

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -14,12 +14,15 @@
     limitations under the License.
  */
 
-import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
-import { UUID } from '@mds-core/mds-types'
+import {
+  JurisdictionServiceClient,
+  JurisdictionDomainModel,
+  JurisdictionIdType
+} from '@mds-core/mds-jurisdiction-service'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
-type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }>
+type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }>
 
 type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
 

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -14,8 +14,11 @@
     limitations under the License.
  */
 
-import { UUID } from '@mds-core/mds-types'
-import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
+import {
+  JurisdictionServiceClient,
+  JurisdictionDomainModel,
+  JurisdictionIdType
+} from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError } from '@mds-core/mds-utils'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { parseRequest } from '@mds-core/mds-api-helpers'
@@ -23,7 +26,7 @@ import { ApiQuery } from '@mds-core/mds-api-server'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../types'
 import { HasJurisdictionClaim } from './utils'
 
-type GetJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: UUID }> & ApiQuery<'effective'>
+type GetJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }> & ApiQuery<'effective'>
 
 type GetJurisdictionResponse = JurisdictionApiResponse<{
   jurisdiction: JurisdictionDomainModel

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -17,13 +17,13 @@
 import {
   UpdateJurisdictionDomainModel,
   JurisdictionServiceClient,
-  JurisdictionDomainModel
+  JurisdictionDomainModel,
+  JurisdictionIdType
 } from '@mds-core/mds-jurisdiction-service'
-import { UUID } from '@mds-core/mds-types'
 import { HandleServiceResponse } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../types'
 
-interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_id: UUID }> {
+interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }> {
   body: UpdateJurisdictionDomainModel
 }
 

--- a/packages/mds-metrics-service/service/repository/entities/metric-entity.ts
+++ b/packages/mds-metrics-service/service/repository/entities/metric-entity.ts
@@ -15,7 +15,6 @@
  */
 
 import { Entity, Column, Index } from 'typeorm'
-import { UUID, Timestamp, Nullable, VEHICLE_TYPE } from '@mds-core/mds-types'
 import {
   BigintTransformer,
   IdentityEntity,
@@ -23,19 +22,20 @@ import {
   RecordedEntity,
   RecordedEntityModel
 } from '@mds-core/mds-repository'
+import { MetricDomainModel } from '../../../@types'
 
 export interface MetricEntityModel extends IdentityEntityModel, RecordedEntityModel {
-  name: string
-  time_bin_size: Timestamp
-  time_bin_start: Timestamp
-  provider_id: Nullable<UUID>
-  geography_id: Nullable<UUID>
-  vehicle_type: Nullable<VEHICLE_TYPE>
-  count: Nullable<number>
-  sum: Nullable<number>
-  min: Nullable<number>
-  max: Nullable<number>
-  avg: Nullable<number>
+  name: MetricDomainModel['name']
+  time_bin_size: MetricDomainModel['time_bin_size']
+  time_bin_start: MetricDomainModel['time_bin_start']
+  provider_id: MetricDomainModel['provider_id']
+  geography_id: MetricDomainModel['geography_id']
+  vehicle_type: MetricDomainModel['vehicle_type']
+  count: MetricDomainModel['count']
+  sum: MetricDomainModel['sum']
+  min: MetricDomainModel['min']
+  max: MetricDomainModel['max']
+  avg: MetricDomainModel['avg']
 }
 
 @Entity('metrics')
@@ -47,35 +47,35 @@ export interface MetricEntityModel extends IdentityEntityModel, RecordedEntityMo
 export class MetricEntity extends IdentityEntity(RecordedEntity(class {}), { primary: true })
   implements MetricEntityModel {
   @Column('varchar', { primary: true, length: 255 })
-  name: string
+  name: MetricEntityModel['name']
 
   @Column('bigint', { primary: true, transformer: BigintTransformer })
-  time_bin_size: Timestamp
+  time_bin_size: MetricEntityModel['time_bin_size']
 
   @Column('bigint', { primary: true, transformer: BigintTransformer })
-  time_bin_start: Timestamp
+  time_bin_start: MetricEntityModel['time_bin_start']
 
   @Column('uuid', { nullable: true })
-  provider_id: Nullable<UUID>
+  provider_id: MetricEntityModel['provider_id']
 
   @Column('uuid', { nullable: true })
-  geography_id: Nullable<UUID>
+  geography_id: MetricEntityModel['geography_id']
 
   @Column('varchar', { length: 31, nullable: true })
-  vehicle_type: Nullable<VEHICLE_TYPE>
+  vehicle_type: MetricEntityModel['vehicle_type']
 
   @Column('bigint', { transformer: BigintTransformer, nullable: true })
-  count: Nullable<number>
+  count: MetricEntityModel['count']
 
   @Column('double precision', { nullable: true })
-  sum: Nullable<number>
+  sum: MetricEntityModel['sum']
 
   @Column('double precision', { nullable: true })
-  min: Nullable<number>
+  min: MetricEntityModel['min']
 
   @Column('double precision', { nullable: true })
-  max: Nullable<number>
+  max: MetricEntityModel['max']
 
   @Column('double precision', { nullable: true })
-  avg: Nullable<number>
+  avg: MetricEntityModel['avg']
 }

--- a/packages/mds-metrics-service/service/repository/index.ts
+++ b/packages/mds-metrics-service/service/repository/index.ts
@@ -14,13 +14,7 @@
     limitations under the License.
  */
 
-import {
-  CreateRepository,
-  CreateRepositoryMethod,
-  InsertReturning,
-  entityPropertyFilter,
-  RepositoryError
-} from '@mds-core/mds-repository'
+import { InsertReturning, entityPropertyFilter, RepositoryError, ReadWriteRepository } from '@mds-core/mds-repository'
 import { Between } from 'typeorm'
 import { timeframe } from '@mds-core/mds-utils'
 
@@ -29,59 +23,54 @@ import { ReadMetricsOptions, MetricDomainModel } from '../../@types'
 import * as migrations from './migrations'
 import { MetricEntityToDomain, MetricDomainToEntityCreate } from './mappers'
 
-const RepositoryReadMetrics = CreateRepositoryMethod(connect => async (options: ReadMetricsOptions): Promise<
-  MetricDomainModel[]
-> => {
-  try {
-    const { name, time_bin_size, time_bin_start, time_bin_end, provider_id, geography_id, vehicle_type } = options
-    const connection = await connect('ro')
-    const entities = await connection.getRepository(MetricEntity).find({
-      where: {
-        name,
-        time_bin_size,
-        time_bin_start: Between(
-          timeframe(time_bin_size, time_bin_start).start_time,
-          timeframe(time_bin_size, time_bin_end ?? time_bin_start).end_time
-        ),
-        ...entityPropertyFilter<MetricEntity, 'provider_id'>('provider_id', provider_id),
-        ...entityPropertyFilter<MetricEntity, 'geography_id'>('geography_id', geography_id),
-        ...entityPropertyFilter<MetricEntity, 'vehicle_type'>('vehicle_type', vehicle_type)
-      }
-    })
-    return entities.map(MetricEntityToDomain.mapper())
-  } catch (error) {
-    throw RepositoryError(error)
-  }
-})
-
-const RepositoryWriteMetrics = CreateRepositoryMethod(connect => async (metrics: MetricDomainModel[]): Promise<
-  MetricDomainModel[]
-> => {
-  try {
-    const connection = await connect('rw')
-    const { raw: entities }: InsertReturning<MetricEntity> = await connection
-      .getRepository(MetricEntity)
-      .createQueryBuilder()
-      .insert()
-      .values(metrics.map(MetricDomainToEntityCreate.mapper()))
-      .returning('*')
-      .execute()
-    return entities
-  } catch (error) {
-    throw RepositoryError(error)
-  }
-})
-
-export const MetricsRepository = CreateRepository(
-  'metrics',
-  connect => {
-    return {
-      readMetrics: RepositoryReadMetrics(connect),
-      writeMetrics: RepositoryWriteMetrics(connect)
+class MetricsReadWriteRepository extends ReadWriteRepository {
+  public readMetrics = async (options: ReadMetricsOptions): Promise<MetricDomainModel[]> => {
+    const { connect } = this
+    try {
+      const { name, time_bin_size, time_bin_start, time_bin_end, provider_id, geography_id, vehicle_type } = options
+      const connection = await connect('ro')
+      const entities = await connection.getRepository(MetricEntity).find({
+        where: {
+          name,
+          time_bin_size,
+          time_bin_start: Between(
+            timeframe(time_bin_size, time_bin_start).start_time,
+            timeframe(time_bin_size, time_bin_end ?? time_bin_start).end_time
+          ),
+          ...entityPropertyFilter<MetricEntity, 'provider_id'>('provider_id', provider_id),
+          ...entityPropertyFilter<MetricEntity, 'geography_id'>('geography_id', geography_id),
+          ...entityPropertyFilter<MetricEntity, 'vehicle_type'>('vehicle_type', vehicle_type)
+        }
+      })
+      return entities.map(MetricEntityToDomain.mapper())
+    } catch (error) {
+      throw RepositoryError(error)
     }
-  },
-  {
-    entities: [MetricEntity],
-    migrations: Object.values(migrations)
   }
-)
+
+  public writeMetrics = async (metrics: MetricDomainModel[]): Promise<MetricDomainModel[]> => {
+    const { connect } = this
+    try {
+      const connection = await connect('rw')
+      const { raw: entities }: InsertReturning<MetricEntity> = await connection
+        .getRepository(MetricEntity)
+        .createQueryBuilder()
+        .insert()
+        .values(metrics.map(MetricDomainToEntityCreate.mapper()))
+        .returning('*')
+        .execute()
+      return entities
+    } catch (error) {
+      throw RepositoryError(error)
+    }
+  }
+
+  constructor() {
+    super('metrics', {
+      entities: [MetricEntity],
+      migrations: Object.values(migrations)
+    })
+  }
+}
+
+export const MetricsRepository = new MetricsReadWriteRepository()

--- a/packages/mds-repository/repository.ts
+++ b/packages/mds-repository/repository.ts
@@ -15,14 +15,18 @@
  */
 
 import { Connection } from 'typeorm'
-import { ConnectionManager, ConnectionManagerOptions, ConnectionMode } from './connection'
+import { ConnectionManager, ConnectionManagerOptions, ConnectionMode, ConnectionManagerCliOptions } from './connection'
 import { CreateRepositoryMigration } from './migration'
 
 type RepositoryMethod<TMethod> = (connect: (mode: ConnectionMode) => Promise<Connection>) => TMethod
 
 export const CreateRepositoryMethod: <TMethod>(
   method: RepositoryMethod<TMethod>
-) => RepositoryMethod<TMethod> = method => method
+) => RepositoryMethod<TMethod> = method => {
+  // eslint-disable-next-line no-console
+  console.warn('CreateRepositoryMethod is deprecated. Extend ReadWriteRepository instead.')
+  return method
+}
 
 export type RepositoryOptions = Pick<ConnectionManagerOptions, 'entities' | 'migrations'>
 
@@ -31,6 +35,8 @@ export const CreateRepository = <TRepositoryMethods>(
   methods: (connect: (mode: ConnectionMode) => Promise<Connection>) => TRepositoryMethods,
   { entities = [], migrations = [] }: RepositoryOptions = {}
 ) => {
+  // eslint-disable-next-line no-console
+  console.warn('CreateRepository is deprecated. Extend ReadWriteRepository instead.')
   const migrationsTableName = `${name}-migrations`
   const { connect, ...manager } = new ConnectionManager(name, {
     migrationsTableName,
@@ -40,5 +46,39 @@ export const CreateRepository = <TRepositoryMethods>(
   return {
     ...manager,
     ...methods(connect)
+  }
+}
+
+export abstract class ReadWriteRepository {
+  private readonly manager: ConnectionManager
+
+  public initialize = async (): Promise<void> => {
+    const { initialize } = this.manager
+    await initialize()
+  }
+
+  protected connect = async (mode: ConnectionMode): Promise<Connection> => {
+    const { connect } = this.manager
+    const connection = await connect(mode)
+    return connection
+  }
+
+  public shutdown = async (): Promise<void> => {
+    const { shutdown } = this.manager
+    await shutdown()
+  }
+
+  public cli = (options: ConnectionManagerCliOptions) => {
+    const { cli } = this.manager
+    return cli(options)
+  }
+
+  constructor(public readonly name: string, { entities = [], migrations = [] }: RepositoryOptions = {}) {
+    const migrationsTableName = `${name}-migrations`
+    this.manager = new ConnectionManager(name, {
+      migrationsTableName,
+      entities,
+      migrations: [CreateRepositoryMigration(migrationsTableName), ...migrations]
+    })
   }
 }

--- a/packages/mds-repository/repository.ts
+++ b/packages/mds-repository/repository.ts
@@ -32,7 +32,7 @@ export const CreateRepository = <TRepositoryMethods>(
   { entities = [], migrations = [] }: RepositoryOptions = {}
 ) => {
   const migrationsTableName = `${name}-migrations`
-  const { connect, ...manager } = ConnectionManager(name, {
+  const { connect, ...manager } = new ConnectionManager(name, {
     migrationsTableName,
     entities,
     migrations: [CreateRepositoryMigration(migrationsTableName), ...migrations]

--- a/packages/mds-repository/tests/connection.spec.ts
+++ b/packages/mds-repository/tests/connection.spec.ts
@@ -19,7 +19,7 @@ import { ConnectionManager } from '../connection'
 
 const TEST_REPOSITORY_NAME = 'test-repository'
 
-const manager = ConnectionManager(TEST_REPOSITORY_NAME)
+const manager = new ConnectionManager(TEST_REPOSITORY_NAME)
 
 describe('Test Connections', () => {
   before(async () => {


### PR DESCRIPTION
This greatly simplifies repository definition. No longer necessary to call `CreateRepositoryMethod/CreateRepository` or to pass around a `connect` function. 