### PR TITLE
Fix a potential issue with handling process.env

### DIFF
--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -10,17 +10,17 @@ export interface AuthorizerClaims {
   jurisdictions: string | null
 }
 
-const {
-  TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id',
-  TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email',
-  TOKEN_JURISDICTIONS_CLAIM = 'https://ladot.io/jurisdictions'
-} = process.env
-
 export type Authorizer = (authorization: string) => AuthorizerClaims | null
 export type ApiAuthorizer = (req: express.Request) => AuthorizerClaims | null
 
 const decoders: { [scheme: string]: (token: string) => AuthorizerClaims } = {
   bearer: (token: string) => {
+    const {
+      TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id',
+      TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email',
+      TOKEN_JURISDICTIONS_CLAIM = 'https://ladot.io/jurisdictions'
+    } = process.env
+
     const {
       sub: principalId,
       scope,

--- a/packages/mds-api-authorizer/package.json
+++ b/packages/mds-api-authorizer/package.json
@@ -22,7 +22,8 @@
     "jwt-decode": "2.2.0"
   },
   "devDependencies": {
-    "@mds-core/mds-test-data": "0.1.26"
+    "@mds-core/mds-test-data": "0.1.26",
+    "jsonwebtoken": "8.5.1"
   },
   "license": "Apache-2.0"
 }

--- a/packages/mds-api-authorizer/tests/index.spec.ts
+++ b/packages/mds-api-authorizer/tests/index.spec.ts
@@ -1,49 +1,92 @@
 import test from 'unit.js'
 import { MOCHA_PROVIDER_ID } from '@mds-core/mds-providers'
 import express from 'express'
+import jwt from 'jsonwebtoken'
+import { uuid } from '@mds-core/mds-utils'
 import { AuthorizationHeaderApiAuthorizer, WebSocketAuthorizer } from '../index'
 
+const TOKEN_PROVIDER_ID_CLAIM = 'https://some-domain.ai/provider_id'
 const PROVIDER_SCOPES = 'admin:all'
-const ADMIN_AUTH = `basic ${Buffer.from(`${MOCHA_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
+const Basic = `Basic ${Buffer.from(`${MOCHA_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
+const PROVIDER_SUBJECT = uuid()
+const Bearer = `Bearer ${jwt.sign(
+  {
+    sub: PROVIDER_SUBJECT,
+    [TOKEN_PROVIDER_ID_CLAIM]: MOCHA_PROVIDER_ID,
+    scope: PROVIDER_SCOPES
+  },
+  'secret'
+)}`
+
+let env: NodeJS.ProcessEnv
+
+process.env.TOKEN_PROVIDER_ID_CLAIM = TOKEN_PROVIDER_ID_CLAIM
 
 describe('Test API Authorizer', () => {
-  it('No Authorizaton', done => {
-    const authorizer = AuthorizationHeaderApiAuthorizer({} as express.Request)
-    test.value(authorizer).is(null)
-    done()
+  before(() => {
+    env = process.env
+    process.env = { TOKEN_PROVIDER_ID_CLAIM }
   })
 
-  it('Invalid Authorizaton Scheme', done => {
-    const authorizer = AuthorizationHeaderApiAuthorizer({ headers: { authorization: 'invalid' } } as express.Request)
-    test.value(authorizer).is(null)
-    done()
+  describe('Authorizaton Header Authorizer', () => {
+    it('No Authorizaton', async () => {
+      test.value(AuthorizationHeaderApiAuthorizer({} as express.Request)).is(null)
+    })
+
+    it('Invalid Authorizaton Scheme', async () => {
+      test
+        .value(
+          AuthorizationHeaderApiAuthorizer({
+            headers: { authorization: 'invalid' }
+          } as express.Request)
+        )
+        .is(null)
+    })
+
+    it('Basic Authorizaton', async () => {
+      test
+        .object(
+          AuthorizationHeaderApiAuthorizer({
+            headers: { authorization: Basic }
+          } as express.Request)
+        )
+        .hasProperty('principalId', MOCHA_PROVIDER_ID)
+        .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('scope', PROVIDER_SCOPES)
+    })
+
+    it('Bearer Authorizaton', async () => {
+      test
+        .object(
+          AuthorizationHeaderApiAuthorizer({
+            headers: { authorization: Bearer }
+          } as express.Request)
+        )
+        .hasProperty('principalId', PROVIDER_SUBJECT)
+        .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('scope', PROVIDER_SCOPES)
+    })
   })
 
-  it('Basic Authorizaton', done => {
-    const apiAuthorizer = AuthorizationHeaderApiAuthorizer({
-      headers: { authorization: ADMIN_AUTH }
-    } as express.Request)
-    test.object(apiAuthorizer).hasProperty('principalId', MOCHA_PROVIDER_ID).hasProperty('scope', PROVIDER_SCOPES)
+  describe('WebSocket Authorizer', () => {
+    it('Basic Authorization', async () => {
+      test
+        .object(WebSocketAuthorizer(Basic))
+        .hasProperty('principalId', MOCHA_PROVIDER_ID)
+        .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('scope', PROVIDER_SCOPES)
+    })
 
-    const webSocketAuthorizer = WebSocketAuthorizer(ADMIN_AUTH)
-    test.object(webSocketAuthorizer).hasProperty('principalId', MOCHA_PROVIDER_ID).hasProperty('scope', PROVIDER_SCOPES)
-    done()
+    it('Bearer Authorization', async () => {
+      test
+        .object(WebSocketAuthorizer(Bearer))
+        .hasProperty('principalId', PROVIDER_SUBJECT)
+        .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('scope', PROVIDER_SCOPES)
+    })
   })
 
-  it('Bearer Authorizaton', done => {
-    const apiAuthorizer = AuthorizationHeaderApiAuthorizer({
-      headers: { authorization: ADMIN_AUTH }
-    } as express.Request)
-    test
-      .object(apiAuthorizer)
-      .hasProperty('principalId', 'c8051767-4b14-4794-abc1-85aad48baff1')
-      .hasProperty('scope', PROVIDER_SCOPES)
-
-    const webSocketAuthorizer = WebSocketAuthorizer(ADMIN_AUTH)
-    test
-      .object(webSocketAuthorizer)
-      .hasProperty('principalId', 'c8051767-4b14-4794-abc1-85aad48baff1')
-      .hasProperty('scope', PROVIDER_SCOPES)
-    done()
+  after(() => {
+    process.env = env
   })
 })

--- a/packages/mds-api-authorizer/tests/index.spec.ts
+++ b/packages/mds-api-authorizer/tests/index.spec.ts
@@ -5,13 +5,17 @@ import jwt from 'jsonwebtoken'
 import { uuid } from '@mds-core/mds-utils'
 import { AuthorizationHeaderApiAuthorizer, WebSocketAuthorizer } from '../index'
 
-const TOKEN_PROVIDER_ID_CLAIM = 'https://some-domain.ai/provider_id'
+const TOKEN_PROVIDER_ID_CLAIM = 'https://test.ai/provider_id'
 const PROVIDER_SCOPES = 'admin:all'
-const Basic = `Basic ${Buffer.from(`${MOCHA_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
 const PROVIDER_SUBJECT = uuid()
+const PROVIDER_EMAIL = 'user@test.ai'
+
+const Basic = `Basic ${Buffer.from(`${MOCHA_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
+
 const Bearer = `Bearer ${jwt.sign(
   {
     sub: PROVIDER_SUBJECT,
+    'https://ladot.io/user_email': PROVIDER_EMAIL,
     [TOKEN_PROVIDER_ID_CLAIM]: MOCHA_PROVIDER_ID,
     scope: PROVIDER_SCOPES
   },
@@ -64,6 +68,7 @@ describe('Test API Authorizer', () => {
         )
         .hasProperty('principalId', PROVIDER_SUBJECT)
         .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('user_email', PROVIDER_EMAIL)
         .hasProperty('scope', PROVIDER_SCOPES)
     })
   })
@@ -82,6 +87,7 @@ describe('Test API Authorizer', () => {
         .object(WebSocketAuthorizer(Bearer))
         .hasProperty('principalId', PROVIDER_SUBJECT)
         .hasProperty('provider_id', MOCHA_PROVIDER_ID)
+        .hasProperty('user_email', PROVIDER_EMAIL)
         .hasProperty('scope', PROVIDER_SCOPES)
     })
   })


### PR DESCRIPTION
I think the issue only exists when running tests, but the solution feels more correct anyway. Added tests that override the environment variables.