### PR TITLE
🐛[mds-stream] Change ts-nats import to properly resolve methods

### DIFF
--- a/packages/mds-stream/nats/helpers.ts
+++ b/packages/mds-stream/nats/helpers.ts
@@ -1,10 +1,10 @@
-import nats from 'ts-nats'
+import { connect, MsgCallback, SubscriptionOptions, Client } from 'ts-nats'
 import logger from '@mds-core/mds-logger'
 import { getEnvVar } from '@mds-core/mds-utils'
 
 const initializeNatsClient = () => {
   const { NATS } = getEnvVar({ NATS: 'localhost' })
-  return nats.connect({
+  return connect({
     url: `nats://${NATS}:4222`,
     reconnect: true,
     waitOnFirstConnect: true,
@@ -14,8 +14,8 @@ const initializeNatsClient = () => {
 
 export const createStreamConsumer = async (
   topic: string,
-  processor: nats.MsgCallback,
-  options: nats.SubscriptionOptions = {}
+  processor: MsgCallback,
+  options: SubscriptionOptions = {}
 ) => {
   const natsClient = await initializeNatsClient()
 
@@ -32,4 +32,4 @@ export const createStreamProducer = async () => {
   return initializeNatsClient()
 }
 
-export const disconnectClient = (consumer: nats.Client) => consumer.close()
+export const disconnectClient = (consumer: Client) => consumer.close()


### PR DESCRIPTION
## 📚 Purpose
Though typescript/webpack do not complain, it appears that if you use a default-style import for ts-nats at runtime the methods are unable to be resolved. Tests are lacking for everything in mds-stream, and we ought to improve that at some point soon. This has been tested in one of our development environments and resolves the issue. I will probably cut a PR to update the typing for the ts-nats library at some point, too.

## 📦 Impacts:
mds-stream
mds-agency
mds-web-sockets

## ✅ PR Checklist