### PR TITLE
Make async getServiceResult helper

### DIFF
--- a/packages/mds-service-helpers/client/index.ts
+++ b/packages/mds-service-helpers/client/index.ts
@@ -32,7 +32,8 @@ export const handleServiceResponse = <R>(
   return response
 }
 
-export const getServiceResult = <R>(response: ServiceResponse<R>): R => {
+export const getServiceResult = async <R>(request: Promise<ServiceResponse<R>>): Promise<R> => {
+  const response = await request
   if (response.error) {
     throw response.error
   }

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -68,7 +68,7 @@ describe('Tests Service Helpers', () => {
 
   it('Get ServiceResult', async () => {
     try {
-      const result = getServiceResult(ServiceResult('success'))
+      const result = await getServiceResult(Promise.resolve(ServiceResult('success')))
       test.value(result).is('success')
     } catch (error) {
       test.value(error).is(null)
@@ -77,7 +77,9 @@ describe('Tests Service Helpers', () => {
 
   it('Catch ServiceError', async () => {
     try {
-      const result = getServiceResult(ServiceError({ type: 'ValidationError', message: 'Validation Error' }))
+      const result = await getServiceResult(
+        Promise.resolve(ServiceError({ type: 'ValidationError', message: 'Validation Error' }))
+      )
       test.value(result).is(null)
     } catch (error) {
       test.value(isServiceError(error)).is(true)


### PR DESCRIPTION
Based on feedback, there is now an alternative to `handleServiceResponse` for getting the result of a service call and starting a separate exception chain in the consumer in the event of a service error.

Using `handleServiceResponse`:
```ts
export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
  handleServiceResponse(
    await JurisdictionServiceClient.getJurisdictions(),
    error => {
      return res.status(500).send({ error })
    },
    jurisdictions => {
      return res.status(200).send({ 
        version: res.locals.version, 
        jurisdictions: jurisdictions.filter(HasJurisdictionClaim(res)) 
      })
    }
  )
}
```

Using `getServiceResult`:
```ts
export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
  try {
    const jurisdictions = await getServiceResult(JurisdictionServiceClient.getJurisdictions())
    return res.status(200).send({ 
      version: res.locals.version, 
      jurisdictions: jurisdictions.filter(HasJurisdictionClaim(res)) 
    })
  } catch (error) {
    return res.status(500).send({ error })
  }
}
```
There is also a new `isServiceError` type guard that can be within a `catch` if desired:
```ts
catch (error) {
  // error is an any
  if (isServiceError(error)) {
    // error is a ServiceErrorDescriptor
  }
}
```