### PR TITLE
Add ES2019 lib to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "*": ["@types/*", "*"]
     },
     "target": "ES2019",
-    "lib": ["ES2020.Promise"],
+    "lib": ["ES2020.Promise", "ES2019"],
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
With the recent addition of `ES2020.Promise` to the `lib` section of `tsconfig.json`, certain interfaces (such as Array) have appeared to fall back to their es5 definitions. Adding `ES2019` to `lib` seems to resolve this. 

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author