### PR TITLE
Fix NATS and Kafka default values

### DIFF
--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -90,11 +90,12 @@ spec:
             value: {{ $.Values.redis.port | quote }}
           {{- if $.Values.nats.enabled }}
           - name: NATS
-            value: {{ default "nats" $.Values.natsNamespace }}-nats-server.{{ default "nats" $.Values.natsNamespace }}.svc.cluster.local
-#            value: nats-cluster-mgmt.{{ default "nats" $.Values.natsNamespace }}.svc.cluster.local
+            value: {{ $.Values.nats.host }}
           {{- end }}
+          {{- if $.Values.kafka.enabled }}
           - name: KAFKA_HOST
-            value: host.docker.internal:9092
+            value: {{ $.Values.kafka.host }}:{{ $.Values.kafka.port }}
+          {{- end }}
           - name: TENANT_ID
           {{- if hasKey $.Values "tenantId" }}
             value: {{ $.Values.tenantId }}

--- a/helm/mds/values.yaml
+++ b/helm/mds/values.yaml
@@ -54,9 +54,6 @@ apis:
     pathPrefix: /geography-author
     version: latest
     migration: false
-nats:
-  enabled: true
-  credentials: false
 tenantId:
 timezone: America/Los_Angeles
 registry:
@@ -71,6 +68,14 @@ jwt:
   bypassInternal: false
   firstInstall: false
   audiences: []
+nats:
+  enabled: false
+  host:
+  credentials: false
+kafka:
+  enabled: false
+  host:
+  port: 9092
 postgresql:
   internal: true
   host:


### PR DESCRIPTION
NATS and Kafka default to disabled.  When enabled, helm will use the hostname provided in values.yaml.