### PR TITLE
[mds-stream] [mds-agency] Add missing return statement for kafka writes

### DIFF
--- a/packages/mds-stream/kafka/stream-producer.ts
+++ b/packages/mds-stream/kafka/stream-producer.ts
@@ -65,6 +65,7 @@ export const KafkaStreamProducer = <TMessage>(
           topic,
           messages
         })
+        return
       }
       throw new ClientDisconnectedError(ExceptionMessages.INITIALIZE_CLIENT_MESSAGE)
     },


### PR DESCRIPTION
## 📚 Purpose
There's a bug in the logic that results in a write _always_ falling through to throwing a ClientDisconnectedError. FWIW, we probably ought to not be returning a Promise<void> for writes, but we can revisit that another time. 

## 📦 Impacts:
mds-stream
mds-agency