### PR TITLE
Make Express types more composable

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -15,23 +15,28 @@ import {
   EVENT_STATUS_MAP,
   VEHICLE_EVENT,
   VEHICLE_REASON,
-  UUID,
-  Stop
+  UUID
 } from '@mds-core/mds-types'
 import urls from 'url'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiRequestParams } from '@mds-core/mds-api-server'
 import {
   AgencyApiRequest,
-  AgencyRegisterVehicleResponse,
-  AgencyGetVehicleByIdResponse,
-  AgencyGetVehiclesByProviderResponse,
-  AgencyUpdateVehicleResponse,
-  AgencySubmitVehicleEventResponse,
-  AgencySubmitVehicleTelemetryResponse,
-  AgencyRegisterStopResponse,
-  AgencyReadStopsResponse,
-  AgencyReadStopResponse
+  AgencyApiRegisterVehicleResponse,
+  AgencyAipGetVehicleByIdResponse,
+  AgencyApiGetVehiclesByProviderResponse,
+  AgencyApiUpdateVehicleResponse,
+  AgencyApiSubmitVehicleEventResponse,
+  AgencyApiSubmitVehicleTelemetryResponse,
+  AgencyApiRegisterStopResponse,
+  AgencyApiReadStopsResponse,
+  AgencyApiReadStopResponse,
+  AgencyApiGetVehicleByIdRequest,
+  AgencyApiUpdateVehicleRequest,
+  AgencyApiSubmitVehicleEventRequest,
+  AgencyApiSubmitVehicleTelemetryRequest,
+  AgencyApiRegisterStopRequest,
+  AgencyApiReadStopRequest,
+  AgencyApiRegisterVehicleRequest
 } from './types'
 import {
   badDevice,
@@ -49,7 +54,7 @@ import {
 stream.initialize()
 const agencyServerError = { error: 'server_error', error_description: 'Unknown server error' }
 
-export const registerVehicle = async (req: AgencyApiRequest<Device>, res: AgencyRegisterVehicleResponse) => {
+export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res: AgencyApiRegisterVehicleResponse) => {
   const { body } = req
   const recorded = now()
 
@@ -114,10 +119,7 @@ export const registerVehicle = async (req: AgencyApiRequest<Device>, res: Agency
   }
 }
 
-export const getVehicleById = async (
-  req: AgencyApiRequest & ApiRequestParams<'device_id'>,
-  res: AgencyGetVehicleByIdResponse
-) => {
+export const getVehicleById = async (req: AgencyApiGetVehicleByIdRequest, res: AgencyAipGetVehicleByIdResponse) => {
   const { device_id } = req.params
 
   const { provider_id } = res.locals.scopes.includes('vehicles:read')
@@ -134,7 +136,7 @@ export const getVehicleById = async (
   res.status(200).send({ ...compositeData })
 }
 
-export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyGetVehiclesByProviderResponse) => {
+export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiGetVehiclesByProviderResponse) => {
   const PAGE_SIZE = 1000
 
   const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')
@@ -161,7 +163,7 @@ export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyGe
 
 export async function updateVehicleFail(
   req: AgencyApiRequest,
-  res: AgencyUpdateVehicleResponse,
+  res: AgencyApiUpdateVehicleResponse,
   provider_id: UUID,
   device_id: UUID,
   err: Error | string
@@ -181,10 +183,7 @@ export async function updateVehicleFail(
   }
 }
 
-export const updateVehicle = async (
-  req: AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
-  res: AgencyUpdateVehicleResponse
-) => {
+export const updateVehicle = async (req: AgencyApiUpdateVehicleRequest, res: AgencyApiUpdateVehicleResponse) => {
   const { device_id } = req.params
 
   const { vehicle_id } = req.body
@@ -215,8 +214,8 @@ export const updateVehicle = async (
 }
 
 export const submitVehicleEvent = async (
-  req: AgencyApiRequest<VehicleEvent> & ApiRequestParams<'device_id'>,
-  res: AgencySubmitVehicleEventResponse
+  req: AgencyApiSubmitVehicleEventRequest,
+  res: AgencyApiSubmitVehicleEventResponse
 ) => {
   const { device_id } = req.params
 
@@ -336,8 +335,8 @@ export const submitVehicleEvent = async (
 }
 
 export const submitVehicleTelemetry = async (
-  req: AgencyApiRequest<{ data: Telemetry[] }>,
-  res: AgencySubmitVehicleTelemetryResponse
+  req: AgencyApiSubmitVehicleTelemetryRequest,
+  res: AgencyApiSubmitVehicleTelemetryResponse
 ) => {
   const start = Date.now()
 
@@ -450,7 +449,7 @@ export const submitVehicleTelemetry = async (
   }
 }
 
-export const registerStop = async (req: AgencyApiRequest<Stop>, res: AgencyRegisterStopResponse) => {
+export const registerStop = async (req: AgencyApiRegisterStopRequest, res: AgencyApiRegisterStopResponse) => {
   const stop = req.body
 
   try {
@@ -466,7 +465,7 @@ export const registerStop = async (req: AgencyApiRequest<Stop>, res: AgencyRegis
   }
 }
 
-export const readStop = async (req: AgencyApiRequest & ApiRequestParams<'stop_id'>, res: AgencyReadStopResponse) => {
+export const readStop = async (req: AgencyApiReadStopRequest, res: AgencyApiReadStopResponse) => {
   const { stop_id } = req.params
   try {
     const recorded_stop = await db.readStop(stop_id)
@@ -480,7 +479,7 @@ export const readStop = async (req: AgencyApiRequest & ApiRequestParams<'stop_id
   }
 }
 
-export const readStops = async (req: AgencyApiRequest, res: AgencyReadStopsResponse) => {
+export const readStops = async (req: AgencyApiRequest, res: AgencyApiReadStopsResponse) => {
   try {
     const stops = await db.readStops()
 

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -23,6 +23,7 @@ import {
   AgencyApiRequest,
   AgencyApiRegisterVehicleResponse,
   AgencyAipGetVehicleByIdResponse,
+  AgencyApiGetVehiclesByProviderRequest,
   AgencyApiGetVehiclesByProviderResponse,
   AgencyApiUpdateVehicleResponse,
   AgencyApiSubmitVehicleEventResponse,
@@ -136,7 +137,10 @@ export const getVehicleById = async (req: AgencyApiGetVehicleByIdRequest, res: A
   res.status(200).send({ ...compositeData })
 }
 
-export const getVehiclesByProvider = async (req: AgencyApiRequest, res: AgencyApiGetVehiclesByProviderResponse) => {
+export const getVehiclesByProvider = async (
+  req: AgencyApiGetVehiclesByProviderRequest,
+  res: AgencyApiGetVehiclesByProviderResponse
+) => {
   const PAGE_SIZE = 1000
 
   const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -3,6 +3,7 @@ import cache from '@mds-core/mds-agency-cache'
 import db from '@mds-core/mds-db'
 import { ServerError } from '@mds-core/mds-utils'
 import { parseRequest } from '@mds-core/mds-api-helpers'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse } from './types'
 import { refresh } from './utils'
 
@@ -16,7 +17,7 @@ export const getCacheInfo = async (req: AgencyApiRequest, res: AgencyApiResponse
   }
 }
 
-export const wipeDevice = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
+export const wipeDevice = async (req: AgencyApiRequest & ApiRequestParams<'device_id'>, res: AgencyApiResponse) => {
   try {
     const { device_id } = req.params
     logger.info('about to wipe', device_id)

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -3,7 +3,7 @@ import cache from '@mds-core/mds-agency-cache'
 import db from '@mds-core/mds-db'
 import { ServerError } from '@mds-core/mds-utils'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiRequestParams } from '@mds-core/mds-api-server'
+import { ApiRequestParams, ApiRequestQuery } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse } from './types'
 import { refresh } from './utils'
 
@@ -17,7 +17,9 @@ export const getCacheInfo = async (req: AgencyApiRequest, res: AgencyApiResponse
   }
 }
 
-export const wipeDevice = async (req: AgencyApiRequest & ApiRequestParams<'device_id'>, res: AgencyApiResponse) => {
+export type AgencyApiWipeDeviceRequest = AgencyApiRequest & ApiRequestParams<'device_id'>
+
+export const wipeDevice = async (req: AgencyApiWipeDeviceRequest, res: AgencyApiResponse) => {
   try {
     const { device_id } = req.params
     logger.info('about to wipe', device_id)
@@ -40,7 +42,9 @@ export const wipeDevice = async (req: AgencyApiRequest & ApiRequestParams<'devic
   }
 }
 
-export const refreshCache = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
+export type AgencyApiRefreshCacheRequest = AgencyApiRequest & ApiRequestQuery<'skip' | 'take'>
+
+export const refreshCache = async (req: AgencyApiRefreshCacheRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
   const { skip = 0, take = 10000000000 } = parseRequest(req, { parser: Number }).query('skip', 'take')
 

--- a/packages/mds-agency/tests/request-handlers.spec.ts
+++ b/packages/mds-agency/tests/request-handlers.spec.ts
@@ -5,8 +5,13 @@ import { Device, VEHICLE_TYPES } from '@mds-core/mds-types'
 import db from '@mds-core/mds-db'
 import cache from '@mds-core/mds-agency-cache'
 import stream from '@mds-core/mds-stream'
-import { ApiRequestParams } from '@mds-core/mds-api-server'
-import { AgencyApiRequest, AgencyApiResponse, AgencyGetVehiclesByProviderResponse } from '../types'
+import {
+  AgencyApiRequest,
+  AgencyApiResponse,
+  AgencyApiGetVehiclesByProviderResponse,
+  AgencyApiGetVehicleByIdRequest,
+  AgencyApiUpdateVehicleRequest
+} from '../types'
 import {
   registerVehicle,
   getVehicleById,
@@ -168,7 +173,7 @@ describe('Agency API request handlers', () => {
         ({
           params: { device_id },
           query: { cached: false }
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiGetVehicleByIdRequest,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -200,7 +205,7 @@ describe('Agency API request handlers', () => {
         ({
           params: { device_id },
           query: { cached: false }
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiGetVehicleByIdRequest,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -226,7 +231,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiRequest,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -237,7 +242,7 @@ describe('Agency API request handlers', () => {
     it('Gets vehicles by provider', async () => {
       const provider_id = uuid()
       const device_id = uuid()
-      const res: AgencyGetVehiclesByProviderResponse = {} as AgencyGetVehiclesByProviderResponse
+      const res: AgencyApiGetVehiclesByProviderResponse = {} as AgencyApiGetVehiclesByProviderResponse
       const sendHandler = Sinon.fake.returns('asdf')
       const statusHandler = Sinon.fake.returns({
         send: sendHandler
@@ -252,7 +257,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiRequest,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -279,7 +284,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+          } as unknown) as AgencyApiUpdateVehicleRequest,
           res,
           provider_id,
           device_id,
@@ -306,7 +311,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+          } as unknown) as AgencyApiUpdateVehicleRequest,
           res,
           provider_id,
           device_id,
@@ -339,7 +344,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+          } as unknown) as AgencyApiUpdateVehicleRequest,
           res,
           provider_id,
           device_id,
@@ -366,7 +371,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+          } as unknown) as AgencyApiUpdateVehicleRequest,
           res,
           provider_id,
           device_id,
@@ -394,7 +399,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiRequest,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -420,7 +425,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiUpdateVehicleRequest,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -446,7 +451,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiUpdateVehicleRequest,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -475,7 +480,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiUpdateVehicleRequest,
         res
       )
       assert.equal(statusHandler.calledWith(201), true)

--- a/packages/mds-agency/tests/request-handlers.spec.ts
+++ b/packages/mds-agency/tests/request-handlers.spec.ts
@@ -10,7 +10,9 @@ import {
   AgencyApiResponse,
   AgencyApiGetVehiclesByProviderResponse,
   AgencyApiGetVehicleByIdRequest,
-  AgencyApiUpdateVehicleRequest
+  AgencyApiUpdateVehicleRequest,
+  AgencyApiRegisterVehicleRequest,
+  AgencyApiGetVehiclesByProviderRequest
 } from '../types'
 import {
   registerVehicle,
@@ -57,7 +59,7 @@ describe('Agency API request handlers', () => {
       } as any)
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(400), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -74,7 +76,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-db'))
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(500), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -91,7 +93,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-other'))
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(500), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -108,7 +110,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-duplicate'))
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(409), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -128,7 +130,7 @@ describe('Agency API request handlers', () => {
       Sinon.replace(cache, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(stream, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(utils, 'writeRegisterEvent', Sinon.fake.resolves('it-worked'))
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(201), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -148,7 +150,7 @@ describe('Agency API request handlers', () => {
       Sinon.replace(cache, 'writeDevice', Sinon.fake.rejects('it-broke'))
       Sinon.replace(stream, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(utils, 'writeRegisterEvent', Sinon.fake.resolves('it-worked'))
-      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
+      await registerVehicle({ body } as AgencyApiRegisterVehicleRequest, res)
       assert.equal(statusHandler.calledWith(201), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -231,7 +233,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest,
+        } as unknown) as AgencyApiGetVehiclesByProviderRequest,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -257,7 +259,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest,
+        } as unknown) as AgencyApiGetVehiclesByProviderRequest,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)

--- a/packages/mds-agency/tests/request-handlers.spec.ts
+++ b/packages/mds-agency/tests/request-handlers.spec.ts
@@ -5,6 +5,7 @@ import { Device, VEHICLE_TYPES } from '@mds-core/mds-types'
 import db from '@mds-core/mds-db'
 import cache from '@mds-core/mds-agency-cache'
 import stream from '@mds-core/mds-stream'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse, AgencyGetVehiclesByProviderResponse } from '../types'
 import {
   registerVehicle,
@@ -51,7 +52,7 @@ describe('Agency API request handlers', () => {
       } as any)
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(400), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -68,7 +69,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-db'))
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(500), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -85,7 +86,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-other'))
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(500), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -102,7 +103,7 @@ describe('Agency API request handlers', () => {
       res.status = statusHandler
       res.locals = getLocals(provider_id) as any
       Sinon.replace(db, 'writeDevice', Sinon.fake.rejects('fake-rejects-duplicate'))
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(409), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -122,7 +123,7 @@ describe('Agency API request handlers', () => {
       Sinon.replace(cache, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(stream, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(utils, 'writeRegisterEvent', Sinon.fake.resolves('it-worked'))
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(201), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -142,7 +143,7 @@ describe('Agency API request handlers', () => {
       Sinon.replace(cache, 'writeDevice', Sinon.fake.rejects('it-broke'))
       Sinon.replace(stream, 'writeDevice', Sinon.fake.resolves('it-worked'))
       Sinon.replace(utils, 'writeRegisterEvent', Sinon.fake.resolves('it-worked'))
-      await registerVehicle({ body } as AgencyApiRequest, res)
+      await registerVehicle({ body } as AgencyApiRequest<Device>, res)
       assert.equal(statusHandler.calledWith(201), true)
       assert.equal(sendHandler.called, true)
       Sinon.restore()
@@ -167,7 +168,7 @@ describe('Agency API request handlers', () => {
         ({
           params: { device_id },
           query: { cached: false }
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -199,7 +200,7 @@ describe('Agency API request handlers', () => {
         ({
           params: { device_id },
           query: { cached: false }
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -225,7 +226,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -251,7 +252,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -278,7 +279,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest<{ device_id: string }>,
+          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
           res,
           provider_id,
           device_id,
@@ -305,7 +306,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest<{ device_id: string }>,
+          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
           res,
           provider_id,
           device_id,
@@ -338,7 +339,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest<{ device_id: string }>,
+          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
           res,
           provider_id,
           device_id,
@@ -365,7 +366,7 @@ describe('Agency API request handlers', () => {
             params: { device_id },
             query: { cached: false },
             get: Sinon.fake.returns('foo') as any
-          } as unknown) as AgencyApiRequest<{ device_id: string }>,
+          } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
           res,
           provider_id,
           device_id,
@@ -393,7 +394,7 @@ describe('Agency API request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -419,7 +420,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -445,7 +446,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(404), true)
@@ -474,7 +475,7 @@ describe('Agency API request handlers', () => {
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any,
           body: { vehicle_id }
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest<Device> & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(201), true)

--- a/packages/mds-agency/tests/sandbox-admin-request-handlers.spec.ts
+++ b/packages/mds-agency/tests/sandbox-admin-request-handlers.spec.ts
@@ -3,9 +3,14 @@ import assert from 'assert'
 import { uuid } from '@mds-core/mds-utils'
 import cache from '@mds-core/mds-agency-cache'
 import db from '@mds-core/mds-db'
-import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse } from '../types'
-import { getCacheInfo, wipeDevice, refreshCache } from '../sandbox-admin-request-handlers'
+import {
+  getCacheInfo,
+  wipeDevice,
+  refreshCache,
+  AgencyApiWipeDeviceRequest,
+  AgencyApiRefreshCacheRequest
+} from '../sandbox-admin-request-handlers'
 import * as utils from '../utils'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -55,7 +60,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiWipeDeviceRequest,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -78,7 +83,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiWipeDeviceRequest,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -103,7 +108,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiRefreshCacheRequest,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -127,7 +132,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
+        } as unknown) as AgencyApiRefreshCacheRequest,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)

--- a/packages/mds-agency/tests/sandbox-admin-request-handlers.spec.ts
+++ b/packages/mds-agency/tests/sandbox-admin-request-handlers.spec.ts
@@ -3,6 +3,7 @@ import assert from 'assert'
 import { uuid } from '@mds-core/mds-utils'
 import cache from '@mds-core/mds-agency-cache'
 import db from '@mds-core/mds-db'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse } from '../types'
 import { getCacheInfo, wipeDevice, refreshCache } from '../sandbox-admin-request-handlers'
 import * as utils from '../utils'
@@ -54,7 +55,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)
@@ -77,7 +78,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -102,7 +103,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(200), true)
@@ -126,7 +127,7 @@ describe('Sandbox admin request handlers', () => {
           params: { device_id },
           query: { cached: false },
           get: Sinon.fake.returns('foo') as any
-        } as unknown) as AgencyApiRequest<{ device_id: string }>,
+        } as unknown) as AgencyApiRequest & ApiRequestParams<'device_id'>,
         res
       )
       assert.equal(statusHandler.calledWith(500), true)

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -1,12 +1,20 @@
 import { UUID, Device, VehicleEvent, Telemetry, Timestamp, Recorded, VEHICLE_STATUS, Stop } from '@mds-core/mds-types'
 import { MultiPolygon } from 'geojson'
-import { ApiRequest, ApiClaims, ApiResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiClaims, ApiResponse, ApiResponseLocals, ApiRequestParams } from '@mds-core/mds-api-server'
 
 export const AGENCY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type AGENCY_API_SUPPORTED_VERSION = typeof AGENCY_API_SUPPORTED_VERSIONS[number]
 export const [AGENCY_API_DEFAULT_VERSION] = AGENCY_API_SUPPORTED_VERSIONS
 
 export type AgencyApiRequest<B = {}> = ApiRequest<B>
+
+export type AgencyApiRegisterVehicleRequest = AgencyApiRequest<Device>
+export type AgencyApiGetVehicleByIdRequest = AgencyApiRequest & ApiRequestParams<'device_id'>
+export type AgencyApiUpdateVehicleRequest = AgencyApiRequest<Device> & ApiRequestParams<'device_id'>
+export type AgencyApiSubmitVehicleEventRequest = AgencyApiRequest<VehicleEvent> & ApiRequestParams<'device_id'>
+export type AgencyApiSubmitVehicleTelemetryRequest = AgencyApiRequest<{ data: Telemetry[] }>
+export type AgencyApiRegisterStopRequest = AgencyApiRequest<Stop>
+export type AgencyApiReadStopRequest = AgencyApiRequest & ApiRequestParams<'stop_id'>
 
 export type AgencyApiAccessTokenScopes = 'admin:all' | 'vehicles:read'
 
@@ -17,26 +25,26 @@ export type AgencyApiResponse<B = {}> = ApiResponse<B> &
     }
   >
 
-export type AgencyRegisterVehicleResponse = AgencyApiResponse
+export type AgencyApiRegisterVehicleResponse = AgencyApiResponse
 
-export type AgencyGetVehicleByIdResponse = AgencyApiResponse<CompositeVehicle>
-export type AgencyGetVehiclesByProviderResponse = AgencyApiResponse<PaginatedVehiclesList>
-export type AgencyUpdateVehicleResponse = AgencyApiResponse
-export type AgencySubmitVehicleEventResponse = AgencyApiResponse<{
+export type AgencyAipGetVehicleByIdResponse = AgencyApiResponse<CompositeVehicle>
+export type AgencyApiGetVehiclesByProviderResponse = AgencyApiResponse<PaginatedVehiclesList>
+export type AgencyApiUpdateVehicleResponse = AgencyApiResponse
+export type AgencyApiSubmitVehicleEventResponse = AgencyApiResponse<{
   device_id: UUID
   status: VEHICLE_STATUS
 }>
 
-export type AgencySubmitVehicleTelemetryResponse = AgencyApiResponse<{
+export type AgencyApiSubmitVehicleTelemetryResponse = AgencyApiResponse<{
   result: string
   recorded: Timestamp
   unique: number
   failures: string[]
 }>
 
-export type AgencyRegisterStopResponse = AgencyApiResponse<Recorded<Stop>>
-export type AgencyReadStopResponse = AgencyApiResponse<Recorded<Stop>>
-export type AgencyReadStopsResponse = AgencyApiResponse<{
+export type AgencyApiRegisterStopResponse = AgencyApiResponse<Recorded<Stop>>
+export type AgencyApiReadStopResponse = AgencyApiResponse<Recorded<Stop>>
+export type AgencyApiReadStopsResponse = AgencyApiResponse<{
   stops: Readonly<
     Required<
       Stop & {

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -10,6 +10,7 @@ export type AgencyApiRequest<B = {}> = ApiRequest<B>
 
 export type AgencyApiRegisterVehicleRequest = AgencyApiRequest<Device>
 export type AgencyApiGetVehicleByIdRequest = AgencyApiRequest & ApiRequestParams<'device_id'>
+export type AgencyApiGetVehiclesByProviderRequest = AgencyApiRequest
 export type AgencyApiUpdateVehicleRequest = AgencyApiRequest<Device> & ApiRequestParams<'device_id'>
 export type AgencyApiSubmitVehicleEventRequest = AgencyApiRequest<VehicleEvent> & ApiRequestParams<'device_id'>
 export type AgencyApiSubmitVehicleTelemetryRequest = AgencyApiRequest<{ data: Telemetry[] }>

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -1,22 +1,21 @@
 import { UUID, Device, VehicleEvent, Telemetry, Timestamp, Recorded, VEHICLE_STATUS, Stop } from '@mds-core/mds-types'
 import { MultiPolygon } from 'geojson'
-import { ApiRequest, ApiClaims, ApiResponse } from '@mds-core/mds-api-server'
-import { Params, ParamsDictionary } from 'express-serve-static-core'
+import { ApiRequest, ApiClaims, ApiResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
 
 export const AGENCY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type AGENCY_API_SUPPORTED_VERSION = typeof AGENCY_API_SUPPORTED_VERSIONS[number]
 export const [AGENCY_API_DEFAULT_VERSION] = AGENCY_API_SUPPORTED_VERSIONS
 
-export type AgencyApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
+export type AgencyApiRequest<B = {}> = ApiRequest<B>
 
 export type AgencyApiAccessTokenScopes = 'admin:all' | 'vehicles:read'
 
-export type AgencyApiResponse<TBody = {}> = ApiResponse<
-  ApiClaims<AgencyApiAccessTokenScopes> & {
-    provider_id: UUID
-  },
-  TBody
->
+export type AgencyApiResponse<B = {}> = ApiResponse<B> &
+  ApiResponseLocals<
+    ApiClaims<AgencyApiAccessTokenScopes> & {
+      provider_id: UUID
+    }
+  >
 
 export type AgencyRegisterVehicleResponse = AgencyApiResponse
 

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -15,15 +15,15 @@
  */
 
 import urls from 'url'
-import express from 'express'
 import { parseObjectProperties, ParseObjectPropertiesOptions } from '@mds-core/mds-utils'
+import { ApiRequest } from '@mds-core/mds-api-server'
 
 interface PagingParams {
   skip: number
   take: number
 }
 
-const jsonApiLink = (req: express.Request, skip: number, take: number): string =>
+const jsonApiLink = (req: ApiRequest, skip: number, take: number): string =>
   urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,
     host: req.get('host'),
@@ -33,7 +33,7 @@ const jsonApiLink = (req: express.Request, skip: number, take: number): string =
 
 export type JsonApiLinks = Partial<{ first: string; prev: string; next: string; last: string }> | undefined
 
-export const asJsonApiLinks = (req: express.Request, skip: number, take: number, count: number): JsonApiLinks => {
+export const asJsonApiLinks = (req: ApiRequest, skip: number, take: number, count: number): JsonApiLinks => {
   if (skip > 0 || take < count) {
     const first = skip > 0 ? jsonApiLink(req, 0, take) : undefined
     const prev = skip - take >= 0 && skip - take < count ? jsonApiLink(req, skip - take, take) : undefined
@@ -44,13 +44,13 @@ export const asJsonApiLinks = (req: express.Request, skip: number, take: number,
   return undefined
 }
 
-export const parseRequest = <T = string>(req: express.Request, options?: ParseObjectPropertiesOptions<T>) => {
+export const parseRequest = <T = string>(req: ApiRequest, options?: ParseObjectPropertiesOptions<T>) => {
   const { keys: query } = parseObjectProperties<T>(req.query, options)
   const { keys: params } = parseObjectProperties<T>(req.params, options)
   return { params, query }
 }
 
-export const parsePagingQueryParams = (req: express.Request) => {
+export const parsePagingQueryParams = (req: ApiRequest) => {
   const [DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE] = [100, 1000]
   const { skip = 0, take = DEFAULT_PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')
   return {

--- a/packages/mds-api-helpers/package.json
+++ b/packages/mds-api-helpers/package.json
@@ -9,12 +9,11 @@
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
   "dependencies": {
+    "@mds-core/mds-api-server": "0.1.26",
     "@mds-core/mds-agency-cache": "0.1.26",
     "@mds-core/mds-db": "0.1.26",
     "@mds-core/mds-types": "0.1.23",
-    "@mds-core/mds-utils": "0.1.26",
-    "@types/express": "4.17.6",
-    "express": "4.17.1"
+    "@mds-core/mds-utils": "0.1.26"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mds-api-helpers/tsconfig.build.json
+++ b/packages/mds-api-helpers/tsconfig.build.json
@@ -5,6 +5,7 @@
   },
   "references": [
     { "path": "../../packages/mds-agency-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
     { "path": "../../packages/mds-db/tsconfig.build.json" },
     { "path": "../../packages/mds-types/tsconfig.build.json" },
     { "path": "../../packages/mds-utils/tsconfig.build.json" }

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -55,10 +55,10 @@ export type ApiClaims<AccessTokenScope extends string> = {
   scopes: AccessTokenScope[]
 }
 
-export type ApiVersion<TVersion extends string> = { version: TVersion }
+export type ApiVersion<V extends string> = { version: V }
 
-export type ApiVersionedResponse<TVersion extends string, B = {}> = ApiResponse<B & ApiVersion<TVersion>> &
-  ApiResponseLocals<ApiVersion<TVersion>>
+export type ApiVersionedResponse<V extends string, B = {}> = ApiResponse<B & ApiVersion<V>> &
+  ApiResponseLocals<ApiVersion<V>>
 
 const about = () => {
   const {
@@ -133,10 +133,10 @@ const MinorVersion = (version: string) => {
   return `${major}.${minor}`
 }
 
-export const ApiVersionMiddleware = <TVersion extends string>(mimeType: string, versions: readonly TVersion[]) => ({
-  withDefaultVersion: (preferred: TVersion) => async (
+export const ApiVersionMiddleware = <V extends string>(mimeType: string, versions: readonly V[]) => ({
+  withDefaultVersion: (preferred: V) => async (
     req: ApiRequest,
-    res: ApiVersionedResponse<TVersion>,
+    res: ApiVersionedResponse<V>,
     next: express.NextFunction
   ) => {
     // Parse the Accept header into a list of values separated by commas
@@ -172,7 +172,7 @@ export const ApiVersionMiddleware = <TVersion extends string>(mimeType: string, 
     const supported = accepted
       .map(info => ({
         ...info,
-        latest: versions.reduce<TVersion | undefined>((latest, version) => {
+        latest: versions.reduce<V | undefined>((latest, version) => {
           if (MinorVersion(info.version) === MinorVersion(version)) {
             if (latest) {
               return latest > version ? latest : version

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -12,27 +12,41 @@ import {
   UserEmailClaim,
   JurisdictionsClaim
 } from '@mds-core/mds-api-authorizer'
-import { Params, ParamsDictionary } from 'express-serve-static-core'
 
-export type ApiRequest<P extends Params = ParamsDictionary> = express.Request<P>
+export type ApiRequest<B = {}> = express.Request<{}, unknown, B, {}>
 
-export type ApiQuery<Q1 extends string, Q2 extends string[] = never> = {
-  query: Partial<
-    {
-      [P in Q1]: string
-    }
-  > &
-    Partial<
-      {
-        [P in Q2[number]]: string | string[]
-      }
-    > & { [x: string]: never }
+/**
+ * Type of request route/path parameters (req.params)
+ * R: Required route parameter(s)
+ * O: Optional route parameter(s)
+ */
+export type ApiRequestParams<R extends string, O extends string = never> = {
+  params: { [P in R]: string } & Partial<{ [P in O]: string }>
 }
 
-export interface ApiResponse<L = unknown, B = unknown>
-  extends express.Response<
+/**
+ * Type of request query parameters (res.query)
+ * S: (Single) Query parameter expected to appear at most once
+ * M: (Multiple) Query parameter that can appear 0 or more times
+ */
+export type ApiRequestQuery<S extends string, M extends string[] = never> = {
+  query: Partial<{ [P in Exclude<S, M[number]>]: string }> & Partial<{ [P in M[number]]: string | string[] }>
+}
+
+/**
+ * B: Type of response body (res.send)
+ */
+export type ApiResponse<B = {}> = Omit<
+  express.Response<
     B | { error: unknown; error_description?: string; error_details?: string[] } | { errors: unknown[] }
-  > {
+  >,
+  'locals'
+> & { locals: {} }
+
+/**
+ * L: Type of response locals (res.locals)
+ */
+export type ApiResponseLocals<L> = {
   locals: L
 }
 
@@ -43,10 +57,8 @@ export type ApiClaims<AccessTokenScope extends string> = {
 
 export type ApiVersion<TVersion extends string> = { version: TVersion }
 
-export type ApiVersionedResponse<TVersion extends string, L = unknown, TBody = unknown> = ApiResponse<
-  L & ApiVersion<TVersion>,
-  TBody & ApiVersion<TVersion>
->
+export type ApiVersionedResponse<TVersion extends string, B = {}> = ApiResponse<B & ApiVersion<TVersion>> &
+  ApiResponseLocals<ApiVersion<TVersion>>
 
 const about = () => {
   const {
@@ -71,7 +83,7 @@ const about = () => {
 
 export const RequestLoggingMiddleware = <AccessTokenScope extends string>(): express.RequestHandler =>
   morgan(
-    (tokens, req: ApiRequest, res: ApiResponse<ApiClaims<AccessTokenScope>>) =>
+    (tokens, req: ApiRequest, res: ApiResponse & ApiResponseLocals<ApiClaims<AccessTokenScope>>) =>
       [
         ...(res.locals.claims?.provider_id ? [res.locals.claims.provider_id] : []),
         tokens.method(req, res),
@@ -107,7 +119,7 @@ export const AuthorizerMiddleware = ({
   authorizer = AuthorizationHeaderApiAuthorizer
 }: Partial<AuthorizerMiddlewareOptions> = {}) => <AccessTokenScope extends string>(
   req: ApiRequest,
-  res: ApiResponse<ApiClaims<AccessTokenScope>>,
+  res: ApiResponse & ApiResponseLocals<ApiClaims<AccessTokenScope>>,
   next: express.NextFunction
 ) => {
   const claims = authorizer(req)
@@ -300,7 +312,11 @@ export const checkAccess = <AccessTokenScope extends string = never>(
     ? async (req: ApiRequest, res: ApiResponse<ApiClaims<AccessTokenScope>>, next: express.NextFunction) => {
         next() // Bypass
       }
-    : async (req: ApiRequest, res: ApiResponse<ApiClaims<AccessTokenScope>>, next: express.NextFunction) => {
+    : async (
+        req: ApiRequest,
+        res: ApiResponse & ApiResponseLocals<ApiClaims<AccessTokenScope>>,
+        next: express.NextFunction
+      ) => {
         const { scopes, claims } = res.locals
         const valid = await validator(scopes, claims)
         return valid

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -669,7 +669,7 @@ function api(app: express.Express): express.Express {
   app.get(
     pathsFor('/vehicles'),
     checkAuditApiAccess(scopes => scopes.includes('audits:vehicles:read')),
-    async (req, res: GetAuditVehiclesResponse) => {
+    async (req: AuditApiGetVehicleRequest, res: GetAuditVehiclesResponse) => {
       const { skip, take } = { skip: 0, take: 10000 }
       const { strict = true, bbox, provider_id } = {
         ...parseRequest(req, { parser: JSON.parse }).query('strict', 'bbox'),

--- a/packages/mds-audit/types.ts
+++ b/packages/mds-audit/types.ts
@@ -28,58 +28,56 @@ import {
   VEHICLE_REASON,
   VEHICLE_STATUS
 } from '@mds-core/mds-types'
-import { ApiRequest, ApiQuery, ApiClaims, ApiVersionedResponse } from '@mds-core/mds-api-server'
-import { Params, ParamsDictionary } from 'express-serve-static-core'
+import {
+  ApiRequest,
+  ApiRequestQuery,
+  ApiClaims,
+  ApiVersionedResponse,
+  ApiRequestParams,
+  ApiResponseLocals
+} from '@mds-core/mds-api-server'
 
 export const AUDIT_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type AUDIT_API_SUPPORTED_VERSION = typeof AUDIT_API_SUPPORTED_VERSIONS[number]
 export const [AUDIT_API_DEFAULT_VERSION] = AUDIT_API_SUPPORTED_VERSIONS
 
 // Allow adding type definitions for Express Request objects
-export type AuditApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
+export type AuditApiRequest<B = {}> = ApiRequest<B>
 
-export type AuditApiTripRequest = AuditApiRequest<{ audit_trip_id: UUID }>
+export type AuditApiTripRequest<B = {}> = AuditApiRequest<B> & ApiRequestParams<'audit_trip_id'>
 
-export interface AuditApiAuditStartRequest extends AuditApiTripRequest {
-  body: {
-    audit_device_id: string
-    audit_event_id: UUID
-    audit_event_type: string
-    provider_id: UUID
-    provider_vehicle_id: string
-    telemetry?: Telemetry
-    timestamp: Timestamp
-  }
-}
+export type AuditApiAuditStartRequest = AuditApiTripRequest<{
+  audit_device_id: string
+  audit_event_id: UUID
+  audit_event_type: string
+  provider_id: UUID
+  provider_vehicle_id: string
+  telemetry?: Telemetry
+  timestamp: Timestamp
+}>
 
-export interface AuditApiVehicleEventRequest extends AuditApiTripRequest {
-  body: {
-    audit_event_id: UUID
-    event_type: string
-    telemetry?: Telemetry
-    trip_id: UUID
-    timestamp: Timestamp
-  }
-}
+export type AuditApiVehicleEventRequest = AuditApiTripRequest<{
+  audit_event_id: UUID
+  event_type: string
+  telemetry?: Telemetry
+  trip_id: UUID
+  timestamp: Timestamp
+}>
 
-export interface AuditApiVehicleTelemetryRequest extends AuditApiTripRequest {
-  body: {
-    audit_event_id: UUID
-    telemetry: Telemetry
-    timestamp: Timestamp
-  }
-}
+export type AuditApiVehicleTelemetryRequest = AuditApiTripRequest<{
+  audit_event_id: UUID
+  telemetry: Telemetry
+  timestamp: Timestamp
+}>
 
-export interface AuditApiAuditNoteRequest extends AuditApiTripRequest {
-  body: {
-    audit_event_id: UUID
-    audit_event_type: string
-    audit_issue_code?: string
-    note?: string
-    telemetry?: Telemetry
-    timestamp: Timestamp
-  }
-}
+export type AuditApiAuditNoteRequest = AuditApiTripRequest<{
+  audit_event_id: UUID
+  audit_event_type: string
+  audit_issue_code?: string
+  note?: string
+  telemetry?: Telemetry
+  timestamp: Timestamp
+}>
 
 export interface AuditApiAuditEndRequest extends AuditApiTripRequest {
   body: {
@@ -91,9 +89,11 @@ export interface AuditApiAuditEndRequest extends AuditApiTripRequest {
 }
 
 export type AuditApiGetTripsRequest = AuditApiRequest &
-  ApiQuery<'skip' | 'take' | 'provider_id' | 'provider_vehicle_id' | 'audit_subject_id' | 'start_time' | 'end_time'>
+  ApiRequestQuery<
+    'skip' | 'take' | 'provider_id' | 'provider_vehicle_id' | 'audit_subject_id' | 'start_time' | 'end_time'
+  >
 
-export type AuditApiGetTripRequest = AuditApiTripRequest & ApiQuery<'event_viewport_adjustment'>
+export type AuditApiGetTripRequest = AuditApiTripRequest & ApiRequestQuery<'event_viewport_adjustment'>
 
 export interface AuditApiGetVehicleRequest extends AuditApiRequest {
   params: {
@@ -117,16 +117,14 @@ type AuditedDevice =
       updated?: number | null | undefined
     })
 // Allow adding type definitions for Express Response objects
-export type AuditApiResponse<T = unknown> = ApiVersionedResponse<
-  AUDIT_API_SUPPORTED_VERSION,
-  ApiClaims<AuditApiAccessTokenScopes> & {
+export type AuditApiResponse<B = {}> = ApiVersionedResponse<AUDIT_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<AuditApiAccessTokenScopes>> &
+  ApiResponseLocals<{
     audit_subject_id: string
     audit_trip_id: UUID
     audit: Audit | null
     recorded: Timestamp
-  },
-  T
->
+  }>
 
 export type PostAuditTripStartResponse = AuditApiResponse<{
   provider_id: string

--- a/packages/mds-audit/types.ts
+++ b/packages/mds-audit/types.ts
@@ -95,12 +95,9 @@ export type AuditApiGetTripsRequest = AuditApiRequest &
 
 export type AuditApiGetTripRequest = AuditApiTripRequest & ApiRequestQuery<'event_viewport_adjustment'>
 
-export interface AuditApiGetVehicleRequest extends AuditApiRequest {
-  params: {
-    provider_id: UUID
-    vin: string
-  }
-}
+export type AuditApiGetVehicleRequest = AuditApiRequest &
+  ApiRequestParams<'provider_id' | 'vin'> &
+  ApiRequestQuery<'strict' | 'bbox' | 'provider_id'>
 
 export type AuditApiAccessTokenScopes = 'audits:write' | 'audits:read' | 'audits:delete' | 'audits:vehicles:read'
 

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -34,6 +34,7 @@ import { Geography, Device, UUID, VehicleEvent } from '@mds-core/mds-types'
 import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID, BLUE_SYSTEMS_PROVIDER_ID, providerName } from '@mds-core/mds-providers'
 import { Geometry, FeatureCollection } from 'geojson'
 import { parseRequest } from '@mds-core/mds-api-helpers'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import * as compliance_engine from './mds-compliance-engine'
 import {
   ComplianceApiRequest,
@@ -83,149 +84,157 @@ function api(app: express.Express): express.Express {
     next()
   })
 
-  app.get(pathsFor('/snapshot/:policy_uuid'), async (req: ComplianceApiRequest, res: ComplianceSnapshotApiResponse) => {
-    const { provider_id, version } = res.locals
-    const { provider_id: queried_provider_id, timestamp } = {
-      ...parseRequest(req).query('provider_id'),
-      ...parseRequest(req, { parser: Number }).query('timestamp')
-    }
-
-    // default to now() if no timestamp supplied
-    const query_date = timestamp || now()
-
-    const { policy_uuid } = req.params
-
-    if (!isUUID(policy_uuid)) {
-      return res.status(400).send({ error: new BadParamsError('Bad policy UUID') })
-    }
-
-    try {
-      const all_policies = await db.readActivePolicies(query_date)
-      const policy = compliance_engine.filterPolicies(all_policies).find(p => {
-        return p.policy_id === policy_uuid
-      })
-      if (!policy) {
-        return res.status(404).send({ error: new NotFoundError('Policy not found') })
+  app.get(
+    pathsFor('/snapshot/:policy_uuid'),
+    async (req: ComplianceApiRequest & ApiRequestParams<'policy_uuid'>, res: ComplianceSnapshotApiResponse) => {
+      const { provider_id, version } = res.locals
+      const { provider_id: queried_provider_id, timestamp } = {
+        ...parseRequest(req).query('provider_id'),
+        ...parseRequest(req, { parser: Number }).query('timestamp')
       }
 
-      if (
-        policy &&
-        ((policy.provider_ids && policy.provider_ids.includes(provider_id)) ||
-          !policy.provider_ids ||
-          (AllowedProviderIDs.includes(provider_id) &&
-            ((policy.provider_ids &&
-              policy.provider_ids.length !== 0 &&
-              queried_provider_id &&
-              policy.provider_ids.includes(queried_provider_id)) ||
-              !policy.provider_ids ||
-              policy.provider_ids.length === 0)))
-      ) {
-        const target_provider_id = AllowedProviderIDs.includes(provider_id) ? queried_provider_id : provider_id
-        if (
-          compliance_engine
-            .filterPolicies(all_policies)
-            .map(p => p.policy_id)
-            .includes(policy.policy_id)
-        ) {
-          const [geographies, deviceRecords] = await Promise.all([
-            db.readGeographies() as Promise<Geography[]>,
-            db.readDeviceIds(target_provider_id)
-          ])
-          const deviceIdSubset = deviceRecords.map((record: { device_id: UUID; provider_id: UUID }) => record.device_id)
-          const devices = await cache.readDevices(deviceIdSubset)
-          // if a timestamp was supplied, the data we want is probably old enough it's going to be in the db
-          const events = timestamp
-            ? await db.readHistoricalEvents({ provider_id: target_provider_id, end_date: timestamp })
-            : await cache.readEvents(deviceIdSubset)
+      // default to now() if no timestamp supplied
+      const query_date = timestamp || now()
 
-          const deviceMap = devices.reduce((map: { [d: string]: Device }, device) => {
-            return device ? Object.assign(map, { [device.device_id]: device }) : map
-          }, {})
+      const { policy_uuid } = req.params
 
-          const filteredEvents = compliance_engine.filterEvents(events)
-          const result = compliance_engine.processPolicy(policy, filteredEvents, geographies, deviceMap)
-          if (result === undefined) {
-            return res.status(400).send({ error: new BadParamsError('Unable to process compliance results') })
-          }
+      if (!isUUID(policy_uuid)) {
+        return res.status(400).send({ error: new BadParamsError('Bad policy UUID') })
+      }
 
-          return res.status(200).send({ ...result, timestamp: query_date, version })
+      try {
+        const all_policies = await db.readActivePolicies(query_date)
+        const policy = compliance_engine.filterPolicies(all_policies).find(p => {
+          return p.policy_id === policy_uuid
+        })
+        if (!policy) {
+          return res.status(404).send({ error: new NotFoundError('Policy not found') })
         }
-      } else {
-        return res.status(401).send({ error: new AuthorizationError() })
-      }
-    } catch (err) {
-      return res.status(500).send({ error: new ServerError() })
-    }
-  })
 
-  app.get(pathsFor('/count/:rule_id'), async (req: ComplianceApiRequest, res: ComplianceCountApiResponse) => {
-    const { timestamp } = {
-      ...parseRequest(req, { parser: Number }).query('timestamp')
-    }
-    const query_date = timestamp || now()
-    if (!AllowedProviderIDs.includes(res.locals.provider_id)) {
-      return res.status(401).send({ error: new AuthorizationError('Unauthorized') })
-    }
+        if (
+          policy &&
+          ((policy.provider_ids && policy.provider_ids.includes(provider_id)) ||
+            !policy.provider_ids ||
+            (AllowedProviderIDs.includes(provider_id) &&
+              ((policy.provider_ids &&
+                policy.provider_ids.length !== 0 &&
+                queried_provider_id &&
+                policy.provider_ids.includes(queried_provider_id)) ||
+                !policy.provider_ids ||
+                policy.provider_ids.length === 0)))
+        ) {
+          const target_provider_id = AllowedProviderIDs.includes(provider_id) ? queried_provider_id : provider_id
+          if (
+            compliance_engine
+              .filterPolicies(all_policies)
+              .map(p => p.policy_id)
+              .includes(policy.policy_id)
+          ) {
+            const [geographies, deviceRecords] = await Promise.all([
+              db.readGeographies() as Promise<Geography[]>,
+              db.readDeviceIds(target_provider_id)
+            ])
+            const deviceIdSubset = deviceRecords.map(
+              (record: { device_id: UUID; provider_id: UUID }) => record.device_id
+            )
+            const devices = await cache.readDevices(deviceIdSubset)
+            // if a timestamp was supplied, the data we want is probably old enough it's going to be in the db
+            const events = timestamp
+              ? await db.readHistoricalEvents({ provider_id: target_provider_id, end_date: timestamp })
+              : await cache.readEvents(deviceIdSubset)
 
-    const { rule_id } = req.params
-    try {
-      const activePolicies = await db.readActivePolicies(query_date)
-      const [policy] = activePolicies.filter(activePolicy => {
-        const matches = activePolicy.rules.filter(policy_rule => policy_rule.rule_id === rule_id)
-        return matches.length !== 0
-      })
-      if (!policy) {
-        throw new NotFoundError('invalid rule_id')
-      }
-      const [rule] = policy.rules.filter(r => r.rule_id === rule_id)
-      const geography_ids = rule.geographies.reduce((acc: UUID[], geo: UUID) => {
-        return [...acc, geo]
-      }, [])
-      const geographies = (
-        await Promise.all(
-          geography_ids.reduce((acc: Promise<Geography>[], geography_id) => {
-            const geography = db.readSingleGeography(geography_id)
-            return [...acc, geography]
-          }, [])
-        )
-      ).reduce((acc: Geography[], geos) => {
-        return [...acc, geos]
-      }, [])
+            const deviceMap = devices.reduce((map: { [d: string]: Device }, device) => {
+              return device ? Object.assign(map, { [device.device_id]: device }) : map
+            }, {})
 
-      const polys = geographies.reduce((acc: (Geometry | FeatureCollection)[], geography) => {
-        return [...acc, getPolygon(geographies, geography.geography_id)]
-      }, [])
-
-      const events = timestamp ? await db.readHistoricalEvents({ end_date: timestamp }) : await cache.readAllEvents()
-
-      // https://stackoverflow.com/a/51577579 to remove nulls in typesafe way
-      const filteredVehicleEvents = events.filter(
-        (event): event is VehicleEvent => event !== null && isInStatesOrEvents(rule, event)
-      )
-      const filteredEvents = compliance_engine.filterEvents(filteredVehicleEvents)
-
-      const count = filteredEvents.reduce((count_acc, event) => {
-        return (
-          count_acc +
-          polys.reduce((poly_acc, poly) => {
-            if (event.telemetry && pointInShape(event.telemetry.gps, poly)) {
-              return poly_acc + 1
+            const filteredEvents = compliance_engine.filterEvents(events)
+            const result = compliance_engine.processPolicy(policy, filteredEvents, geographies, deviceMap)
+            if (result === undefined) {
+              return res.status(400).send({ error: new BadParamsError('Unable to process compliance results') })
             }
-            return poly_acc
-          }, 0)
-        )
-      }, 0)
 
-      const { version } = res.locals
-      return res.status(200).send({ policy, count, timestamp: query_date, version })
-    } catch (error) {
-      await logger.error(error.stack)
-      if (error instanceof NotFoundError) {
-        return res.status(404).send({ error })
+            return res.status(200).send({ ...result, timestamp: query_date, version })
+          }
+        } else {
+          return res.status(401).send({ error: new AuthorizationError() })
+        }
+      } catch (err) {
+        return res.status(500).send({ error: new ServerError() })
       }
-      return res.status(500).send({ error: new ServerError('An internal server error has occurred and been logged') })
     }
-  })
+  )
+
+  app.get(
+    pathsFor('/count/:rule_id'),
+    async (req: ComplianceApiRequest & ApiRequestParams<'rule_id'>, res: ComplianceCountApiResponse) => {
+      const { timestamp } = {
+        ...parseRequest(req, { parser: Number }).query('timestamp')
+      }
+      const query_date = timestamp || now()
+      if (!AllowedProviderIDs.includes(res.locals.provider_id)) {
+        return res.status(401).send({ error: new AuthorizationError('Unauthorized') })
+      }
+
+      const { rule_id } = req.params
+      try {
+        const activePolicies = await db.readActivePolicies(query_date)
+        const [policy] = activePolicies.filter(activePolicy => {
+          const matches = activePolicy.rules.filter(policy_rule => policy_rule.rule_id === rule_id)
+          return matches.length !== 0
+        })
+        if (!policy) {
+          throw new NotFoundError('invalid rule_id')
+        }
+        const [rule] = policy.rules.filter(r => r.rule_id === rule_id)
+        const geography_ids = rule.geographies.reduce((acc: UUID[], geo: UUID) => {
+          return [...acc, geo]
+        }, [])
+        const geographies = (
+          await Promise.all(
+            geography_ids.reduce((acc: Promise<Geography>[], geography_id) => {
+              const geography = db.readSingleGeography(geography_id)
+              return [...acc, geography]
+            }, [])
+          )
+        ).reduce((acc: Geography[], geos) => {
+          return [...acc, geos]
+        }, [])
+
+        const polys = geographies.reduce((acc: (Geometry | FeatureCollection)[], geography) => {
+          return [...acc, getPolygon(geographies, geography.geography_id)]
+        }, [])
+
+        const events = timestamp ? await db.readHistoricalEvents({ end_date: timestamp }) : await cache.readAllEvents()
+
+        // https://stackoverflow.com/a/51577579 to remove nulls in typesafe way
+        const filteredVehicleEvents = events.filter(
+          (event): event is VehicleEvent => event !== null && isInStatesOrEvents(rule, event)
+        )
+        const filteredEvents = compliance_engine.filterEvents(filteredVehicleEvents)
+
+        const count = filteredEvents.reduce((count_acc, event) => {
+          return (
+            count_acc +
+            polys.reduce((poly_acc, poly) => {
+              if (event.telemetry && pointInShape(event.telemetry.gps, poly)) {
+                return poly_acc + 1
+              }
+              return poly_acc
+            }, 0)
+          )
+        }, 0)
+
+        const { version } = res.locals
+        return res.status(200).send({ policy, count, timestamp: query_date, version })
+      } catch (error) {
+        await logger.error(error.stack)
+        if (error instanceof NotFoundError) {
+          return res.status(404).send({ error })
+        }
+        return res.status(500).send({ error: new ServerError('An internal server error has occurred and been logged') })
+      }
+    }
+  )
   return app
 }
 

--- a/packages/mds-compliance/types.ts
+++ b/packages/mds-compliance/types.ts
@@ -1,5 +1,11 @@
 import { MatchedVehicle, VehicleEvent, UUID, Timestamp, ComplianceResponse, Policy } from '@mds-core/mds-types'
-import { ApiRequest, ApiClaims, ApiVersionedResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
+import {
+  ApiRequest,
+  ApiClaims,
+  ApiVersionedResponse,
+  ApiResponseLocals,
+  ApiRequestParams
+} from '@mds-core/mds-api-server'
 
 export const COMPLIANCE_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type COMPLIANCE_API_SUPPORTED_VERSION = typeof COMPLIANCE_API_SUPPORTED_VERSIONS[number]
@@ -7,19 +13,17 @@ export const [COMPLIANCE_API_DEFAULT_VERSION] = COMPLIANCE_API_SUPPORTED_VERSION
 
 export type ComplianceApiRequest<B = {}> = ApiRequest<B>
 
+export type ComplianceApiSnapshotRequest = ComplianceApiRequest & ApiRequestParams<'policy_uuid'>
+export type ComplianceApiCountRequest = ComplianceApiRequest & ApiRequestParams<'rule_id'>
+
 export type ComplianceApiAccessTokenScopes = never
 
 export type ComplianceApiResponse<B = {}> = ApiVersionedResponse<COMPLIANCE_API_SUPPORTED_VERSION, B> &
-  ApiResponseLocals<
-    ApiClaims<ComplianceApiAccessTokenScopes> & {
-      provider_id: UUID
-    }
-  >
+  ApiResponseLocals<ApiClaims<ComplianceApiAccessTokenScopes>> &
+  ApiResponseLocals<{ provider_id: UUID }>
 
-type ComplianceSnapshotResponse = ComplianceResponse & { timestamp: Timestamp }
-
-export type ComplianceSnapshotApiResponse = ComplianceApiResponse<ComplianceSnapshotResponse>
-export type ComplianceCountApiResponse = ComplianceApiResponse<{
+export type ComplianceApiSnapshotResponse = ComplianceApiResponse<ComplianceResponse & { timestamp: Timestamp }>
+export type ComplianceApiCountResponse = ComplianceApiResponse<{
   policy: Policy
   count: number
   timestamp: Timestamp

--- a/packages/mds-compliance/types.ts
+++ b/packages/mds-compliance/types.ts
@@ -1,21 +1,20 @@
 import { MatchedVehicle, VehicleEvent, UUID, Timestamp, ComplianceResponse, Policy } from '@mds-core/mds-types'
-import { ApiRequest, ApiClaims, ApiVersionedResponse } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiClaims, ApiVersionedResponse, ApiResponseLocals } from '@mds-core/mds-api-server'
 
 export const COMPLIANCE_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type COMPLIANCE_API_SUPPORTED_VERSION = typeof COMPLIANCE_API_SUPPORTED_VERSIONS[number]
 export const [COMPLIANCE_API_DEFAULT_VERSION] = COMPLIANCE_API_SUPPORTED_VERSIONS
 
-export type ComplianceApiRequest = ApiRequest
+export type ComplianceApiRequest<B = {}> = ApiRequest<B>
 
 export type ComplianceApiAccessTokenScopes = never
 
-export type ComplianceApiResponse<TBody = {}> = ApiVersionedResponse<
-  COMPLIANCE_API_SUPPORTED_VERSION,
-  ApiClaims<ComplianceApiAccessTokenScopes> & {
-    provider_id: UUID
-  },
-  TBody
->
+export type ComplianceApiResponse<B = {}> = ApiVersionedResponse<COMPLIANCE_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<
+    ApiClaims<ComplianceApiAccessTokenScopes> & {
+      provider_id: UUID
+    }
+  >
 
 type ComplianceSnapshotResponse = ComplianceResponse & { timestamp: Timestamp }
 

--- a/packages/mds-daily/request-handlers.ts
+++ b/packages/mds-daily/request-handlers.ts
@@ -11,8 +11,7 @@ import {
   TripsStats,
   Device
 } from '@mds-core/mds-types'
-import { ApiRequestParams } from '@mds-core/mds-api-server'
-import { DailyApiRequest, DailyApiResponse, ProviderInfo } from './types'
+import { DailyApiRequest, DailyApiResponse, ProviderInfo, DailyApiGetRawTripDataRequest } from './types'
 import {
   getTimeSinceLastEvent,
   getNumVehiclesRegisteredLast24Hours,
@@ -39,7 +38,7 @@ const SERVER_ERROR = {
 
 type Item = Pick<Device, 'provider_id' | 'device_id'>
 
-export async function getRawTripData(req: DailyApiRequest & ApiRequestParams<'trip_id'>, res: DailyApiResponse) {
+export async function getRawTripData(req: DailyApiGetRawTripDataRequest, res: DailyApiResponse) {
   try {
     const start = now()
     const { trip_id } = req.params

--- a/packages/mds-daily/request-handlers.ts
+++ b/packages/mds-daily/request-handlers.ts
@@ -11,6 +11,7 @@ import {
   TripsStats,
   Device
 } from '@mds-core/mds-types'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { DailyApiRequest, DailyApiResponse, ProviderInfo } from './types'
 import {
   getTimeSinceLastEvent,
@@ -38,7 +39,7 @@ const SERVER_ERROR = {
 
 type Item = Pick<Device, 'provider_id' | 'device_id'>
 
-export async function getRawTripData(req: DailyApiRequest, res: DailyApiResponse) {
+export async function getRawTripData(req: DailyApiRequest & ApiRequestParams<'trip_id'>, res: DailyApiResponse) {
   try {
     const start = now()
     const { trip_id } = req.params

--- a/packages/mds-daily/tests/request-handlers.spec.ts
+++ b/packages/mds-daily/tests/request-handlers.spec.ts
@@ -1,7 +1,6 @@
 import db from '@mds-core/mds-db'
 import Sinon from 'sinon'
-import { ApiRequestParams } from '@mds-core/mds-api-server/dist'
-import { DailyApiRequest, DailyApiResponse } from '../types'
+import { DailyApiResponse, DailyApiGetRawTripDataRequest } from '../types'
 import { getRawTripData } from '../request-handlers'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -19,7 +18,7 @@ describe('Request handlers', () => {
       await getRawTripData(
         {
           params: { trip_id: 'fake-trip-id' }
-        } as DailyApiRequest & ApiRequestParams<'trip_id'>,
+        } as DailyApiGetRawTripDataRequest,
         res as DailyApiResponse
       )
       Sinon.restore()

--- a/packages/mds-daily/tests/request-handlers.spec.ts
+++ b/packages/mds-daily/tests/request-handlers.spec.ts
@@ -1,5 +1,6 @@
 import db from '@mds-core/mds-db'
 import Sinon from 'sinon'
+import { ApiRequestParams } from '@mds-core/mds-api-server/dist'
 import { DailyApiRequest, DailyApiResponse } from '../types'
 import { getRawTripData } from '../request-handlers'
 
@@ -18,7 +19,7 @@ describe('Request handlers', () => {
       await getRawTripData(
         {
           params: { trip_id: 'fake-trip-id' }
-        } as DailyApiRequest<{ trip_id: string }>,
+        } as DailyApiRequest & ApiRequestParams<'trip_id'>,
         res as DailyApiResponse
       )
       Sinon.restore()

--- a/packages/mds-daily/types.ts
+++ b/packages/mds-daily/types.ts
@@ -1,8 +1,10 @@
 import { UUID } from '@mds-core/mds-types'
 import { MultiPolygon } from 'geojson'
-import { ApiRequest, ApiResponse, ApiResponseLocals, ApiClaims } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiResponse, ApiResponseLocals, ApiClaims, ApiRequestParams } from '@mds-core/mds-api-server'
 
 export type DailyApiRequest<B = {}> = ApiRequest<B>
+
+export type DailyApiGetRawTripDataRequest = DailyApiRequest & ApiRequestParams<'trip_id'>
 
 export type DailyApiAccessTokenScopes = 'admin:all'
 

--- a/packages/mds-daily/types.ts
+++ b/packages/mds-daily/types.ts
@@ -1,13 +1,12 @@
 import { UUID } from '@mds-core/mds-types'
 import { MultiPolygon } from 'geojson'
-import { ApiRequest, ApiResponse, ApiClaims } from '@mds-core/mds-api-server'
-import { Params, ParamsDictionary } from 'express-serve-static-core'
+import { ApiRequest, ApiResponse, ApiResponseLocals, ApiClaims } from '@mds-core/mds-api-server'
 
-export type DailyApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
+export type DailyApiRequest<B = {}> = ApiRequest<B>
 
 export type DailyApiAccessTokenScopes = 'admin:all'
 
-export type DailyApiResponse = ApiResponse<ApiClaims<DailyApiAccessTokenScopes>>
+export type DailyApiResponse<B = {}> = ApiResponse<B> & ApiResponseLocals<ApiClaims<DailyApiAccessTokenScopes>>
 
 export interface ServiceArea {
   service_area_id: UUID

--- a/packages/mds-geography-author/api.ts
+++ b/packages/mds-geography-author/api.ts
@@ -15,25 +15,24 @@ import {
 import { geographyValidationDetails } from '@mds-core/mds-schema-validators'
 import logger from '@mds-core/mds-logger'
 
-import {
-  checkAccess,
-  AccessTokenScopeValidator,
-  ApiResponse,
-  ApiRequest,
-  ApiRequestQuery,
-  ApiRequestParams
-} from '@mds-core/mds-api-server'
-import { Geography, GeographyMetadata } from '@mds-core/mds-types'
+import { checkAccess, AccessTokenScopeValidator, ApiResponse, ApiRequest } from '@mds-core/mds-api-server'
 import { GeographyAuthorApiVersionMiddleware } from './middleware'
 import {
-  GeographyAuthorApiRequest,
   GeographyAuthorApiAccessTokenScopes,
-  GetGeographyMetadatumResponse,
-  DeleteGeographyResponse,
-  PostGeographyResponse,
-  PutGeographyResponse,
-  PutGeographyMetadataResponse,
-  GetGeographyMetadataResponse
+  GeographyAuthorApiGetGeographyMetadatumResponse,
+  GeographyAuthorApiDeleteGeographyResponse,
+  GeographyAuthorApiPostGeographyResponse,
+  GeographyAuthorApiPutGeographyResponse,
+  GeographyAuthorApiPutGeographyMetadataResponse,
+  GeographyAuthorApiGetGeographyMetadataResponse,
+  GeographyAuthorApiGetGeographyMetadataRequest,
+  GeographyAuthorApiPostGeographyRequest,
+  GeographyAuthorApiPutGeographyRequest,
+  GeographyAuthorApiDeleteGeographyRequest,
+  GeographyAuthorApiGetGeographyMetadatumRequest,
+  GeographyAuthorApiPutGeographyMetadataRequest,
+  GeographyAuthorApiPublishGeographyRequest,
+  GeographyAuthorApiPublishGeographyResponse
 } from './types'
 
 const checkGeographyAuthorApiAccess = (validator: AccessTokenScopeValidator<GeographyAuthorApiAccessTokenScopes>) =>
@@ -48,8 +47,8 @@ function api(app: express.Express): express.Express {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
     async (
-      req: GeographyAuthorApiRequest & ApiRequestQuery<'get_published' | 'get_unpublished'>,
-      res: GetGeographyMetadataResponse,
+      req: GeographyAuthorApiGetGeographyMetadataRequest,
+      res: GeographyAuthorApiGetGeographyMetadataResponse,
       next: express.NextFunction
     ) => {
       const { scopes } = res.locals
@@ -104,7 +103,11 @@ function api(app: express.Express): express.Express {
   app.post(
     pathsFor('/geographies/'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
-    async (req: GeographyAuthorApiRequest<Geography>, res: PostGeographyResponse, next: express.NextFunction) => {
+    async (
+      req: GeographyAuthorApiPostGeographyRequest,
+      res: GeographyAuthorApiPostGeographyResponse,
+      next: express.NextFunction
+    ) => {
       const geography = req.body
 
       try {
@@ -133,7 +136,11 @@ function api(app: express.Express): express.Express {
   app.put(
     pathsFor('/geographies/:geography_id'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
-    async (req: GeographyAuthorApiRequest<Geography>, res: PutGeographyResponse, next: express.NextFunction) => {
+    async (
+      req: GeographyAuthorApiPutGeographyRequest,
+      res: GeographyAuthorApiPutGeographyResponse,
+      next: express.NextFunction
+    ) => {
       const geography = req.body
       try {
         const details = geographyValidationDetails(geography)
@@ -159,8 +166,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/geographies/:geography_id'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
-      req: GeographyAuthorApiRequest & ApiRequestParams<'geography_id'>,
-      res: DeleteGeographyResponse,
+      req: GeographyAuthorApiDeleteGeographyRequest,
+      res: GeographyAuthorApiDeleteGeographyResponse,
       next: express.NextFunction
     ) => {
       const { geography_id } = req.params
@@ -202,8 +209,8 @@ function api(app: express.Express): express.Express {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
     async (
-      req: GeographyAuthorApiRequest & ApiRequestParams<'geography_id'>,
-      res: GetGeographyMetadatumResponse,
+      req: GeographyAuthorApiGetGeographyMetadatumRequest,
+      res: GeographyAuthorApiGetGeographyMetadatumResponse,
       next: express.NextFunction
     ) => {
       const { geography_id } = req.params
@@ -231,8 +238,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/geographies/:geography_id/meta'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
-      req: GeographyAuthorApiRequest<GeographyMetadata>,
-      res: PutGeographyMetadataResponse,
+      req: GeographyAuthorApiPutGeographyMetadataRequest,
+      res: GeographyAuthorApiPutGeographyMetadataResponse,
       next: express.NextFunction
     ) => {
       const geography_metadata = req.body
@@ -262,8 +269,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/geographies/:geography_id/publish'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:publish')),
     async (
-      req: GeographyAuthorApiRequest & ApiRequestParams<'geography_id'>,
-      res: PutGeographyResponse,
+      req: GeographyAuthorApiPublishGeographyRequest,
+      res: GeographyAuthorApiPublishGeographyResponse,
       next: express.NextFunction
     ) => {
       const { geography_id } = req.params

--- a/packages/mds-geography-author/types.ts
+++ b/packages/mds-geography-author/types.ts
@@ -14,7 +14,14 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
+import {
+  ApiRequest,
+  ApiVersionedResponse,
+  ApiClaims,
+  ApiResponseLocals,
+  ApiRequestQuery,
+  ApiRequestParams
+} from '@mds-core/mds-api-server'
 import { GeographyMetadata, Geography, UUID } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
@@ -30,23 +37,39 @@ export type GeographyAuthorApiAccessTokenScopes =
   | 'geographies:write'
   | 'geographies:publish'
 
+export type GeographyAuthorApiGetGeographyMetadataRequest = GeographyAuthorApiRequest &
+  ApiRequestQuery<'get_published' | 'get_unpublished'>
+
+export type GeographyAuthorApiPostGeographyRequest = GeographyAuthorApiRequest<Geography>
+
+export type GeographyAuthorApiPutGeographyRequest = GeographyAuthorApiRequest<Geography>
+
+export type GeographyAuthorApiDeleteGeographyRequest = GeographyAuthorApiRequest & ApiRequestParams<'geography_id'>
+
+export type GeographyAuthorApiGetGeographyMetadatumRequest = GeographyAuthorApiRequest &
+  ApiRequestParams<'geography_id'>
+
+export type GeographyAuthorApiPutGeographyMetadataRequest = GeographyAuthorApiRequest<GeographyMetadata>
+
+export type GeographyAuthorApiPublishGeographyRequest = GeographyAuthorApiRequest & ApiRequestParams<'geography_id'>
+
 export type GeographyAuthorApiResponse<B = {}> = ApiVersionedResponse<GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION, B> &
   ApiResponseLocals<ApiClaims<GeographyAuthorApiAccessTokenScopes>>
 
-export type GetGeographyMetadatumResponse = GeographyAuthorApiResponse<{
+export type GeographyAuthorApiGetGeographyMetadatumResponse = GeographyAuthorApiResponse<{
   data: { geography_metadata: GeographyMetadata }
 }>
 
-export type GetGeographyMetadataResponse = GeographyAuthorApiResponse<{
+export type GeographyAuthorApiGetGeographyMetadataResponse = GeographyAuthorApiResponse<{
   data: { geography_metadata: GeographyMetadata[] }
 }>
 
-export type PostGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
+export type GeographyAuthorApiPostGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
 
-export type PutGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
-export type PublishGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
-export type PutGeographyMetadataResponse = GeographyAuthorApiResponse<{
+export type GeographyAuthorApiPutGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
+export type GeographyAuthorApiPublishGeographyResponse = GeographyAuthorApiResponse<{ data: { geography: Geography } }>
+export type GeographyAuthorApiPutGeographyMetadataResponse = GeographyAuthorApiResponse<{
   data: { geography_metadata: GeographyMetadata }
 }>
 
-export type DeleteGeographyResponse = GeographyAuthorApiResponse<{ data: { geography_id: UUID } }>
+export type GeographyAuthorApiDeleteGeographyResponse = GeographyAuthorApiResponse<{ data: { geography_id: UUID } }>

--- a/packages/mds-geography-author/types.ts
+++ b/packages/mds-geography-author/types.ts
@@ -14,14 +14,14 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
 import { GeographyMetadata, Geography, UUID } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION = typeof GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS[number]
 export const [GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION] = GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSIONS
 
-export type GeographyAuthorApiRequest = ApiRequest
+export type GeographyAuthorApiRequest<B = {}> = ApiRequest<B>
 
 export type GeographyAuthorApiAccessTokenScopes =
   | 'geographies:read'
@@ -30,11 +30,8 @@ export type GeographyAuthorApiAccessTokenScopes =
   | 'geographies:write'
   | 'geographies:publish'
 
-export type GeographyAuthorApiResponse<TBody extends {}> = ApiVersionedResponse<
-  GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION,
-  ApiClaims<GeographyAuthorApiAccessTokenScopes>,
-  TBody
->
+export type GeographyAuthorApiResponse<B = {}> = ApiVersionedResponse<GEOGRAPHY_AUTHOR_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<GeographyAuthorApiAccessTokenScopes>>
 
 export type GetGeographyMetadatumResponse = GeographyAuthorApiResponse<{
   data: { geography_metadata: GeographyMetadata }

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -4,7 +4,14 @@ import db from '@mds-core/mds-db'
 import { pathsFor, ServerError, NotFoundError, InsufficientPermissionsError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 
-import { checkAccess, AccessTokenScopeValidator, ApiResponse, ApiRequest } from '@mds-core/mds-api-server'
+import {
+  checkAccess,
+  AccessTokenScopeValidator,
+  ApiResponse,
+  ApiRequest,
+  ApiRequestParams,
+  ApiRequestQuery
+} from '@mds-core/mds-api-server'
 import { GeographyApiVersionMiddleware } from './middleware'
 import {
   GeographyApiAccessTokenScopes,
@@ -24,7 +31,11 @@ function api(app: express.Express): express.Express {
     checkGeographyApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
-    async (req: GeographyApiRequest, res: GetGeographyResponse, next: express.NextFunction) => {
+    async (
+      req: GeographyApiRequest & ApiRequestParams<'geography_id'>,
+      res: GetGeographyResponse,
+      next: express.NextFunction
+    ) => {
       const { geography_id } = req.params
       try {
         const geography = await db.readSingleGeography(geography_id)
@@ -52,7 +63,11 @@ function api(app: express.Express): express.Express {
     checkGeographyApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
-    async (req: GeographyApiRequest, res: GetGeographiesResponse, next: express.NextFunction) => {
+    async (
+      req: GeographyApiRequest & ApiRequestQuery<'summary' | 'get_published' | 'get_unpublished'>,
+      res: GetGeographiesResponse,
+      next: express.NextFunction
+    ) => {
       const summary = req.query.summary === 'true'
       const { get_published, get_unpublished } = req.query
       const params = {

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -4,20 +4,14 @@ import db from '@mds-core/mds-db'
 import { pathsFor, ServerError, NotFoundError, InsufficientPermissionsError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 
-import {
-  checkAccess,
-  AccessTokenScopeValidator,
-  ApiResponse,
-  ApiRequest,
-  ApiRequestParams,
-  ApiRequestQuery
-} from '@mds-core/mds-api-server'
+import { checkAccess, AccessTokenScopeValidator, ApiResponse, ApiRequest } from '@mds-core/mds-api-server'
 import { GeographyApiVersionMiddleware } from './middleware'
 import {
   GeographyApiAccessTokenScopes,
-  GeographyApiRequest,
-  GetGeographyResponse,
-  GetGeographiesResponse
+  GeographyApiGetGeographyResponse,
+  GeographyApiGetGeographiesResponse,
+  GeographyApiGetGeographyRequest,
+  GeographyApiGetGeographiesRequest
 } from './types'
 
 const checkGeographyApiAccess = (validator: AccessTokenScopeValidator<GeographyApiAccessTokenScopes>) =>
@@ -31,11 +25,7 @@ function api(app: express.Express): express.Express {
     checkGeographyApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
-    async (
-      req: GeographyApiRequest & ApiRequestParams<'geography_id'>,
-      res: GetGeographyResponse,
-      next: express.NextFunction
-    ) => {
+    async (req: GeographyApiGetGeographyRequest, res: GeographyApiGetGeographyResponse, next: express.NextFunction) => {
       const { geography_id } = req.params
       try {
         const geography = await db.readSingleGeography(geography_id)
@@ -64,8 +54,8 @@ function api(app: express.Express): express.Express {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
     async (
-      req: GeographyApiRequest & ApiRequestQuery<'summary' | 'get_published' | 'get_unpublished'>,
-      res: GetGeographiesResponse,
+      req: GeographyApiGetGeographiesRequest,
+      res: GeographyApiGetGeographiesResponse,
       next: express.NextFunction
     ) => {
       const summary = req.query.summary === 'true'

--- a/packages/mds-geography/types.ts
+++ b/packages/mds-geography/types.ts
@@ -14,25 +14,22 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
 import { Geography, GeographySummary } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type GEOGRAPHY_API_SUPPORTED_VERSION = typeof GEOGRAPHY_API_SUPPORTED_VERSIONS[number]
 export const [GEOGRAPHY_API_DEFAULT_VERSION] = GEOGRAPHY_API_SUPPORTED_VERSIONS
 
-export type GeographyApiRequest = ApiRequest
+export type GeographyApiRequest<B = {}> = ApiRequest<B>
 
 export type GeographyApiAccessTokenScopes =
   | 'geographies:read'
   | 'geographies:read:unpublished'
   | 'geographies:read:published'
 
-export type GeographyApiResponse<TBody extends {}> = ApiVersionedResponse<
-  GEOGRAPHY_API_SUPPORTED_VERSION,
-  ApiClaims<GeographyApiAccessTokenScopes>,
-  TBody
->
+export type GeographyApiResponse<B = {}> = ApiVersionedResponse<GEOGRAPHY_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<GeographyApiAccessTokenScopes>>
 
 export type GetGeographyResponse = GeographyApiResponse<{
   data: { geographies: Geography[] | GeographySummary[] } | { geography: Geography | GeographySummary }

--- a/packages/mds-geography/types.ts
+++ b/packages/mds-geography/types.ts
@@ -14,7 +14,14 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
+import {
+  ApiRequest,
+  ApiVersionedResponse,
+  ApiClaims,
+  ApiResponseLocals,
+  ApiRequestParams,
+  ApiRequestQuery
+} from '@mds-core/mds-api-server'
 import { Geography, GeographySummary } from '@mds-core/mds-types'
 
 export const GEOGRAPHY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
@@ -22,6 +29,11 @@ export type GEOGRAPHY_API_SUPPORTED_VERSION = typeof GEOGRAPHY_API_SUPPORTED_VER
 export const [GEOGRAPHY_API_DEFAULT_VERSION] = GEOGRAPHY_API_SUPPORTED_VERSIONS
 
 export type GeographyApiRequest<B = {}> = ApiRequest<B>
+
+export type GeographyApiGetGeographyRequest = GeographyApiRequest & ApiRequestParams<'geography_id'>
+
+export type GeographyApiGetGeographiesRequest = GeographyApiRequest &
+  ApiRequestQuery<'summary' | 'get_published' | 'get_unpublished'>
 
 export type GeographyApiAccessTokenScopes =
   | 'geographies:read'
@@ -31,10 +43,10 @@ export type GeographyApiAccessTokenScopes =
 export type GeographyApiResponse<B = {}> = ApiVersionedResponse<GEOGRAPHY_API_SUPPORTED_VERSION, B> &
   ApiResponseLocals<ApiClaims<GeographyApiAccessTokenScopes>>
 
-export type GetGeographyResponse = GeographyApiResponse<{
+export type GeographyApiGetGeographyResponse = GeographyApiResponse<{
   data: { geographies: Geography[] | GeographySummary[] } | { geography: Geography | GeographySummary }
 }>
 
-export type GetGeographiesResponse = GeographyApiResponse<{
+export type GeographyApiGetGeographiesResponse = GeographyApiResponse<{
   data: { geographies: Geography[] | GeographySummary[] }
 }>

--- a/packages/mds-jurisdiction/@types/index.ts
+++ b/packages/mds-jurisdiction/@types/index.ts
@@ -14,20 +14,16 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
-import { Params, ParamsDictionary } from 'express-serve-static-core'
+import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
 
 export const JURISDICTION_API_SUPPORTED_VERSIONS = ['0.1.0'] as const
 export type JURISDICTION_API_SUPPORTED_VERSION = typeof JURISDICTION_API_SUPPORTED_VERSIONS[number]
 export const [JURISDICTION_API_DEFAULT_VERSION] = JURISDICTION_API_SUPPORTED_VERSIONS
 
 // Allow adding type definitions for Express Request objects
-export type JurisdictionApiRequest<P extends Params = ParamsDictionary> = ApiRequest<P>
+export type JurisdictionApiRequest<B = {}> = ApiRequest<B>
 
 export type JurisdictionApiAccessTokenScopes = 'jurisdictions:read' | 'jurisdictions:read:claim' | 'jurisdictions:write'
 
-export type JurisdictionApiResponse<TBody extends {}> = ApiVersionedResponse<
-  JURISDICTION_API_SUPPORTED_VERSION,
-  ApiClaims<JurisdictionApiAccessTokenScopes>,
-  TBody
->
+export type JurisdictionApiResponse<B = {}> = ApiVersionedResponse<JURISDICTION_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<JurisdictionApiAccessTokenScopes>>

--- a/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
@@ -22,16 +22,22 @@ import {
 import { isServiceError } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
+export type JurisdictionApiCreateJurisdictionRequest = JurisdictionApiRequest<
+  CreateJurisdictionDomainModel | CreateJurisdictionDomainModel[]
+>
+
+export type JurisdictionApiCreateJurisdictionResponse = JurisdictionApiResponse<
+  | {
+      jurisdiction: JurisdictionDomainModel
+    }
+  | {
+      jurisdictions: JurisdictionDomainModel[]
+    }
+>
+
 export const CreateJurisdictionHandler = async (
-  req: JurisdictionApiRequest<CreateJurisdictionDomainModel | CreateJurisdictionDomainModel[]>,
-  res: JurisdictionApiResponse<
-    | {
-        jurisdiction: JurisdictionDomainModel
-      }
-    | {
-        jurisdictions: JurisdictionDomainModel[]
-      }
-  >
+  req: JurisdictionApiCreateJurisdictionRequest,
+  res: JurisdictionApiCreateJurisdictionResponse
 ) => {
   try {
     const jurisdictions = await JurisdictionServiceClient.createJurisdictions(

--- a/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/create-jurisdiction.ts
@@ -22,20 +22,17 @@ import {
 import { isServiceError } from '@mds-core/mds-service-helpers'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
-interface CreateJurisdictionRequest extends JurisdictionApiRequest {
-  body: CreateJurisdictionDomainModel | CreateJurisdictionDomainModel[]
-}
-
-type CreateJurisdictionResponse = JurisdictionApiResponse<
-  | {
-      jurisdiction: JurisdictionDomainModel
-    }
-  | {
-      jurisdictions: JurisdictionDomainModel[]
-    }
->
-
-export const CreateJurisdictionHandler = async (req: CreateJurisdictionRequest, res: CreateJurisdictionResponse) => {
+export const CreateJurisdictionHandler = async (
+  req: JurisdictionApiRequest<CreateJurisdictionDomainModel | CreateJurisdictionDomainModel[]>,
+  res: JurisdictionApiResponse<
+    | {
+        jurisdiction: JurisdictionDomainModel
+      }
+    | {
+        jurisdictions: JurisdictionDomainModel[]
+      }
+  >
+) => {
   try {
     const jurisdictions = await JurisdictionServiceClient.createJurisdictions(
       Array.isArray(req.body) ? req.body : [req.body]

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -14,19 +14,15 @@
     limitations under the License.
  */
 
-import {
-  JurisdictionServiceClient,
-  JurisdictionDomainModel,
-  JurisdictionIdType
-} from '@mds-core/mds-jurisdiction-service'
+import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { isServiceError } from '@mds-core/mds-service-helpers'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
-type DeleteJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }>
-
-type DeleteJurisdictionResponse = JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
-
-export const DeleteJurisdictionHandler = async (req: DeleteJurisdictionRequest, res: DeleteJurisdictionResponse) => {
+export const DeleteJurisdictionHandler = async (
+  req: JurisdictionApiRequest & ApiRequestParams<'jurisdiction_id'>,
+  res: JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
+) => {
   const { jurisdiction_id } = req.params
   try {
     const result = await JurisdictionServiceClient.deleteJurisdiction(jurisdiction_id)

--- a/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/delete-jurisdiction.ts
@@ -19,9 +19,15 @@ import { isServiceError } from '@mds-core/mds-service-helpers'
 import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
+export type JurisdictionApiDeleteJurisdictionRequest = JurisdictionApiRequest & ApiRequestParams<'jurisdiction_id'>
+
+export type JurisdictionApiDeleteJurisdictionResponse = JurisdictionApiResponse<
+  Pick<JurisdictionDomainModel, 'jurisdiction_id'>
+>
+
 export const DeleteJurisdictionHandler = async (
-  req: JurisdictionApiRequest & ApiRequestParams<'jurisdiction_id'>,
-  res: JurisdictionApiResponse<Pick<JurisdictionDomainModel, 'jurisdiction_id'>>
+  req: JurisdictionApiDeleteJurisdictionRequest,
+  res: JurisdictionApiDeleteJurisdictionResponse
 ) => {
   const { jurisdiction_id } = req.params
   try {

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -14,25 +14,18 @@
     limitations under the License.
  */
 
-import {
-  JurisdictionServiceClient,
-  JurisdictionDomainModel,
-  JurisdictionIdType
-} from '@mds-core/mds-jurisdiction-service'
+import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { AuthorizationError } from '@mds-core/mds-utils'
 import { isServiceError } from '@mds-core/mds-service-helpers'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiQuery } from '@mds-core/mds-api-server'
+import { ApiRequestQuery, ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../@types'
 import { HasJurisdictionClaim } from './utils'
 
-type GetJurisdictionRequest = JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }> & ApiQuery<'effective'>
-
-type GetJurisdictionResponse = JurisdictionApiResponse<{
-  jurisdiction: JurisdictionDomainModel
-}>
-
-export const GetJurisdictionHandler = async (req: GetJurisdictionRequest, res: GetJurisdictionResponse) => {
+export const GetJurisdictionHandler = async (
+  req: JurisdictionApiRequest & ApiRequestParams<'jurisdiction_id'> & ApiRequestQuery<'effective'>,
+  res: JurisdictionApiResponse<{ jurisdiction: JurisdictionDomainModel }>
+) => {
   try {
     const { jurisdiction_id } = req.params
     const { effective } = parseRequest(req, { parser: Number }).query('effective')

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -22,9 +22,15 @@ import { ApiRequestQuery, ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiResponse, JurisdictionApiRequest } from '../@types'
 import { HasJurisdictionClaim } from './utils'
 
+export type JurisdictionApiGetJurisdictionRequest = JurisdictionApiRequest &
+  ApiRequestParams<'jurisdiction_id'> &
+  ApiRequestQuery<'effective'>
+
+export type JurisdictionApiGetJurisdictionResponse = JurisdictionApiResponse<{ jurisdiction: JurisdictionDomainModel }>
+
 export const GetJurisdictionHandler = async (
-  req: JurisdictionApiRequest & ApiRequestParams<'jurisdiction_id'> & ApiRequestQuery<'effective'>,
-  res: JurisdictionApiResponse<{ jurisdiction: JurisdictionDomainModel }>
+  req: JurisdictionApiGetJurisdictionRequest,
+  res: JurisdictionApiGetJurisdictionResponse
 ) => {
   try {
     const { jurisdiction_id } = req.params

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -20,9 +20,15 @@ import { ApiRequestQuery } from '@mds-core/mds-api-server'
 import { HasJurisdictionClaim } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
+export type JurisdictionApiGetJurisdictionsRequest = JurisdictionApiRequest & ApiRequestQuery<'effective'>
+
+export type JurisdictionApiGetJurisdictionsResponse = JurisdictionApiResponse<{
+  jurisdictions: JurisdictionDomainModel[]
+}>
+
 export const GetJurisdictionsHandler = async (
-  req: JurisdictionApiRequest & ApiRequestQuery<'effective'>,
-  res: JurisdictionApiResponse<{ jurisdictions: JurisdictionDomainModel[] }>
+  req: JurisdictionApiGetJurisdictionsRequest,
+  res: JurisdictionApiGetJurisdictionsResponse
 ) => {
   try {
     const { effective } = parseRequest(req, { parser: Number }).query('effective')

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -16,17 +16,14 @@
 
 import { JurisdictionServiceClient, JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiQuery } from '@mds-core/mds-api-server'
+import { ApiRequestQuery } from '@mds-core/mds-api-server'
 import { HasJurisdictionClaim } from './utils'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
-type GetJurisdictionsRequest = JurisdictionApiRequest & ApiQuery<'effective'>
-
-type GetJurisdictionsResponse = JurisdictionApiResponse<{
-  jurisdictions: JurisdictionDomainModel[]
-}>
-
-export const GetJurisdictionsHandler = async (req: GetJurisdictionsRequest, res: GetJurisdictionsResponse) => {
+export const GetJurisdictionsHandler = async (
+  req: JurisdictionApiRequest & ApiRequestQuery<'effective'>,
+  res: JurisdictionApiResponse<{ jurisdictions: JurisdictionDomainModel[] }>
+) => {
   try {
     const { effective } = parseRequest(req, { parser: Number }).query('effective')
     const jurisdictions = await JurisdictionServiceClient.getJurisdictions({ effective })

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -23,9 +23,16 @@ import { isServiceError } from '@mds-core/mds-service-helpers'
 import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
+export type JurisdictionApiUpdateJurisdictionRequest = JurisdictionApiRequest<UpdateJurisdictionDomainModel> &
+  ApiRequestParams<'jurisdiction_id'>
+
+export type JurisdictionApiUpdateJurisdictionResponse = JurisdictionApiResponse<{
+  jurisdiction: JurisdictionDomainModel
+}>
+
 export const UpdateJurisdictionHandler = async (
-  req: JurisdictionApiRequest<UpdateJurisdictionDomainModel> & ApiRequestParams<'jurisdiction_id'>,
-  res: JurisdictionApiResponse<{ jurisdiction: JurisdictionDomainModel }>
+  req: JurisdictionApiUpdateJurisdictionRequest,
+  res: JurisdictionApiUpdateJurisdictionResponse
 ) => {
   try {
     const { jurisdiction_id } = req.params

--- a/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/update-jurisdiction.ts
@@ -17,21 +17,16 @@
 import {
   UpdateJurisdictionDomainModel,
   JurisdictionServiceClient,
-  JurisdictionDomainModel,
-  JurisdictionIdType
+  JurisdictionDomainModel
 } from '@mds-core/mds-jurisdiction-service'
 import { isServiceError } from '@mds-core/mds-service-helpers'
+import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { JurisdictionApiRequest, JurisdictionApiResponse } from '../@types'
 
-interface UpdateJurisdictionRequest extends JurisdictionApiRequest<{ jurisdiction_id: JurisdictionIdType }> {
-  body: UpdateJurisdictionDomainModel
-}
-
-type UpdateJurisdictionResponse = JurisdictionApiResponse<{
-  jurisdiction: JurisdictionDomainModel
-}>
-
-export const UpdateJurisdictionHandler = async (req: UpdateJurisdictionRequest, res: UpdateJurisdictionResponse) => {
+export const UpdateJurisdictionHandler = async (
+  req: JurisdictionApiRequest<UpdateJurisdictionDomainModel> & ApiRequestParams<'jurisdiction_id'>,
+  res: JurisdictionApiResponse<{ jurisdiction: JurisdictionDomainModel }>
+) => {
   try {
     const { jurisdiction_id } = req.params
     const { version } = res.locals

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -31,26 +31,24 @@ import db from '@mds-core/mds-db'
 import { policyValidationDetails } from '@mds-core/mds-schema-validators'
 import logger from '@mds-core/mds-logger'
 
-import {
-  checkAccess,
-  AccessTokenScopeValidator,
-  ApiRequest,
-  ApiResponse,
-  ApiRequestParams,
-  ApiRequestQuery
-} from '@mds-core/mds-api-server'
-import { Policy, PolicyMetadata } from '@mds-core/mds-types'
+import { checkAccess, AccessTokenScopeValidator, ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
 import { PolicyAuthorApiVersionMiddleware } from './middleware/policy-author-api-version'
 import {
-  PolicyAuthorApiRequest,
-  PostPolicyResponse,
-  EditPolicyResponse,
-  DeletePolicyResponse,
+  PolicyAuthorApiPostPolicyResponse,
+  PolicyAuthorApiEditPolicyResponse,
+  PolicyAuthorApiDeletePolicyResponse,
   PolicyAuthorApiAccessTokenScopes,
-  PublishPolicyResponse,
-  EditPolicyMetadataResponse,
-  GetPolicyMetadatumResponse,
-  GetPolicyMetadataResponse
+  PolicyAuthorApiPublishPolicyResponse,
+  PolicyAuthorApiEditPolicyMetadataResponse,
+  PolicyAuthorApiGetPolicyMetadatumResponse,
+  PolicyAuthorApiGetPolicyMetadataResponse,
+  PolicyAuthorApiPostPolicyRequest,
+  PolicyAuthorApiPublishPolicyRequest,
+  PolicyAuthorApiEditPolicyRequest,
+  PolicyAuthorApiDeletePolicyRequest,
+  PolicyAuthorApiGetPolicyMetadataRequest,
+  PolicyAuthorApiGetPolicyMetadatumRequest,
+  PolicyAuthorApiEditPolicyMetadataRequest
 } from './types'
 
 const checkPolicyAuthorApiAccess = (validator: AccessTokenScopeValidator<PolicyAuthorApiAccessTokenScopes>) =>
@@ -62,7 +60,11 @@ function api(app: express.Express): express.Express {
   app.post(
     pathsFor('/policies'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
-    async (req: PolicyAuthorApiRequest<Policy>, res: PostPolicyResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiPostPolicyRequest,
+      res: PolicyAuthorApiPostPolicyResponse,
+      next: express.NextFunction
+    ) => {
       const policy = { policy_id: uuid(), ...req.body }
 
       const details = policyValidationDetails(policy)
@@ -88,8 +90,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/policies/:policy_id/publish'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:publish')),
     async (
-      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
-      res: PublishPolicyResponse,
+      req: PolicyAuthorApiPublishPolicyRequest,
+      res: PolicyAuthorApiPublishPolicyResponse,
       next: express.NextFunction
     ) => {
       const { policy_id } = req.params
@@ -122,7 +124,11 @@ function api(app: express.Express): express.Express {
   app.put(
     pathsFor('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
-    async (req: PolicyAuthorApiRequest<Policy>, res: EditPolicyResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiEditPolicyRequest,
+      res: PolicyAuthorApiEditPolicyResponse,
+      next: express.NextFunction
+    ) => {
       const policy = req.body
 
       const details = policyValidationDetails(policy)
@@ -152,8 +158,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:delete')),
     async (
-      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
-      res: DeletePolicyResponse,
+      req: PolicyAuthorApiDeletePolicyRequest,
+      res: PolicyAuthorApiDeletePolicyResponse,
       next: express.NextFunction
     ) => {
       const { policy_id } = req.params
@@ -174,8 +180,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/policies/meta/'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
     async (
-      req: PolicyAuthorApiRequest & ApiRequestQuery<'get_published' | 'get_unpublished'>,
-      res: GetPolicyMetadataResponse,
+      req: PolicyAuthorApiGetPolicyMetadataRequest,
+      res: PolicyAuthorApiGetPolicyMetadataResponse,
       next: express.NextFunction
     ) => {
       const { get_published, get_unpublished } = req.query
@@ -214,8 +220,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
     async (
-      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
-      res: GetPolicyMetadatumResponse,
+      req: PolicyAuthorApiGetPolicyMetadatumRequest,
+      res: PolicyAuthorApiGetPolicyMetadatumResponse,
       next: express.NextFunction
     ) => {
       const { policy_id } = req.params
@@ -244,8 +250,8 @@ function api(app: express.Express): express.Express {
     pathsFor('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
     async (
-      req: PolicyAuthorApiRequest<PolicyMetadata>,
-      res: EditPolicyMetadataResponse,
+      req: PolicyAuthorApiEditPolicyMetadataRequest,
+      res: PolicyAuthorApiEditPolicyMetadataResponse,
       next: express.NextFunction
     ) => {
       const policy_metadata = req.body

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -31,7 +31,15 @@ import db from '@mds-core/mds-db'
 import { policyValidationDetails } from '@mds-core/mds-schema-validators'
 import logger from '@mds-core/mds-logger'
 
-import { checkAccess, AccessTokenScopeValidator, ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
+import {
+  checkAccess,
+  AccessTokenScopeValidator,
+  ApiRequest,
+  ApiResponse,
+  ApiRequestParams,
+  ApiRequestQuery
+} from '@mds-core/mds-api-server'
+import { Policy, PolicyMetadata } from '@mds-core/mds-types'
 import { PolicyAuthorApiVersionMiddleware } from './middleware/policy-author-api-version'
 import {
   PolicyAuthorApiRequest,
@@ -40,9 +48,9 @@ import {
   DeletePolicyResponse,
   PolicyAuthorApiAccessTokenScopes,
   PublishPolicyResponse,
-  GetPolicyMetadataResponse,
+  EditPolicyMetadataResponse,
   GetPolicyMetadatumResponse,
-  EditPolicyMetadataResponse
+  GetPolicyMetadataResponse
 } from './types'
 
 const checkPolicyAuthorApiAccess = (validator: AccessTokenScopeValidator<PolicyAuthorApiAccessTokenScopes>) =>
@@ -54,7 +62,7 @@ function api(app: express.Express): express.Express {
   app.post(
     pathsFor('/policies'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
-    async (req: PolicyAuthorApiRequest, res: PostPolicyResponse, next: express.NextFunction) => {
+    async (req: PolicyAuthorApiRequest<Policy>, res: PostPolicyResponse, next: express.NextFunction) => {
       const policy = { policy_id: uuid(), ...req.body }
 
       const details = policyValidationDetails(policy)
@@ -79,7 +87,11 @@ function api(app: express.Express): express.Express {
   app.post(
     pathsFor('/policies/:policy_id/publish'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:publish')),
-    async (req: PolicyAuthorApiRequest, res: PublishPolicyResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
+      res: PublishPolicyResponse,
+      next: express.NextFunction
+    ) => {
       const { policy_id } = req.params
       try {
         const policy = await db.publishPolicy(policy_id)
@@ -110,7 +122,7 @@ function api(app: express.Express): express.Express {
   app.put(
     pathsFor('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
-    async (req: PolicyAuthorApiRequest, res: EditPolicyResponse, next: express.NextFunction) => {
+    async (req: PolicyAuthorApiRequest<Policy>, res: EditPolicyResponse, next: express.NextFunction) => {
       const policy = req.body
 
       const details = policyValidationDetails(policy)
@@ -139,7 +151,11 @@ function api(app: express.Express): express.Express {
   app.delete(
     pathsFor('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:delete')),
-    async (req: PolicyAuthorApiRequest, res: DeletePolicyResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
+      res: DeletePolicyResponse,
+      next: express.NextFunction
+    ) => {
       const { policy_id } = req.params
       try {
         await db.deletePolicy(policy_id)
@@ -157,7 +173,11 @@ function api(app: express.Express): express.Express {
   app.get(
     pathsFor('/policies/meta/'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
-    async (req: PolicyAuthorApiRequest, res: GetPolicyMetadataResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiRequest & ApiRequestQuery<'get_published' | 'get_unpublished'>,
+      res: GetPolicyMetadataResponse,
+      next: express.NextFunction
+    ) => {
       const { get_published, get_unpublished } = req.query
       const params = {
         get_published: get_published ? get_published === 'true' : null,
@@ -193,7 +213,11 @@ function api(app: express.Express): express.Express {
   app.get(
     pathsFor('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
-    async (req: PolicyAuthorApiRequest, res: GetPolicyMetadatumResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>,
+      res: GetPolicyMetadatumResponse,
+      next: express.NextFunction
+    ) => {
       const { policy_id } = req.params
 
       try {
@@ -219,7 +243,11 @@ function api(app: express.Express): express.Express {
   app.put(
     pathsFor('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
-    async (req: PolicyAuthorApiRequest, res: EditPolicyMetadataResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyAuthorApiRequest<PolicyMetadata>,
+      res: EditPolicyMetadataResponse,
+      next: express.NextFunction
+    ) => {
       const policy_metadata = req.body
       try {
         await db.updatePolicyMetadata(policy_metadata)

--- a/packages/mds-policy-author/types.ts
+++ b/packages/mds-policy-author/types.ts
@@ -1,11 +1,27 @@
 import { Policy, UUID, PolicyMetadata } from '@mds-core/mds-types'
-import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
+import {
+  ApiRequest,
+  ApiVersionedResponse,
+  ApiClaims,
+  ApiResponseLocals,
+  ApiRequestParams,
+  ApiRequestQuery
+} from '@mds-core/mds-api-server'
 
 export const POLICY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type POLICY_AUTHOR_API_SUPPORTED_VERSION = typeof POLICY_AUTHOR_API_SUPPORTED_VERSIONS[number]
 export const [POLICY_AUTHOR_API_DEFAULT_VERSION] = POLICY_AUTHOR_API_SUPPORTED_VERSIONS
 
 export type PolicyAuthorApiRequest<B = {}> = ApiRequest<B>
+
+export type PolicyAuthorApiPostPolicyRequest = PolicyAuthorApiRequest<Policy>
+export type PolicyAuthorApiPublishPolicyRequest = PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>
+export type PolicyAuthorApiEditPolicyRequest = PolicyAuthorApiRequest<Policy>
+export type PolicyAuthorApiDeletePolicyRequest = PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>
+export type PolicyAuthorApiGetPolicyMetadataRequest = PolicyAuthorApiRequest &
+  ApiRequestQuery<'get_published' | 'get_unpublished'>
+export type PolicyAuthorApiGetPolicyMetadatumRequest = PolicyAuthorApiRequest & ApiRequestParams<'policy_id'>
+export type PolicyAuthorApiEditPolicyMetadataRequest = PolicyAuthorApiRequest<PolicyMetadata>
 
 export type PolicyAuthorApiAccessTokenScopes =
   | 'policies:read'
@@ -16,13 +32,19 @@ export type PolicyAuthorApiAccessTokenScopes =
 type PolicyAuthorApiResponse<B = {}> = ApiVersionedResponse<POLICY_AUTHOR_API_SUPPORTED_VERSION, B> &
   ApiResponseLocals<ApiClaims<PolicyAuthorApiAccessTokenScopes>>
 
-export type GetPoliciesResponse = PolicyAuthorApiResponse<{ data: { policies: Policy[] } }>
-export type GetPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
-export type PostPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
-export type PublishPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
-export type EditPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
-export type DeletePolicyResponse = PolicyAuthorApiResponse<{ data: { policy_id: UUID } }>
+export type PolicyAuthorApiGetPoliciesResponse = PolicyAuthorApiResponse<{ data: { policies: Policy[] } }>
+export type PolicyAuthorApiGetPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PolicyAuthorApiPostPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PolicyAuthorApiPublishPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PolicyAuthorApiEditPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>
+export type PolicyAuthorApiDeletePolicyResponse = PolicyAuthorApiResponse<{ data: { policy_id: UUID } }>
 
-export type GetPolicyMetadatumResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata } }>
-export type GetPolicyMetadataResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata[] } }>
-export type EditPolicyMetadataResponse = PolicyAuthorApiResponse<{ data: { policy_metadata: PolicyMetadata } }>
+export type PolicyAuthorApiGetPolicyMetadatumResponse = PolicyAuthorApiResponse<{
+  data: { policy_metadata: PolicyMetadata }
+}>
+export type PolicyAuthorApiGetPolicyMetadataResponse = PolicyAuthorApiResponse<{
+  data: { policy_metadata: PolicyMetadata[] }
+}>
+export type PolicyAuthorApiEditPolicyMetadataResponse = PolicyAuthorApiResponse<{
+  data: { policy_metadata: PolicyMetadata }
+}>

--- a/packages/mds-policy-author/types.ts
+++ b/packages/mds-policy-author/types.ts
@@ -1,11 +1,11 @@
 import { Policy, UUID, PolicyMetadata } from '@mds-core/mds-types'
-import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
 
 export const POLICY_AUTHOR_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type POLICY_AUTHOR_API_SUPPORTED_VERSION = typeof POLICY_AUTHOR_API_SUPPORTED_VERSIONS[number]
 export const [POLICY_AUTHOR_API_DEFAULT_VERSION] = POLICY_AUTHOR_API_SUPPORTED_VERSIONS
 
-export type PolicyAuthorApiRequest = ApiRequest
+export type PolicyAuthorApiRequest<B = {}> = ApiRequest<B>
 
 export type PolicyAuthorApiAccessTokenScopes =
   | 'policies:read'
@@ -13,11 +13,8 @@ export type PolicyAuthorApiAccessTokenScopes =
   | 'policies:publish'
   | 'policies:delete'
 
-type PolicyAuthorApiResponse<TBody extends {}> = ApiVersionedResponse<
-  POLICY_AUTHOR_API_SUPPORTED_VERSION,
-  ApiClaims<PolicyAuthorApiAccessTokenScopes>,
-  TBody
->
+type PolicyAuthorApiResponse<B = {}> = ApiVersionedResponse<POLICY_AUTHOR_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<PolicyAuthorApiAccessTokenScopes>>
 
 export type GetPoliciesResponse = PolicyAuthorApiResponse<{ data: { policies: Policy[] } }>
 export type GetPolicyResponse = PolicyAuthorApiResponse<{ data: { policy: Policy } }>

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -21,8 +21,15 @@ import db from '@mds-core/mds-db'
 import { now, pathsFor, NotFoundError, isUUID, BadParamsError, ServerError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiRequest, ApiResponse, ApiRequestQuery, ApiRequestParams } from '@mds-core/mds-api-server'
-import { PolicyApiRequest, PolicyApiResponse, GetPoliciesResponse, GetPolicyResponse } from './types'
+import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
+import {
+  PolicyApiRequest,
+  PolicyApiResponse,
+  PolicyApiGetPoliciesResponse,
+  PolicyApiGetPolicyResponse,
+  PolicyApiGetPoliciesRequest,
+  PolicyApiGetPolicyRequest
+} from './types'
 import { PolicyApiVersionMiddleware } from './middleware'
 
 function api(app: express.Express): express.Express {
@@ -67,11 +74,7 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/policies'),
-    async (
-      req: PolicyApiRequest & ApiRequestQuery<'start_date' | 'end_date'>,
-      res: GetPoliciesResponse,
-      next: express.NextFunction
-    ) => {
+    async (req: PolicyApiGetPoliciesRequest, res: PolicyApiGetPoliciesResponse, next: express.NextFunction) => {
       const { start_date = now(), end_date = now() } = req.query
       const { scopes } = res.locals
 
@@ -121,11 +124,7 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/policies/:policy_id'),
-    async (
-      req: PolicyApiRequest & ApiRequestParams<'policy_id'>,
-      res: GetPolicyResponse,
-      next: express.NextFunction
-    ) => {
+    async (req: PolicyApiGetPolicyRequest, res: PolicyApiGetPolicyResponse, next: express.NextFunction) => {
       const { policy_id } = req.params
       const { scopes } = res.locals
 

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -21,7 +21,7 @@ import db from '@mds-core/mds-db'
 import { now, pathsFor, NotFoundError, isUUID, BadParamsError, ServerError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 import { parseRequest } from '@mds-core/mds-api-helpers'
-import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiResponse, ApiRequestQuery, ApiRequestParams } from '@mds-core/mds-api-server'
 import { PolicyApiRequest, PolicyApiResponse, GetPoliciesResponse, GetPolicyResponse } from './types'
 import { PolicyApiVersionMiddleware } from './middleware'
 
@@ -67,7 +67,11 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/policies'),
-    async (req: PolicyApiRequest, res: GetPoliciesResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyApiRequest & ApiRequestQuery<'start_date' | 'end_date'>,
+      res: GetPoliciesResponse,
+      next: express.NextFunction
+    ) => {
       const { start_date = now(), end_date = now() } = req.query
       const { scopes } = res.locals
 
@@ -117,7 +121,11 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/policies/:policy_id'),
-    async (req: PolicyApiRequest, res: GetPolicyResponse, next: express.NextFunction) => {
+    async (
+      req: PolicyApiRequest & ApiRequestParams<'policy_id'>,
+      res: GetPolicyResponse,
+      next: express.NextFunction
+    ) => {
       const { policy_id } = req.params
       const { scopes } = res.locals
 

--- a/packages/mds-policy/types.ts
+++ b/packages/mds-policy/types.ts
@@ -14,22 +14,19 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims } from '@mds-core/mds-api-server'
+import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
 import { Policy } from '@mds-core/mds-types'
 
 export const POLICY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
 export type POLICY_API_SUPPORTED_VERSION = typeof POLICY_API_SUPPORTED_VERSIONS[number]
 export const [POLICY_API_DEFAULT_VERSION] = POLICY_API_SUPPORTED_VERSIONS
 
-export type PolicyApiRequest = ApiRequest
+export type PolicyApiRequest<B = {}> = ApiRequest<B>
 
 export type PolicyApiAccessTokenScopes = 'policies:read'
 
-export type PolicyApiResponse<TBody = {}> = ApiVersionedResponse<
-  POLICY_API_SUPPORTED_VERSION,
-  ApiClaims<PolicyApiAccessTokenScopes>,
-  TBody
->
+export type PolicyApiResponse<B = {}> = ApiVersionedResponse<POLICY_API_SUPPORTED_VERSION, B> &
+  ApiResponseLocals<ApiClaims<PolicyApiAccessTokenScopes>>
 
 export type GetPolicyResponse = PolicyApiResponse<{ data: { policy: Policy } }>
 export type GetPoliciesResponse = PolicyApiResponse<{ data: { policies: Policy[] } }>

--- a/packages/mds-policy/types.ts
+++ b/packages/mds-policy/types.ts
@@ -14,7 +14,14 @@
     limitations under the License.
  */
 
-import { ApiRequest, ApiVersionedResponse, ApiClaims, ApiResponseLocals } from '@mds-core/mds-api-server'
+import {
+  ApiRequest,
+  ApiVersionedResponse,
+  ApiClaims,
+  ApiResponseLocals,
+  ApiRequestQuery,
+  ApiRequestParams
+} from '@mds-core/mds-api-server'
 import { Policy } from '@mds-core/mds-types'
 
 export const POLICY_API_SUPPORTED_VERSIONS = ['0.4.1'] as const
@@ -23,10 +30,13 @@ export const [POLICY_API_DEFAULT_VERSION] = POLICY_API_SUPPORTED_VERSIONS
 
 export type PolicyApiRequest<B = {}> = ApiRequest<B>
 
+export type PolicyApiGetPolicyRequest = PolicyApiRequest & ApiRequestParams<'policy_id'>
+export type PolicyApiGetPoliciesRequest = PolicyApiRequest & ApiRequestQuery<'start_date' | 'end_date'>
+
 export type PolicyApiAccessTokenScopes = 'policies:read'
 
 export type PolicyApiResponse<B = {}> = ApiVersionedResponse<POLICY_API_SUPPORTED_VERSION, B> &
   ApiResponseLocals<ApiClaims<PolicyApiAccessTokenScopes>>
 
-export type GetPolicyResponse = PolicyApiResponse<{ data: { policy: Policy } }>
-export type GetPoliciesResponse = PolicyApiResponse<{ data: { policies: Policy[] } }>
+export type PolicyApiGetPolicyResponse = PolicyApiResponse<{ data: { policy: Policy } }>
+export type PolicyApiGetPoliciesResponse = PolicyApiResponse<{ data: { policies: Policy[] } }>

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -133,6 +133,7 @@ export type NullableProperties<T extends object> = {
 }
 export type SingleOrArray<T> = T | T[]
 export type Optional<T, P extends keyof T> = Omit<T, P> & Partial<Pick<T, P>>
+export type NonEmptyArray<T> = [T, ...T[]]
 
 // Represents a row in the "devices" table
 export interface Device {


### PR DESCRIPTION
## 📚 Purpose

Express types are difficult to work with. This PR introduces some composable types that can be used instead.

**API Request**
```ts
// Specify request body (req.body)
ApiRequest<{ devices: Device[] }>

// Specify request body (req.body) and route/path parameters (req.params)
ApiRequest<{ devices: Device[] }> & ApiRequestParams<'provider_id'>

// Specify request body (req.body, route/path parameters (req.params), and query string parameters (req.query)
ApiRequest<{ devices: Device[] }> & ApiRequestParams<'provider_id'> & ApiRequestQuery<'vehicle_type'>
```
**API Response**
```ts
// Specify response body (res.send)
ApiResponse<{ count: number }>

// Specify response body (res.send) and locals (res.locals) (typically JWT claims, etc.)
ApiResponse<{ count: number }> & ApiResponseLocals<{ provider_id: UUID }>
```