### PR TITLE
[mds-policy] [mds-policy-author] [mds-geography] [mds-geography-author] Fix signature for error handling middleware

### DIFF
--- a/packages/mds-geography-author/api.ts
+++ b/packages/mds-geography-author/api.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { NextFunction } from 'express'
 import db from '@mds-core/mds-db'
 
 import {
@@ -287,7 +287,7 @@ function api(app: express.Express): express.Express {
     }
   )
 
-  app.use(async (error: Error, req: ApiRequest, res: ApiResponse) => {
+  app.use(async (error: Error, req: ApiRequest, res: ApiResponse, next: NextFunction) => {
     await logger.error(req.method, req.originalUrl, error)
     return res.status(500).send({ error })
   })

--- a/packages/mds-geography-author/tests/api.spec.ts
+++ b/packages/mds-geography-author/tests/api.spec.ts
@@ -517,5 +517,15 @@ describe('Tests app', () => {
           done(err)
         })
     })
+
+    it('fails to hit non-existent endpoint with a 404', done => {
+      request
+        .get(`/foobar`)
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .expect(404)
+        .end(err => {
+          done(err)
+        })
+    })
   })
 })

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { NextFunction } from 'express'
 import db from '@mds-core/mds-db'
 
 import { pathsFor, ServerError, NotFoundError, InsufficientPermissionsError } from '@mds-core/mds-utils'
@@ -94,7 +94,7 @@ function api(app: express.Express): express.Express {
   /* eslint-reason global error handling middleware */
   /* istanbul ignore next */
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  app.use(async (error: Error, req: ApiRequest, res: ApiResponse) => {
+  app.use(async (error: Error, req: ApiRequest, res: ApiResponse, next: NextFunction) => {
     await logger.error(req.method, req.originalUrl, error)
     return res.status(500).send({ error })
   })

--- a/packages/mds-geography/tests/api.spec.ts
+++ b/packages/mds-geography/tests/api.spec.ts
@@ -215,5 +215,15 @@ describe('Tests app', () => {
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(403)
     })
+
+    it('fails to hit non-existent endpoint with a 404', done => {
+      request
+        .get(`/foobar`)
+        .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
+        .expect(404)
+        .end(err => {
+          done(err)
+        })
+    })
   })
 })

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import express from 'express'
+import express, { NextFunction } from 'express'
 import {
   uuid,
   pathsFor,
@@ -277,7 +277,7 @@ function api(app: express.Express): express.Express {
   /* eslint-reason global error handling middleware */
   /* istanbul ignore next */
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  app.use(async (error: Error, req: ApiRequest, res: ApiResponse) => {
+  app.use(async (error: Error, req: ApiRequest, res: ApiResponse, next: NextFunction) => {
     await logger.error(req.method, req.originalUrl, error)
     return res.status(500).send({ error })
   })

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -149,6 +149,16 @@ describe('Tests app', () => {
         })
     })
 
+    it('fails to hit non-existent endpoint with a 404', done => {
+      request
+        .get(`/foobar`)
+        .set('Authorization', POLICIES_WRITE_SCOPE)
+        .expect(404)
+        .end(err => {
+          done(err)
+        })
+    })
+
     it('creates one current policy', done => {
       const policy = POLICY_JSON_WITHOUT_PUBLISH_DATE
       request

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import express from 'express'
+import express, { NextFunction } from 'express'
 // import { isProviderId, providerName } from '@mds-core/mds-providers'
 import { Policy, UUID } from '@mds-core/mds-types'
 import db from '@mds-core/mds-db'
@@ -166,7 +166,7 @@ function api(app: express.Express): express.Express {
   /* eslint-reason global error handling middleware */
   /* istanbul ignore next */
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  app.use(async (error: Error, req: ApiRequest, res: ApiResponse) => {
+  app.use(async (error: Error, req: ApiRequest, res: ApiResponse, next: NextFunction) => {
     await logger.error(req.method, req.originalUrl, error)
     return res.status(500).send({ error })
   })

--- a/packages/mds-policy/tests/api.spec.ts
+++ b/packages/mds-policy/tests/api.spec.ts
@@ -193,4 +193,14 @@ describe('Tests app', () => {
       .set('Authorization', POLICIES_READ_SCOPE)
       .expect(200)
   })
+
+  it('fails to hit non-existent endpoint with a 404', done => {
+    request
+      .get(`/foobar`)
+      .set('Authorization', POLICIES_READ_SCOPE)
+      .expect(404)
+      .end(err => {
+        done(err)
+      })
+  })
 })


### PR DESCRIPTION
## 📚 Purpose
The recent changes we made to the error handling in the above packages was broken due to an incorrect signature for the global error handling method. This resulted in a spectacularly confusing stack trace when a client attempted to hit a route which was not defined by the API, eventually resulting in the server never responding to the client at all.

## 📦 Impacts:
[mds-policy]
[mds-policy-author]
[mds-geography]
[mds-geography-author]