### PR TITLE
Add custom service error type support

### DIFF
--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /*
     Copyright 2019-2020 City of Los Angeles.
 
@@ -17,15 +16,24 @@
 
 import { AnyFunction } from '@mds-core/mds-types'
 
-export interface ServiceErrorDescriptor {
-  name: '__ServiceErrorDescriptor__'
-  type: 'ServiceException' | 'NotFoundError' | 'ConflictError' | 'ValidationError'
+export const ServiceErrorDescriptorTypes = [
+  'ServiceException',
+  'NotFoundError',
+  'ConflictError',
+  'ValidationError'
+] as const
+
+export type ServiceErrorDescriptorType = typeof ServiceErrorDescriptorTypes[number]
+
+export type ServiceErrorDescriptor<E extends string> = Readonly<{
+  isServiceError: true
+  type: E
   message: string
   details?: string
-}
+}>
 
-export interface ServiceErrorType {
-  error: ServiceErrorDescriptor
+export interface ServiceErrorType<E extends string = ServiceErrorDescriptorType> {
+  error: ServiceErrorDescriptor<E>
 }
 
 export interface ServiceResultType<R> {

--- a/packages/mds-service-helpers/client/index.ts
+++ b/packages/mds-service-helpers/client/index.ts
@@ -15,10 +15,16 @@
  */
 
 import { AnyFunction } from '@mds-core/mds-types'
-import { ServiceResponse, ServiceErrorDescriptor } from '../@types'
+import { ServiceResponse, ServiceErrorDescriptor, ServiceErrorDescriptorType } from '../@types'
 
-export const isServiceError = (error: unknown): error is ServiceErrorDescriptor =>
-  (error as ServiceErrorDescriptor).name === '__ServiceErrorDescriptor__'
+export const isServiceError = <E extends string = ServiceErrorDescriptorType>(
+  error: unknown,
+  ...types: E[]
+): error is ServiceErrorDescriptor<E> =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as ServiceErrorDescriptor<E>).isServiceError === true &&
+  (types.length === 0 || types.includes((error as ServiceErrorDescriptor<E>).type))
 
 // eslint-reason type inference requires any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/mds-service-helpers/server/index.ts
+++ b/packages/mds-service-helpers/server/index.ts
@@ -125,8 +125,10 @@ export const ServiceManager = {
 
 export const ServiceResult = <R>(result: R): ServiceResultType<R> => ({ error: null, result })
 
-export const ServiceError = (error: Omit<ServiceErrorDescriptor, 'name'>): ServiceErrorType => ({
-  error: { name: '__ServiceErrorDescriptor__', ...error }
+export const ServiceError = <E extends string>(
+  error: Omit<ServiceErrorDescriptor<E>, 'isServiceError'>
+): ServiceErrorType<E> => ({
+  error: { isServiceError: true, ...error }
 })
 
 export const ServiceException = (message: string, error?: unknown) => {

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -70,10 +70,15 @@ describe('Tests Service Helpers', () => {
     }
   })
 
+  it('Custom ServiceError type', async () => {
+    const { error } = ServiceError({ type: 'CustomError', message: 'Custom Error Message' })
+    test.value(isServiceError(error, 'CustomError')).is(true)
+  })
+
   it('ServiceError type guard', async () => {
     try {
       const error = Error('Error')
-      test.value(isServiceError(ServiceException('Error', error))).is(true)
+      test.value(isServiceError(ServiceException('Error', error).error)).is(true)
       throw error
     } catch (error) {
       test.value(isServiceError(error)).is(false)


### PR DESCRIPTION
Minor change to allow custom error types so that system isn't locked into the predefined set.
This is a totally backwards compatible change. The following code segments are equivalent:
```ts
if (isServiceError(error)) {
  if (error.type === 'NotFoundError') {
    return res.status(404).send({ error })
  }
}
```
```ts
if (isServiceError(error, 'NotFoundError')) {
    return res.status(404).send({ error })
  }
}
```
Services can now return a custom error:
```ts
return ServiceError({ type: 'CustomError', message: 'Custom error message' })
```
Which can be handled using the new signature:
```ts
if (isServiceError(error, 'CustomError')) {
    return res.status(400).send({ error })
  }
}
```