### PR TITLE
Roll back typescript/tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ts-mocha": "7.0.0",
     "ts-node": "8.10.1",
     "tsconfig-paths": "3.9.0",
-    "typescript": "3.9.2",
+    "typescript": "3.8.3",
     "unit.js": "2.1.1",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10150,10 +10150,10 @@ typeorm@0.2.24:
     yargonaut "^1.1.2"
     yargs "^13.2.1"
 
-typescript@3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
-  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.9.3"


### PR DESCRIPTION
Unfortunately, we need to roll back to TypeScript 3.8. The new TypeScript (and the corresponding new tslib) change the way that module exports are emitted. While the new modules work just fine when published and installed in another repo, the tslib changes break the ability for `Sinon` to mock the exported functions. Reverting until Sinon catches up or provides guidance. 