### PR TITLE
Ensure entity name is used in Nats subject name, add telemetry test

### DIFF
--- a/packages/mds-web-sockets/tests/ws.spec.ts
+++ b/packages/mds-web-sockets/tests/ws.spec.ts
@@ -103,5 +103,31 @@ describe('Tests MDS-Web-Sockets', () => {
         return done
       })
     })
+
+    it('Subscribe and send telemetry', done => {
+      const client = new WebSocket(`ws://localhost:${process.env.PORT || 4000}`)
+      client.onopen = () => {
+        client.send(`AUTH%${ADMIN_AUTH}`)
+      }
+
+      client.on('message', data => {
+        if (data === 'AUTH%{"status":"Success"}') {
+          client.send('SUB%telemetry')
+          return
+        }
+
+        if (data === 'SUB%{"status":"Success"}') {
+          client.send(`PUSH%telemetry%${JSON.stringify({ foo: 'bar' })}`)
+          return
+        }
+
+        if (data === 'telemetry%{"foo":"bar"}') {
+          client.close()
+          return done()
+        }
+
+        return done
+      })
+    })
   })
 })

--- a/packages/mds-web-sockets/ws-server.ts
+++ b/packages/mds-web-sockets/ws-server.ts
@@ -104,7 +104,9 @@ export const WebSocketServer = async <T extends readonly string[]>(entityTypes?:
     await pushToClients(entity, JSON.stringify(msg.data))
   }
 
-  supportedEntities.forEach(async e => {
-    await stream.NatsStreamConsumer(`${TENANT_ID}.${e}`, processor).initialize()
-  })
+  await Promise.all(
+    (supportedEntities as readonly string[]).map(e =>
+      stream.NatsStreamConsumer(`${TENANT_ID}.${e}`, processor).initialize()
+    )
+  )
 }

--- a/packages/mds-web-sockets/ws-server.ts
+++ b/packages/mds-web-sockets/ws-server.ts
@@ -105,6 +105,6 @@ export const WebSocketServer = async <T extends readonly string[]>(entityTypes?:
   }
 
   supportedEntities.forEach(async e => {
-    await stream.NatsStreamConsumer(`${TENANT_ID}.event`, processor).initialize()
+    await stream.NatsStreamConsumer(`${TENANT_ID}.${e}`, processor).initialize()
   })
 }


### PR DESCRIPTION
## 📚 Purpose
This fixes a bug where the entity name passed in was not being used in the Nats subject.  It was still using hardcoded 'event' name.  Let me know if there's a straighforward way this can be tested to avoid.  I added an additional telemetry test which doesn't actually test this code path for the fix.

## 👌 Resolves:

## 📦 Impacts:
mds-web-sockets

## ✅ PR Checklist