### PR TITLE
Fix NATS, Kafka endpoints in helm chart

### DIFF
--- a/helm/backend/requirements.lock
+++ b/helm/backend/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 10.5.7
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 8.6.4
+digest: sha256:064fe32ebc10dca2926cd5557958bac56a0d7095f678888d77fd995bfc64784e
+generated: "2020-05-20T14:37:10.7595032-07:00"

--- a/helm/backend/requirements.yaml
+++ b/helm/backend/requirements.yaml
@@ -1,0 +1,19 @@
+# !! File must end with empty line !!
+dependencies:
+  - name: redis
+    version: 10.5.7
+    repository: alias:stable
+    condition: redis.internal
+  - name: postgresql
+    version: 8.6.4
+    repository: alias:stable
+    condition: postgresql.internal
+  - name: kafka
+    version: 10.3.3
+    repository: alias:bitnami
+    condition: kafka.internal
+  - name: nats
+    version: 4.3.13
+    repository: alias:bitnami
+    condition: nats.internal
+

--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -90,11 +90,12 @@ spec:
             value: {{ $.Values.redis.port | quote }}
           {{- if $.Values.nats.enabled }}
           - name: NATS
-            value: {{ default "nats" $.Values.natsNamespace }}-nats-server.{{ default "nats" $.Values.natsNamespace }}.svc.cluster.local
-#            value: nats-cluster-mgmt.{{ default "nats" $.Values.natsNamespace }}.svc.cluster.local
+            value: {{ $.Values.nats.host }}
           {{- end }}
+          {{- if $.Values.kafka.enabled }}
           - name: KAFKA_HOST
-            value: host.docker.internal:9092
+            value: {{ $.Values.kafka.host }}:{{ $.Values.kafka.port }}
+          {{- end }}
           - name: TENANT_ID
           {{- if hasKey $.Values "tenantId" }}
             value: {{ $.Values.tenantId }}

--- a/helm/mds/values.yaml
+++ b/helm/mds/values.yaml
@@ -54,9 +54,6 @@ apis:
     pathPrefix: /geography-author
     version: latest
     migration: false
-nats:
-  enabled: true
-  credentials: false
 tenantId:
 timezone: America/Los_Angeles
 registry:
@@ -71,6 +68,14 @@ jwt:
   bypassInternal: false
   firstInstall: false
   audiences: []
+nats:
+  enabled: false
+  host:
+  credentials: false
+kafka:
+  enabled: false
+  host:
+  port: 9092
 postgresql:
   internal: true
   host:


### PR DESCRIPTION
Defaults to disabling NATS, Kafka (env vars will not show up in deployment).  If enabled, will use the hostnames provided in values.yaml.  Enabled with no host specified will cause a lot of errors in the logs, should be avoided.