### PR TITLE
Add MS since epoch and ISO timestamps to mds-logger

### DIFF
--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -27,7 +27,10 @@ const redact = (args: unknown[]): string[] =>
 const log = (level: LogLevel, ...args: unknown[]): string[] => {
   const redacted = process.env.QUIET === 'true' ? [] : redact(args)
   if (redacted.length) {
-    logger[level](level.toUpperCase(), ...redacted)
+    const timestamp = Date.now()
+    const ISOTimestamp = new Date(timestamp).toISOString()
+
+    logger[level](level.toUpperCase(), ISOTimestamp, timestamp, ...redacted)
   }
   return redacted
 }


### PR DESCRIPTION
## 📚 Purpose
Trying to scrape through logs without timestamps is a pain. This adds both a human-readable ISO timestamp as well as a ms-since-epoch timestamp to all of our logs.

## 📦 Impacts:
[mds-logger]

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs