### PR TITLE
[mds-service-helpers] Create separate ProcessController interface

### DIFF
--- a/packages/mds-jurisdiction-service/client/index.ts
+++ b/packages/mds-jurisdiction-service/client/index.ts
@@ -18,7 +18,7 @@ import { UnwrapServiceResult, ServiceClient } from '@mds-core/mds-service-helper
 import { JurisdictionServiceProvider } from '../service/provider'
 import { JurisdictionService } from '../@types'
 
-const { initialize, shutdown, ...service } = JurisdictionServiceProvider
+const { start, stop, ...service } = JurisdictionServiceProvider
 
 export const JurisdictionServiceClient: ServiceClient<JurisdictionService> = {
   createJurisdiction: UnwrapServiceResult(service.createJurisdiction),

--- a/packages/mds-jurisdiction-service/server/index.ts
+++ b/packages/mds-jurisdiction-service/server/index.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import { ServiceManager } from '@mds-core/mds-service-helpers'
+import { ProcessManager } from '@mds-core/mds-service-helpers'
 import { JurisdictionServiceProvider } from '../service/provider'
 
-ServiceManager.run(JurisdictionServiceProvider)
+ProcessManager(JurisdictionServiceProvider).monitor()

--- a/packages/mds-jurisdiction-service/service/provider.ts
+++ b/packages/mds-jurisdiction-service/service/provider.ts
@@ -14,13 +14,13 @@
     limitations under the License.
  */
 
-import { ServiceProvider } from '@mds-core/mds-service-helpers'
+import { ServiceProvider, ProcessController } from '@mds-core/mds-service-helpers'
 import { JurisdictionRepository } from './repository'
 import { JurisdictionService } from '../@types'
 import * as handlers from './handlers'
 
-export const JurisdictionServiceProvider: ServiceProvider<JurisdictionService> = {
-  initialize: JurisdictionRepository.initialize,
-  shutdown: JurisdictionRepository.shutdown,
+export const JurisdictionServiceProvider: ServiceProvider<JurisdictionService> & ProcessController = {
+  start: JurisdictionRepository.initialize,
+  stop: JurisdictionRepository.shutdown,
   ...handlers
 }

--- a/packages/mds-jurisdiction-service/tests/index.spec.ts
+++ b/packages/mds-jurisdiction-service/tests/index.spec.ts
@@ -16,6 +16,7 @@
 
 import test from 'unit.js'
 import { uuid, days } from '@mds-core/mds-utils'
+import { ProcessManager } from '@mds-core/mds-service-helpers'
 import { JurisdictionServiceClient } from '../index'
 import { JurisdictionServiceProvider } from '../service/provider'
 
@@ -26,9 +27,11 @@ const TODAY = Date.now()
 const YESTERDAY = TODAY - days(1)
 const LAST_WEEK = TODAY - days(7)
 
+const controller = ProcessManager(JurisdictionServiceProvider).controller()
+
 describe('Write/Read Jurisdictions', () => {
   before(async () => {
-    await JurisdictionServiceProvider.initialize()
+    await controller.start()
   })
 
   it(`Write ${records} Jurisdiction${records > 1 ? 's' : ''}`, async () => {
@@ -228,6 +231,6 @@ describe('Write/Read Jurisdictions', () => {
   })
 
   after(async () => {
-    await JurisdictionServiceProvider.shutdown()
+    await controller.stop()
   })
 })

--- a/packages/mds-jurisdiction/tests/api.spec.ts
+++ b/packages/mds-jurisdiction/tests/api.spec.ts
@@ -21,7 +21,7 @@ import { uuid } from '@mds-core/mds-utils'
 import { JurisdictionServiceProvider } from '@mds-core/mds-jurisdiction-service/service/provider'
 import { SCOPED_AUTH } from '@mds-core/mds-test-data'
 import { JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
-import { ServiceManager } from '@mds-core/mds-service-helpers'
+import { ProcessManager } from '@mds-core/mds-service-helpers'
 import { api } from '../api'
 import { JURISDICTION_API_DEFAULT_VERSION } from '../@types'
 
@@ -34,11 +34,11 @@ const [JURISDICTION0, JURISDICTION1, JURISDICTION2] = [uuid(), uuid(), uuid()].m
   geography_id: uuid()
 }))
 
-const service = ServiceManager.controller(JurisdictionServiceProvider)
+const controller = ProcessManager(JurisdictionServiceProvider).controller()
 
 describe('Test Jurisdiction API', () => {
   before(async () => {
-    await service.start()
+    await controller.start()
   })
 
   it('Create Single Jurisdiction', async () => {
@@ -214,6 +214,6 @@ describe('Test Jurisdiction API', () => {
   })
 
   after(async () => {
-    await service.stop()
+    await controller.stop()
   })
 })

--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -49,7 +49,9 @@ export type ServiceClient<I> = {
 
 export type ServiceProvider<I> = {
   [P in keyof I]: I[P] extends AnyFunction<infer R> ? (...args: Parameters<I[P]>) => Promise<ServiceResponse<R>> : never
-} & {
-  initialize: () => Promise<void>
-  shutdown: () => Promise<void>
+}
+
+export interface ProcessController {
+  start: () => Promise<void>
+  stop: () => Promise<void>
 }

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import test from 'unit.js'
-import { ServiceResult, ServiceError, ServiceException, isServiceError, ServiceManager } from '../index'
+import { ServiceResult, ServiceError, ServiceException, isServiceError, ProcessManager } from '../index'
 import { UnwrapServiceResult } from '../client'
 
 describe('Tests Service Helpers', () => {
@@ -88,14 +88,14 @@ describe('Tests Service Helpers', () => {
 
   it('Test ServiceManager Controller', async () => {
     let started = false
-    const controller = ServiceManager.controller({
-      initialize: async () => {
+    const controller = ProcessManager({
+      start: async () => {
         started = true
       },
-      shutdown: async () => {
+      stop: async () => {
         started = false
       }
-    })
+    }).controller()
     await controller.start()
     test.value(started).is(true)
     await controller.stop()


### PR DESCRIPTION
## 📚 Purpose
Separate the `ProcessController` and `ServiceProvider` methods into separate interfaces. 

## 👌 Resolves:
This change allows more flexibility when creating networked services.

## 📦 Impacts:
- [x] mds-jurisdiction-service