### PR TITLE
[mds-geography][mds-geography-author] Moving read-only geo points out of geo author, leaving metadata endpo…

### DIFF
--- a/packages/mds-geography-author/types.ts
+++ b/packages/mds-geography-author/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
-import { GeographySummary, GeographyMetadata, Geography } from '@mds-core/mds-types'
+import { GeographyMetadata, Geography } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION = typeof GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS[number]
@@ -35,14 +35,6 @@ export type GeographyAuthorApiResponse<TBody extends {}> = ApiVersionedResponse<
   ApiClaims<GeographyAuthorApiAccessTokenScopes>,
   TBody
 >
-
-export type GetGeographyResponse = GeographyAuthorApiResponse<
-  { geographies: Geography[] | GeographySummary[] } | { geography: Geography | GeographySummary }
->
-
-export type GetGeographiesResponse = GeographyAuthorApiResponse<{
-  geographies: Geography[] | GeographySummary[]
-}>
 
 export type GetGeographyMetadatumResponse = GeographyAuthorApiResponse<{ geography_metadata: GeographyMetadata }>
 

--- a/packages/mds-geography/types.ts
+++ b/packages/mds-geography/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
-import { Geography, GeographyMetadata, GeographySummary } from '@mds-core/mds-types'
+import { Geography, GeographySummary } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type GEOGRAPHY_API_SUPPORTED_VERSION = typeof GEOGRAPHY_API_SUPPORTED_VERSIONS[number]
@@ -41,7 +41,3 @@ export type GetGeographyResponse = GeographyApiResponse<
 export type GetGeographiesResponse = GeographyApiResponse<{
   geographies: Geography[] | GeographySummary[]
 }>
-
-export type GetGeographyMetadatumResponse = GeographyApiResponse<{ geography_metadata: GeographyMetadata }>
-
-export type GetGeographyMetadataResponse = GeographyApiResponse<{ geography_metadata: GeographyMetadata[] }>


### PR DESCRIPTION
…ints.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author

These are breaking changes, but it doesn't make much sense to duplicate code between the two services. The specs (still in PR) have both been updated to reflect the new distribution of endpoints between the two services.