### PR TITLE
Patch warning msg

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -1507,7 +1507,7 @@ check() {
         [[ "$(exists ${d})" != "0" ]] && usage "install: ${d}"
       done; unset d
       # todo: include cluster connection check where needed if not globally
-      kubectl cluster-info > /dev/null 2>&1 || usage "connect to kubernetes cluster";;
+      kubectl cluster-info > /dev/null 2>&1 || warn "Please connect to kubernetes cluster";;
     build | testIntegration)
       [[ "$(exists yarn)" != "0" ]] && bootstrap;;
     installCredentials) ;;


### PR DESCRIPTION
## 📚 Purpose
`yarn image` currently fails if your current k8s cluster can't be reached. I think this ought to be a warning rather than a hard failure.

## 👌 Resolves:
No JIRA tracking atm

## 📦 Impacts:
*mdsctl*