### PR TITLE
[mds-policy-author][mds-geography*] Fix/add data payload to policy author and geo services

### DIFF
--- a/packages/mds-geography-author/api.ts
+++ b/packages/mds-geography-author/api.ts
@@ -71,7 +71,7 @@ function api(app: express.Express): express.Express {
           params.get_published = true
         }
         const geography_metadata = await db.readBulkGeographyMetadata(params)
-        return res.status(200).send({ version: res.locals.version, geography_metadata })
+        return res.status(200).send({ version: res.locals.version, data: { geography_metadata } })
       } catch (error) {
         logger.error('failed to read geography metadata', error)
         /* This error is thrown if both get_published and get_unpublished are set.
@@ -101,7 +101,7 @@ function api(app: express.Express): express.Express {
         }
 
         const recorded_geography = await db.writeGeography(geography)
-        return res.status(201).send({ version: res.locals.version, geography: recorded_geography })
+        return res.status(201).send({ version: res.locals.version, data: { geography: recorded_geography } })
       } catch (err) {
         logger.error('POST /geographies failed', err.stack)
         if (err.code === '23505') {
@@ -130,7 +130,7 @@ function api(app: express.Express): express.Express {
           throw new ValidationError(JSON.stringify(details))
         }
         await db.editGeography(geography)
-        return res.status(201).send({ version: res.locals.version, geography })
+        return res.status(201).send({ version: res.locals.version, data: { geography } })
       } catch (error) {
         logger.error('failed to edit geography', error.stack)
         if (error instanceof NotFoundError) {
@@ -166,7 +166,7 @@ function api(app: express.Express): express.Express {
         await db.deleteGeography(geography_id)
         return res.status(200).send({
           version: res.locals.version,
-          result: `Successfully deleted geography and/or geography metadata of id ${geography_id}`
+          data: { geography_id }
         })
       } catch (err) {
         logger.error('failed to delete geography', err.stack)
@@ -220,7 +220,7 @@ function api(app: express.Express): express.Express {
         if (updateErr instanceof NotFoundError) {
           try {
             await db.writeGeographyMetadata(geography_metadata)
-            return res.status(201).send({ version: res.locals.version, geography_metadata })
+            return res.status(201).send({ version: res.locals.version, data: { geography_metadata } })
           } catch (writeErr) {
             logger.error('failed to write geography metadata', writeErr.stack)
             if (writeErr instanceof DependencyMissingError) {
@@ -243,7 +243,7 @@ function api(app: express.Express): express.Express {
       try {
         await db.publishGeography({ geography_id })
         const published_geo = await db.readSingleGeography(geography_id)
-        return res.status(200).send({ version: res.locals.version, geography: published_geo })
+        return res.status(200).send({ version: res.locals.version, data: { geography: published_geo } })
       } catch (updateErr) {
         if (updateErr instanceof NotFoundError) {
           return res.status(404).send({ error: `unable to find geography of ${geography_id}` })

--- a/packages/mds-geography-author/tests/api.spec.ts
+++ b/packages/mds-geography-author/tests/api.spec.ts
@@ -41,12 +41,9 @@ import {
 import { api } from '../api'
 import { GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION } from '../types'
 
-/* eslint-disable-next-line no-console */
-const log = console.log.bind(console)
-
 const request = supertest(ApiServer(api))
 
-const APP_JSON = 'application/vnd.mds.geography-author+json; charset=utf-8; version=0.1'
+const APP_JSON = 'application/vnd.mds.geography-author+json; charset=utf-8; version=0.4'
 const EMPTY_SCOPE = SCOPED_AUTH([], '')
 const EVENTS_READ_SCOPE = SCOPED_AUTH(['events:read'])
 const GEOGRAPHIES_WRITE_SCOPE = SCOPED_AUTH(['geographies:write'])
@@ -103,8 +100,6 @@ describe('Tests app', () => {
         .send(geography)
         .expect(201)
         .end((err, result) => {
-          const body = result.body
-          log('create one geo response:', body)
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })
@@ -231,8 +226,8 @@ describe('Tests app', () => {
         .expect(200)
       test.value(result).hasHeader('content-type', APP_JSON)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
-      test.assert(result.body.geography.geography_id === GEOGRAPHY2_UUID)
-      test.assert(result.body.geography.publish_date)
+      test.assert(result.body.data.geography.geography_id === GEOGRAPHY2_UUID)
+      test.assert(result.body.data.geography.publish_date)
     })
 
     it('cannot publish a geography (wrong auth)', async () => {
@@ -380,7 +375,7 @@ describe('Tests app', () => {
         .get(`/geographies/meta`)
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
-      test.assert(result.body.geography_metadata.length === 2)
+      test.assert(result.body.data.geography_metadata.length === 2)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -390,7 +385,7 @@ describe('Tests app', () => {
         .get(`/geographies/meta?get_published=true`)
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
-      test.assert(result.body.geography_metadata.length === 1)
+      test.assert(result.body.data.geography_metadata.length === 1)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -400,7 +395,7 @@ describe('Tests app', () => {
         .get(`/geographies/meta?get_unpublished=true`)
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
-      test.assert(result.body.geography_metadata.length === 1)
+      test.assert(result.body.data.geography_metadata.length === 1)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -410,7 +405,7 @@ describe('Tests app', () => {
         .get(`/geographies/meta`)
         .set('Authorization', GEOGRAPHIES_BOTH_READ_SCOPES)
         .expect(200)
-      test.assert(result.body.geography_metadata.length === 2)
+      test.assert(result.body.data.geography_metadata.length === 2)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -420,7 +415,7 @@ describe('Tests app', () => {
         .get(`/geographies/meta?get_published=true`)
         .set('Authorization', GEOGRAPHIES_BOTH_READ_SCOPES)
         .expect(200)
-      test.assert(result.body.geography_metadata.length === 1)
+      test.assert(result.body.data.geography_metadata.length === 1)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -431,7 +426,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
-      test.assert(result.body.geography_metadata.length === 1)
+      test.assert(result.body.data.geography_metadata.length === 1)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
 

--- a/packages/mds-geography-author/types.ts
+++ b/packages/mds-geography-author/types.ts
@@ -17,7 +17,7 @@
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
 import { GeographyMetadata, Geography } from '@mds-core/mds-types'
 
-export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
+export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION = typeof GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS[number]
 export const [GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION] = GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS
 
@@ -36,14 +36,20 @@ export type GeographyAuthorApiResponse<TBody extends {}> = ApiVersionedResponse<
   TBody
 >
 
-export type GetGeographyMetadatumResponse = GeographyAuthorApiResponse<{ geography_metadata: GeographyMetadata }>
+export type GetGeographyMetadatumResponse = GeographyAuthorApiResponse<{
+  data: { geography_metadata: GeographyMetadata }
+}>
 
-export type GetGeographyMetadataResponse = GeographyAuthorApiResponse<{ geography_metadata: GeographyMetadata[] }>
+export type GetGeographyMetadataResponse = GeographyAuthorApiResponse<{
+  data: { geography_metadata: GeographyMetadata[] }
+}>
 
-export type PostGeographyResponse = GeographyAuthorApiResponse<{ geography: Geography }>
+export type PostGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
 
-export type PutGeographyResponse = GeographyAuthorApiResponse<{ geography: Geography }>
-export type PublishGeographyResponse = GeographyAuthorApiResponse<{ geography: Geography }>
-export type PutGeographyMetadataResponse = GeographyAuthorApiResponse<{ geography_metadata: GeographyMetadata }>
+export type PutGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
+export type PublishGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
+export type PutGeographyMetadataResponse = GeographyAuthorApiResponse<{
+  data: { geography_metadata: GeographyMetadata }
+}>
 
 export type DeleteGeographyResponse = GeographyAuthorApiResponse<{ result: string }>

--- a/packages/mds-geography-author/types.ts
+++ b/packages/mds-geography-author/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
-import { GeographyMetadata, Geography } from '@mds-core/mds-types'
+import { GeographyMetadata, Geography, UUID } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION = typeof GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS[number]
@@ -52,4 +52,4 @@ export type PutGeographyMetadataResponse = GeographyAuthorApiResponse<{
   data: { geography_metadata: GeographyMetadata }
 }>
 
-export type DeleteGeographyResponse = GeographyAuthorApiResponse<{ result: string }>
+export type DeleteGeographyResponse = GeographyAuthorApiResponse<{ data: { geography_id: UUID } }>

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -31,7 +31,7 @@ function api(app: express.Express): express.Express {
         if (!geography.publish_date && !res.locals.scopes.includes('geographies:read:unpublished')) {
           throw new InsufficientPermissionsError('permission to read unpublished geographies missing')
         }
-        return res.status(200).send({ version: res.locals.version, geography })
+        return res.status(200).send({ version: res.locals.version, data: { geography } })
       } catch (error) {
         logger.error('failed to read geography', error.stack)
         if (error instanceof NotFoundError) {
@@ -70,9 +70,9 @@ function api(app: express.Express): express.Express {
         const geographies = summary ? await db.readGeographySummaries(params) : await db.readGeographies(params)
         if (!res.locals.scopes.includes('geographies:read:unpublished')) {
           const filteredGeos = geographies.filter(geo => !!geo.publish_date)
-          return res.status(200).send({ version: res.locals.version, geographies: filteredGeos })
+          return res.status(200).send({ version: res.locals.version, data: { geographies: filteredGeos } })
         }
-        return res.status(200).send({ version: res.locals.version, geographies })
+        return res.status(200).send({ version: res.locals.version, data: { geographies } })
       } catch (error) {
         /* We don't throw a NotFoundError if the number of results is zero, so the error handling
          * doesn't need to consider it here.

--- a/packages/mds-geography/tests/api.spec.ts
+++ b/packages/mds-geography/tests/api.spec.ts
@@ -42,7 +42,7 @@ import { GEOGRAPHY_API_DEFAULT_VERSION } from '../types'
 
 const request = supertest(ApiServer(api))
 
-const APP_JSON = 'application/vnd.mds-geography+json; charset=utf-8; version=0.1'
+const APP_JSON = 'application/vnd.mds-geography+json; charset=utf-8; version=0.4'
 const EMPTY_SCOPE = SCOPED_AUTH([], '')
 const EVENTS_READ_SCOPE = SCOPED_AUTH(['events:read'])
 const GEOGRAPHIES_READ_PUBLISHED_SCOPE = SCOPED_AUTH(['geographies:read:published'])
@@ -66,7 +66,7 @@ describe('Tests app', () => {
         .get(`/geographies/${GEOGRAPHY_UUID}`)
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
-      test.assert(result.body.geography.geography_id === GEOGRAPHY_UUID)
+      test.assert(result.body.data.geography.geography_id === GEOGRAPHY_UUID)
       test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })
@@ -117,7 +117,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          result.body.geographies.forEach((item: Geography) => {
+          result.body.data.geographies.forEach((item: Geography) => {
             test.assert(item.geography_json)
           })
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
@@ -132,7 +132,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          result.body.geographies.forEach((item: Geography) => {
+          result.body.data.geographies.forEach((item: Geography) => {
             test.assert(!item.geography_json)
           })
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
@@ -155,7 +155,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          test.assert(result.body.geography.geography_id === GEOGRAPHY_UUID)
+          test.assert(result.body.data.geography.geography_id === GEOGRAPHY_UUID)
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
         })
@@ -167,7 +167,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          test.assert(result.body.geographies.length === 2)
+          test.assert(result.body.data.geographies.length === 2)
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
           done(err)
         })
@@ -179,7 +179,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          test.assert(result.body.geographies.length === 1)
+          test.assert(result.body.data.geographies.length === 1)
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
           done(err)
         })
@@ -191,7 +191,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          assert(result.body.geographies.length === 1)
+          assert(result.body.data.geographies.length === 1)
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
           done(err)
         })
@@ -203,7 +203,7 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
-          assert(result.body.geographies.length === 1)
+          assert(result.body.data.geographies.length === 1)
           test.assert(result.body.version === GEOGRAPHY_API_DEFAULT_VERSION)
           done(err)
         })

--- a/packages/mds-geography/types.ts
+++ b/packages/mds-geography/types.ts
@@ -17,7 +17,7 @@
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
 import { Geography, GeographySummary } from '@mds-core/mds-types'
 
-export const GEOGRAPHY_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
+export const GEOGRAPHY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type GEOGRAPHY_API_SUPPORTED_VERSION = typeof GEOGRAPHY_API_SUPPORTED_VERSIONS[number]
 export const [GEOGRAPHY_API_DEFAULT_VERSION] = GEOGRAPHY_API_SUPPORTED_VERSIONS
 
@@ -34,10 +34,10 @@ export type GeographyApiResponse<TBody extends {}> = ApiVersionedResponse<
   TBody
 >
 
-export type GetGeographyResponse = GeographyApiResponse<
-  { geographies: Geography[] | GeographySummary[] } | { geography: Geography | GeographySummary }
->
+export type GetGeographyResponse = GeographyApiResponse<{
+  data: { geographies: Geography[] | GeographySummary[] } | { geography: Geography | GeographySummary }
+}>
 
 export type GetGeographiesResponse = GeographyApiResponse<{
-  geographies: Geography[] | GeographySummary[]
+  data: { geographies: Geography[] | GeographySummary[] }
 }>

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -66,7 +66,7 @@ function api(app: express.Express): express.Express {
 
       try {
         await db.writePolicy(policy)
-        return res.status(201).send({ version: res.locals.version, policy })
+        return res.status(201).send({ version: res.locals.version, data: { policy } })
       } catch (error) {
         if (error.code === '23505') {
           return res
@@ -86,7 +86,7 @@ function api(app: express.Express): express.Express {
       const { policy_id } = req.params
       try {
         const policy = await db.publishPolicy(policy_id)
-        return res.status(200).send({ version: res.locals.version, policy })
+        return res.status(200).send({ version: res.locals.version, data: { policy } })
       } catch (error) {
         logger.error('failed to publish policy', error.stack)
         if (error instanceof AlreadyPublishedError) {

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -119,7 +119,7 @@ function api(app: express.Express): express.Express {
       try {
         await db.editPolicy(policy)
         const result = await db.readPolicy(policy.policy_id)
-        return res.status(200).send({ version: res.locals.version, policy: result })
+        return res.status(200).send({ version: res.locals.version, data: { policy: result } })
       } catch (error) {
         if (error instanceof NotFoundError) {
           return res.status(404).send({ error })
@@ -140,7 +140,7 @@ function api(app: express.Express): express.Express {
       const { policy_id } = req.params
       try {
         await db.deletePolicy(policy_id)
-        return res.status(200).send({ version: res.locals.version, policy_id })
+        return res.status(200).send({ version: res.locals.version, data: { policy_id } })
       } catch (error) {
         /* istanbul ignore next */
         logger.error('failed to delete policy', error.stack)
@@ -168,7 +168,7 @@ function api(app: express.Express): express.Express {
           throw new NotFoundError('No metadata found')
         }
 
-        res.status(200).send({ version: res.locals.version, policy_metadata })
+        res.status(200).send({ version: res.locals.version, data: { policy_metadata } })
       } catch (error) {
         if (error instanceof BadParamsError) {
           res.status(400).send({
@@ -199,7 +199,7 @@ function api(app: express.Express): express.Express {
         }
 
         const result = await db.readSinglePolicyMetadata(policy_id)
-        return res.status(200).send({ version: res.locals.version, policy_metadata: result })
+        return res.status(200).send({ version: res.locals.version, data: { policy_metadata: result } })
       } catch (error) {
         if (error instanceof NotFoundError) {
           return res.status(404).send({ error })
@@ -220,12 +220,12 @@ function api(app: express.Express): express.Express {
       const policy_metadata = req.body
       try {
         await db.updatePolicyMetadata(policy_metadata)
-        return res.status(200).send({ version: res.locals.version, policy_metadata })
+        return res.status(200).send({ version: res.locals.version, data: { policy_metadata } })
       } catch (updateErr) {
         if (updateErr instanceof NotFoundError) {
           try {
             await db.writePolicyMetadata(policy_metadata)
-            return res.status(201).send({ version: res.locals.version, policy_metadata })
+            return res.status(201).send({ version: res.locals.version, data: { policy_metadata } })
           } catch (writeErr) {
             /* istanbul ignore next */
             return next(new ServerError(writeErr))

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -50,7 +50,7 @@ const log = console.log.bind(console)
 
 const request = supertest(ApiServer(api))
 
-const APP_JSON = 'application/vnd.mds.policy-author+json; charset=utf-8; version=0.1'
+const APP_JSON = 'application/vnd.mds.policy-author+json; charset=utf-8; version=0.4'
 const EMPTY_SCOPE = SCOPED_AUTH([], '')
 const EVENTS_READ_SCOPE = SCOPED_AUTH(['events:read'])
 const POLICIES_WRITE_SCOPE = SCOPED_AUTH(['policies:write'])
@@ -530,7 +530,7 @@ describe('Tests app', () => {
         .end((err, result) => {
           test.value(result).hasHeader('content-type', APP_JSON)
           test.value(result.body.version).is(POLICY_AUTHOR_API_DEFAULT_VERSION)
-          test.assert(isUUID(result.body.policy.policy_id))
+          test.assert(isUUID(result.body.data.policy.policy_id))
           done(err)
         })
     })

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -470,7 +470,7 @@ describe('Tests app', () => {
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(200)
         .end((err, result) => {
-          test.value(result.body.policy_metadata.some_arbitrary_thing, 'beep')
+          test.value(result.body.data.policy_metadata.some_arbitrary_thing, 'beep')
           test.value(result.body.version).is(POLICY_AUTHOR_API_DEFAULT_VERSION)
           test.value(result).hasHeader('content-type', APP_JSON)
           done(err)
@@ -516,7 +516,7 @@ describe('Tests app', () => {
 
     it('verifies GETting policy metadata with the same params as for bulk policy reads', async () => {
       const result = await request.get(`/policies/meta`).set('Authorization', POLICIES_READ_SCOPE).expect(200)
-      test.assert(result.body.policy_metadata.length === 1)
+      test.assert(result.body.data.policy_metadata.length === 1)
       test.value(result.body.version).is(POLICY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
     })

--- a/packages/mds-policy-author/types.ts
+++ b/packages/mds-policy-author/types.ts
@@ -1,7 +1,7 @@
 import { Policy, UUID, PolicyMetadata } from '@mds-core/mds-types'
 import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
 
-export const POLICY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
+export const POLICY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type POLICY_AUTHOR_API_SUPPORTED_VERSION = typeof POLICY_AUTHOR_API_SUPPORTED_VERSIONS[number]
 export const [POLICY_AUTHOR_API_DEFAULT_VERSION] = POLICY_AUTHOR_API_SUPPORTED_VERSIONS
 
@@ -19,13 +19,13 @@ type PolicyAuthorApiResponse<TBody extends {}> = ApiVersionedResponse<
   TBody
 >
 
-export type GetPoliciesResponse = PolicyAuthorApiResponse<{ policies: Policy[] }>
-export type GetPolicyResponse = PolicyAuthorApiResponse<{ policy: Policy }>
-export type PostPolicyResponse = PolicyAuthorApiResponse<{ policy: Policy }>
-export type PublishPolicyResponse = PolicyAuthorApiResponse<{ policy: Policy }>
-export type EditPolicyResponse = PolicyAuthorApiResponse<{ policy: Policy }>
-export type DeletePolicyResponse = PolicyAuthorApiResponse<{ policy_id: UUID }>
+export type GetPoliciesResponse = PolicyAuthorApiResponse<{ data: { policies: Policy[] } }>
+export type GetPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PostPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PublishPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type EditPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type DeletePolicyResponse = PolicyAuthorApiResponse<{ data: { policy_id: UUID } }>
 
-export type GetPolicyMetadatumResponse = PolicyAuthorApiResponse<{ policy_metadata: PolicyMetadata }>
-export type GetPolicyMetadataResponse = PolicyAuthorApiResponse<{ policy_metadata: PolicyMetadata[] }>
-export type EditPolicyMetadataResponse = PolicyAuthorApiResponse<{ policy_metadata: PolicyMetadata }>
+export type GetPolicyMetadatumResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata } }>
+export type GetPolicyMetadataResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata[] } }>
+export type EditPolicyMetadataResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata } }>


### PR DESCRIPTION
After discussing with @avatarneil , since the current OMF spec (0.4.1) has a `data` payload in `Policy`, we'll add it to these endpoints to keep it consistent.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [x] Policy Author
- [x] Geography
- [x] Geography Author


