### PR TITLE
[mds-policy-author] [mds-geography-author] Reject payloads that specify a publish_date

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -161,6 +161,28 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Server: mds-geography-author",
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register",
+        "-r",
+        "tsconfig-paths/register",
+        "-r",
+        "dotenv/config"
+      ],
+      "args": ["server.ts"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector",
+      "cwd": "${workspaceFolder}/packages/mds-geography-author",
+      "env": {
+        "DOTENV_CONFIG_PATH": "${workspaceFolder}/.env",
+        "PATH_PREFIX": "/policy-author"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Tests: mds-agency",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
@@ -412,6 +434,28 @@
       "internalConsoleOptions": "neverOpen",
       "protocol": "inspector",
       "cwd": "${workspaceFolder}/packages/mds-policy-author",
+      "env": {
+        "DOTENV_CONFIG_PATH": "${workspaceFolder}/.env",
+        "PATH_PREFIX": "/policy-author"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tests: mds-geography-author",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--project",
+        "${workspaceFolder}/tsconfig.json",
+        "-r",
+        "ts-node/register",
+        "--timeout",
+        "0"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector",
+      "cwd": "${workspaceFolder}/packages/mds-geography-author",
       "env": {
         "DOTENV_CONFIG_PATH": "${workspaceFolder}/.env",
         "PATH_PREFIX": "/policy-author"

--- a/packages/mds-geography-author/tests/api.spec.ts
+++ b/packages/mds-geography-author/tests/api.spec.ts
@@ -482,5 +482,43 @@ describe('Tests app', () => {
           done(err)
         })
     })
+
+    it('verifies cannot PUT geography with a publish_date', done => {
+      const geography = {
+        name: 'foo',
+        geography_id: GEOGRAPHY_UUID,
+        publish_date: 1589817834000,
+        geography_json: LA_CITY_BOUNDARY
+      }
+      request
+        .put(`/geographies/${geography.geography_id}`)
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .send(geography)
+        .expect(400)
+        .end((err, result) => {
+          test.assert(result.body.error.name === `ValidationError`)
+          test.value(result).hasHeader('content-type', APP_JSON)
+          done(err)
+        })
+    })
+
+    it('verifies cannot POST geography with a publish_date', done => {
+      const geography = {
+        name: 'foo',
+        geography_id: GEOGRAPHY_UUID,
+        publish_date: 1589817834000,
+        geography_json: LA_CITY_BOUNDARY
+      }
+      request
+        .post(`/geographies`)
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .send(geography)
+        .expect(400)
+        .end((err, result) => {
+          test.assert(result.body.error.name === `ValidationError`)
+          test.value(result).hasHeader('content-type', APP_JSON)
+          done(err)
+        })
+    })
   })
 })

--- a/packages/mds-geography-author/tests/api.spec.ts
+++ b/packages/mds-geography-author/tests/api.spec.ts
@@ -497,6 +497,7 @@ describe('Tests app', () => {
         .expect(400)
         .end((err, result) => {
           test.assert(result.body.error.name === `ValidationError`)
+          test.assert(result.body.error.reason.includes('publish_date'))
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })
@@ -516,6 +517,7 @@ describe('Tests app', () => {
         .expect(400)
         .end((err, result) => {
           test.assert(result.body.error.name === `ValidationError`)
+          test.assert(result.body.error.reason.includes('publish_date'))
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -39,7 +39,8 @@ import {
   POLICY2_UUID,
   GEOGRAPHY_UUID,
   LA_CITY_BOUNDARY,
-  SCOPED_AUTH
+  SCOPED_AUTH,
+  PUBLISHED_POLICY
 } from '@mds-core/mds-test-data'
 import { api } from '../api'
 import { POLICY_AUTHOR_API_DEFAULT_VERSION } from '../types'
@@ -530,6 +531,32 @@ describe('Tests app', () => {
           test.value(result).hasHeader('content-type', APP_JSON)
           test.value(result.body.version).is(POLICY_AUTHOR_API_DEFAULT_VERSION)
           test.assert(isUUID(result.body.policy.policy_id))
+          done(err)
+        })
+    })
+
+    it('Cannot PUT a policy with publish_date set', done => {
+      request
+        .put(`/policies/${PUBLISHED_POLICY.policy_id}`)
+        .set('Authorization', POLICIES_WRITE_SCOPE)
+        .send(PUBLISHED_POLICY)
+        .expect(400)
+        .end((err, result) => {
+          test.assert(result.body.error.name === `ValidationError`)
+          test.value(result).hasHeader('content-type', APP_JSON)
+          done(err)
+        })
+    })
+
+    it('Cannot POST a policy with publish_date set', done => {
+      request
+        .post(`/policies`)
+        .set('Authorization', POLICIES_WRITE_SCOPE)
+        .send(PUBLISHED_POLICY)
+        .expect(400)
+        .end((err, result) => {
+          test.assert(result.body.error.name === `ValidationError`)
+          test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })
     })

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -543,6 +543,7 @@ describe('Tests app', () => {
         .expect(400)
         .end((err, result) => {
           test.assert(result.body.error.name === `ValidationError`)
+          test.assert(result.body.error.reason.includes('publish_date'))
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })
@@ -556,6 +557,7 @@ describe('Tests app', () => {
         .expect(400)
         .end((err, result) => {
           test.assert(result.body.error.name === `ValidationError`)
+          test.assert(result.body.error.reason.includes('publish_date'))
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -137,15 +137,12 @@ const featureCollectionSchema = Joi.object()
   })
   .unknown(true) // TODO
 
-export const geographySchema = Joi.object()
-  .keys({
-    geography_id: Joi.string().guid().required(),
-    geography_json: featureCollectionSchema,
-    read_only: Joi.boolean().allow(null),
-    previous_geography_ids: Joi.array().items(Joi.string().guid()).allow(null),
-    name: Joi.string().required()
-  })
-  .unknown(true)
+export const geographySchema = Joi.object().keys({
+  geography_id: Joi.string().guid().required(),
+  geography_json: featureCollectionSchema,
+  previous_geography_ids: Joi.array().items(Joi.string().guid()).allow(null),
+  name: Joi.string().required()
+})
 
 const geographiesSchema = Joi.array().items(geographySchema)
 
@@ -375,7 +372,7 @@ export function validateEvents(events: unknown): events is VehicleEvent[] {
 }
 
 export function policyValidationDetails(policy: Policy): Joi.ValidationErrorItem[] | null {
-  const { error } = Joi.validate(policy, policySchema)
+  const { error } = Joi.validate(policy, policySchema, { allowUnknown: false })
   if (error) {
     return error.details
   }
@@ -383,7 +380,7 @@ export function policyValidationDetails(policy: Policy): Joi.ValidationErrorItem
 }
 
 export function geographyValidationDetails(geography: Geography): Joi.ValidationErrorItem[] | null {
-  const { error } = Joi.validate(geography, geographySchema)
+  const { error } = Joi.validate(geography, geographySchema, { allowUnknown: false })
   if (error) {
     return error.details
   }


### PR DESCRIPTION
The POST and PUT endpoints for the Policy and Geography authoring APIs should reject any payloads where the client specifies a publish_date. This is something that should _only_ be set by the `.../publish` APIs. 

Also, added in launch configs for the geography-authoring API


## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [x] Policy Author