### PR TITLE
[mds-agency] Add better agency validation error logs

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -72,7 +72,7 @@ export const registerVehicle = async (req: AgencyApiRequest, res: AgencyRegister
   try {
     isValidDevice(device)
   } catch (err) {
-    logger.info(`Device ValidationError for ${providerName(provider_id)}. Error: ${err}`)
+    logger.info(`Device ValidationError for ${providerName(provider_id)}. Error: ${JSON.stringify(err)}`)
   }
 
   const failure = badDevice(device)
@@ -230,7 +230,7 @@ export const submitVehicleEvent = async (req: AgencyApiRequest, res: AgencySubmi
   try {
     validateEvent(event)
   } catch (err) {
-    logger.info(`Event ValidationError for ${providerName(provider_id)}. Error: ${err}`)
+    logger.info(`Event ValidationError for ${providerName(provider_id)}. Error: ${JSON.stringify(err)}`)
   }
 
   if (event.telemetry) {
@@ -371,7 +371,7 @@ export const submitVehicleTelemetry = async (req: AgencyApiRequest, res: AgencyS
       try {
         isValidTelemetry(telemetry)
       } catch (err) {
-        logger.info(`Telemetry ValidationError for ${providerName(provider_id)}. Error: ${err}`)
+        logger.info(`Telemetry ValidationError for ${providerName(provider_id)}. Error: ${JSON.stringify(err)}`)
       }
 
       const bad_telemetry: ErrorObject | null = badTelemetry(telemetry)


### PR DESCRIPTION
## 📚 Purpose
Previously, the agency logs for validation errors weren't great: 
```
"Device ValidationError for JUMP. Error: ValidationError: invalid_value".
```
Now, they're significantly improved: 
```
INFO "Device ValidationError for c3e036fd-71cc-474e-aa46-c3750bc20115. Error: {\"name\":\"ValidationError\",\"reason\":\"invalid_value\",\"info\":{\"value\":{\"provider_id\":\"c3e036fd-71cc-474e-aa46-c3750bc20115\",\"device_id\":\"\",\"vehicle_id\":\"ec5547b3-76e2-4882-8816-16a746f5362f\",\"type\":\"car\",\"propulsion\":[\"combustion\"],\"year\":1990,\"mfgr\":\"foo inc\",\"model\":\"i date one\",\"recorded\":1591029035661,\"status\":\"removed\"},\"details\":\"value.device_id is required\"}}"
```

## 📦 Impacts:
mds-agency