### PR TITLE
[mds-stream] Remove KAFKA_HOST default from the code to reduce log spam

### DIFF
--- a/packages/mds-stream/kafka/helpers.ts
+++ b/packages/mds-stream/kafka/helpers.ts
@@ -16,7 +16,10 @@
 
 export const getKafkaBrokers = () => {
   const {
-    env: { KAFKA_HOST = 'localhost:9092' }
+    env: { KAFKA_HOST }
   } = process
-  return [KAFKA_HOST]
+
+  if (KAFKA_HOST) return [KAFKA_HOST]
+
+  return null
 }

--- a/packages/mds-stream/kafka/helpers.ts
+++ b/packages/mds-stream/kafka/helpers.ts
@@ -14,6 +14,8 @@
     limitations under the License.
  */
 
+import logger from '@mds-core/mds-logger'
+
 export const getKafkaBrokers = () => {
   const {
     env: { KAFKA_HOST }
@@ -21,5 +23,6 @@ export const getKafkaBrokers = () => {
 
   if (KAFKA_HOST) return [KAFKA_HOST]
 
+  logger.warn('KAFKA_HOST is undefined, skipping initialization.')
   return null
 }

--- a/packages/mds-stream/kafka/stream-consumer.ts
+++ b/packages/mds-stream/kafka/stream-consumer.ts
@@ -32,7 +32,13 @@ const createStreamConsumer = async (
   { clientId = 'client', groupId = 'group' }: Partial<KafkaStreamConsumerOptions> = {}
 ) => {
   try {
-    const kafka = new Kafka({ clientId, brokers: getKafkaBrokers() })
+    const brokers = getKafkaBrokers()
+
+    if (!brokers) {
+      return null
+    }
+
+    const kafka = new Kafka({ clientId, brokers })
     const consumer = kafka.consumer({ groupId })
     await consumer.connect()
     await consumer.subscribe({ topic })

--- a/packages/mds-stream/kafka/stream-producer.ts
+++ b/packages/mds-stream/kafka/stream-producer.ts
@@ -34,8 +34,6 @@ const createStreamProducer = async ({ clientId = 'writer' }: Partial<KafkaStream
       return null
     }
 
-    console.log(brokers)
-
     const kafka = new Kafka({ clientId, brokers })
     const producer = kafka.producer()
     await producer.connect()

--- a/packages/mds-stream/kafka/stream-producer.ts
+++ b/packages/mds-stream/kafka/stream-producer.ts
@@ -28,7 +28,15 @@ export interface KafkaStreamProducerOptions {
 
 const createStreamProducer = async ({ clientId = 'writer' }: Partial<KafkaStreamProducerOptions> = {}) => {
   try {
-    const kafka = new Kafka({ clientId, brokers: getKafkaBrokers() })
+    const brokers = getKafkaBrokers()
+
+    if (!brokers) {
+      return null
+    }
+
+    console.log(brokers)
+
+    const kafka = new Kafka({ clientId, brokers })
     const producer = kafka.producer()
     await producer.connect()
     return producer


### PR DESCRIPTION
## 📚 Purpose
Currently, if you start a package that uses mds-stream's kafka features (e.g. mds-agency) in an environment that does not have Apache Kafka, there is a copious amount of log-spam. This PR removes the default value for KAFKA_HOST from the code, and instead makes it so you cannot initialize a consumer/producer (will just return null).

## 📦 Impacts:
[mds-stream]

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs