### PR TITLE
Fix/refactor compliance snapshot

### DIFF
--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -30,7 +30,7 @@ import {
   BadParamsError,
   AuthorizationError
 } from '@mds-core/mds-utils'
-import { Geography, Device, UUID, VehicleEvent } from '@mds-core/mds-types'
+import { Geography, UUID, VehicleEvent } from '@mds-core/mds-types'
 import { providerName } from '@mds-core/mds-providers'
 import { Geometry, FeatureCollection } from 'geojson'
 import { parseRequest } from '@mds-core/mds-api-helpers'

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -119,7 +119,6 @@ function api(app: express.Express): express.Express {
           /* If the client is one of the allowed providers, they can query for an arbitrary provider's vehicles. Otherwise, they may
            only see compliance results for their own devices.
            */
-          // what if queried_provider_id isn't there though?
           const target_provider_id = AllowedProviderIDs.includes(provider_id) ? queried_provider_id : provider_id
           if (
             // Check to see if the policy for which a snapshot is desired has been superseded or not.

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -45,7 +45,7 @@ import {
 } from './types'
 import { ComplianceApiVersionMiddleware } from './middleware'
 import { AllowedProviderIDs } from './constants'
-import { clientCanViewPolicyCompliance, feedInputsToComplianceEngine } from './helpers'
+import { clientCanViewPolicyCompliance, getComplianceInputs } from './helpers'
 
 function api(app: express.Express): express.Express {
   app.use(ComplianceApiVersionMiddleware)
@@ -127,7 +127,8 @@ function api(app: express.Express): express.Express {
               .map(p => p.policy_id)
               .includes(policy.policy_id)
           ) {
-            const result = await feedInputsToComplianceEngine(policy, target_provider_id, timestamp)
+            const { filteredEvents, geographies, deviceMap } = await getComplianceInputs(target_provider_id, timestamp)
+            const result = compliance_engine.processPolicy(policy, filteredEvents, geographies, deviceMap)
             if (result === undefined) {
               return res.status(400).send({ error: new BadParamsError('Unable to process compliance results') })
             }

--- a/packages/mds-compliance/helpers.ts
+++ b/packages/mds-compliance/helpers.ts
@@ -15,6 +15,7 @@ export function clientCanViewPolicyCompliance(
     ((policy.provider_ids && policy.provider_ids.includes(provider_id)) ||
       // True if a policy has no provider_ids, meaning it applies to every provider
       !policy.provider_ids ||
+      policy.provider_ids.length === 0 ||
       /* True if the client is one of the allowed providers, and either the policy applies to the
        * provider that was queried for, or the policy applies to every provider
        */

--- a/packages/mds-compliance/helpers.ts
+++ b/packages/mds-compliance/helpers.ts
@@ -4,6 +4,10 @@ import db from '@mds-core/mds-db'
 import { AllowedProviderIDs } from './constants'
 import * as compliance_engine from './mds-compliance-engine'
 
+function isPolicyUniversal(policy: Policy) {
+  return !policy.provider_ids || policy.provider_ids.length === 0
+}
+
 export function clientCanViewPolicyCompliance(
   provider_id: string,
   queried_provider_id: string | undefined,
@@ -14,8 +18,7 @@ export function clientCanViewPolicyCompliance(
     // True if the client is looking at a policy that applies to them
     ((policy.provider_ids && policy.provider_ids.includes(provider_id)) ||
       // True if a policy has no provider_ids, meaning it applies to every provider
-      !policy.provider_ids ||
-      policy.provider_ids.length === 0 ||
+      isPolicyUniversal(policy) ||
       /* True if the client is one of the allowed providers, and either the policy applies to the
        * provider that was queried for, or the policy applies to every provider
        */
@@ -24,8 +27,7 @@ export function clientCanViewPolicyCompliance(
           policy.provider_ids.length !== 0 &&
           queried_provider_id &&
           policy.provider_ids.includes(queried_provider_id)) ||
-          !policy.provider_ids ||
-          policy.provider_ids.length === 0)))
+          isPolicyUniversal(policy))))
   )
 }
 

--- a/packages/mds-compliance/helpers.ts
+++ b/packages/mds-compliance/helpers.ts
@@ -1,5 +1,8 @@
-import { Policy } from '@mds-core/mds-types'
+import { Policy, Geography, UUID, Timestamp, Device } from '@mds-core/mds-types'
+import cache from '@mds-core/mds-agency-cache'
+import db from '@mds-core/mds-db'
 import { AllowedProviderIDs } from './constants'
+import * as compliance_engine from './mds-compliance-engine'
 
 export function clientCanViewPolicyCompliance(
   provider_id: string,
@@ -23,4 +26,28 @@ export function clientCanViewPolicyCompliance(
           !policy.provider_ids ||
           policy.provider_ids.length === 0)))
   )
+}
+
+export async function feedInputsToComplianceEngine(
+  policy: Policy,
+  provider_id: string | undefined,
+  timestamp: Timestamp | undefined
+) {
+  const [geographies, deviceRecords] = await Promise.all([
+    db.readGeographies() as Promise<Geography[]>,
+    db.readDeviceIds(provider_id)
+  ])
+  const deviceIdSubset = deviceRecords.map((record: { device_id: UUID; provider_id: UUID }) => record.device_id)
+  const devices = await cache.readDevices(deviceIdSubset)
+  // If a timestamp was supplied, the data we want is probably old enough it's going to be in the db
+  const events = timestamp
+    ? await db.readHistoricalEvents({ provider_id, end_date: timestamp })
+    : await cache.readEvents(deviceIdSubset)
+
+  const deviceMap = devices.reduce((map: { [d: string]: Device }, device) => {
+    return device ? Object.assign(map, { [device.device_id]: device }) : map
+  }, {})
+
+  const filteredEvents = compliance_engine.getRecentEvents(events)
+  return compliance_engine.processPolicy(policy, filteredEvents, geographies, deviceMap)
 }

--- a/packages/mds-compliance/helpers.ts
+++ b/packages/mds-compliance/helpers.ts
@@ -31,11 +31,7 @@ export function clientCanViewPolicyCompliance(
   )
 }
 
-export async function feedInputsToComplianceEngine(
-  policy: Policy,
-  provider_id: string | undefined,
-  timestamp: Timestamp | undefined
-) {
+export async function getComplianceInputs(provider_id: string | undefined, timestamp: Timestamp | undefined) {
   const [geographies, deviceRecords] = await Promise.all([
     db.readGeographies() as Promise<Geography[]>,
     db.readDeviceIds(provider_id)
@@ -52,5 +48,5 @@ export async function feedInputsToComplianceEngine(
   }, {})
 
   const filteredEvents = compliance_engine.getRecentEvents(events)
-  return compliance_engine.processPolicy(policy, filteredEvents, geographies, deviceMap)
+  return { filteredEvents, geographies, deviceMap }
 }

--- a/packages/mds-compliance/index.ts
+++ b/packages/mds-compliance/index.ts
@@ -1,2 +1,3 @@
 export { api } from './api'
 export { processPolicy, getSupersedingPolicies, getRecentEvents } from './mds-compliance-engine'
+export { feedInputsToComplianceEngine } from './helpers'

--- a/packages/mds-compliance/index.ts
+++ b/packages/mds-compliance/index.ts
@@ -1,3 +1,3 @@
 export { api } from './api'
 export { processPolicy, getSupersedingPolicies, getRecentEvents } from './mds-compliance-engine'
-export { feedInputsToComplianceEngine } from './helpers'
+export { getComplianceInputs } from './helpers'

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -35,7 +35,7 @@ import {
 import MockDate from 'mockdate'
 import { Feature, Polygon } from 'geojson'
 import { ApiServer } from '@mds-core/mds-api-server'
-import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID, MOCHA_PROVIDER_ID } from '@mds-core/mds-providers'
+import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID, MOCHA_PROVIDER_ID, JUMP_PROVIDER_ID } from '@mds-core/mds-providers'
 import { api } from '../api'
 
 const request = supertest(ApiServer(api))
@@ -427,7 +427,9 @@ describe('Tests Compliance API:', () => {
   // })
   describe('Count Violation Over Test: ', () => {
     before(done => {
-      const devices: Device[] = makeDevices(15, now())
+      const devicesOfProvider1: Device[] = makeDevices(15, now())
+      const devicesOfProvider2: Device[] = makeDevices(15, now(), JUMP_PROVIDER_ID)
+      const devices = [...devicesOfProvider1, ...devicesOfProvider2]
       const events = makeEventsWithTelemetry(devices, now() - 100000, CITY_OF_LA, 'trip_end')
       const telemetry: Telemetry[] = []
       devices.forEach(device => {
@@ -445,19 +447,33 @@ describe('Tests Compliance API:', () => {
       })
     })
 
-    it('Verifies violation of count compliance (over)', done => {
-      request
+    it('Verifies violation of count compliance (over) and filters results by provider_id', async () => {
+      const adminResult = await request
         .get(`/snapshot/${COUNT_POLICY_UUID}`)
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
-        .end((err, result) => {
-          test.assert.deepEqual(result.body.compliance[0].matches[0].measured, 10)
-          test.assert.deepEqual(result.body.total_violations, 5)
-          test.object(result.body).hasProperty('timestamp')
-          test.object(result.body).hasProperty('version')
-          test.value(result).hasHeader('content-type', APP_JSON)
-          done(err)
-        })
+      test.assert.deepEqual(adminResult.body.compliance[0].matches[0].measured, 10)
+      test.assert.deepEqual(adminResult.body.total_violations, 20)
+      test.object(adminResult.body).hasProperty('timestamp')
+      test.object(adminResult.body).hasProperty('version')
+      test.value(adminResult).hasHeader('content-type', APP_JSON)
+
+      const provider1Result = await request
+        .get(`/snapshot/${COUNT_POLICY_UUID}?provider_id=${TEST1_PROVIDER_ID}`)
+        .set('Authorization', ADMIN_AUTH)
+        .expect(200)
+      test.assert.deepEqual(provider1Result.body.compliance[0].matches[0].measured, 10)
+      test.assert.deepEqual(provider1Result.body.total_violations, 5)
+      test.object(provider1Result.body).hasProperty('timestamp')
+      test.object(provider1Result.body).hasProperty('version')
+      test.value(provider1Result).hasHeader('content-type', APP_JSON)
+
+      const jumpResult = await request
+        .get(`/snapshot/${COUNT_POLICY_UUID}?provider_id=${JUMP_PROVIDER_ID}`)
+        .set('Authorization', ADMIN_AUTH)
+        .expect(200)
+      test.assert.deepEqual(jumpResult.body.compliance[0].matches[0].measured, 10)
+      test.assert.deepEqual(jumpResult.body.total_violations, 5)
     })
 
     afterEach(async () => {

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -449,7 +449,7 @@ describe('Tests Compliance API:', () => {
     })
 
     it('Verifies violation of count compliance (over) and filters results by provider_id', async () => {
-      // Admins should be able to see everything
+      // Admins should be able to see violations across all providers
       const adminResult = await request
         .get(`/snapshot/${COUNT_POLICY_UUID}`)
         .set('Authorization', ADMIN_AUTH)


### PR DESCRIPTION
## 📚 Purpose
1. The `/snapshot` endpoint is lengthy, and does some additional filtering of devices and events before computing compliance output. I wanted to refactor some of this code out both to make this endpoint more comprehensible, and also to expose it to the new compliance metrics service.
2. I noticed there are no tests to verify the code's behavior if a `provider_id` is provided as a query param.

## 👌 Resolves:
- [ ] 🐛 JRA-834 fixes bug
- [ ] ✨ JRA-756 implements new feature

## 📦 Impacts:
*[list of packages]*

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs