### PR TITLE
Remove redundant RepositoryError calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.3.0
   hooks:

--- a/packages/mds-jurisdiction-service/service/handlers/create-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/create-jurisdiction-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { CreateJurisdictionDomainModel, JurisdictionDomainModel } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 import { ValidateJurisdictionForCreate } from '../validators'
@@ -28,7 +27,7 @@ export const createJurisdiction = async (
     const [jurisdiction] = await JurisdictionRepository.createJurisdictions([model].map(ValidateJurisdictionForCreate))
     return ServiceResult(jurisdiction)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Creating Jurisdiction', RepositoryError(error))
+    const exception = ServiceException('Error Creating Jurisdiction', error)
     logger.error(exception, error)
     return exception
   }

--- a/packages/mds-jurisdiction-service/service/handlers/create-jurisdictions-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/create-jurisdictions-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { CreateJurisdictionDomainModel, JurisdictionDomainModel } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 import { ValidateJurisdictionForCreate } from '../validators'
@@ -28,7 +27,7 @@ export const createJurisdictions = async (
     const jurisdictions = await JurisdictionRepository.createJurisdictions(models.map(ValidateJurisdictionForCreate))
     return ServiceResult(jurisdictions)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Creating Jurisdictions', RepositoryError(error))
+    const exception = ServiceException('Error Creating Jurisdictions', error)
     logger.error(exception, error)
     return exception
   }

--- a/packages/mds-jurisdiction-service/service/handlers/delete-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/delete-jurisdiction-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { JurisdictionRepository } from '../repository'
 import { JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 
@@ -27,7 +26,7 @@ export const deleteJurisdiction = async (
     const deleted = await JurisdictionRepository.deleteJurisdiction(jurisdiction_id)
     return ServiceResult(deleted)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Deleting Jurisdiction', RepositoryError(error))
+    const exception = ServiceException('Error Deleting Jurisdiction', error)
     logger.error(exception, error)
     return exception
   }

--- a/packages/mds-jurisdiction-service/service/handlers/get-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/get-jurisdiction-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { GetJurisdictionsOptions, JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 
@@ -28,7 +27,7 @@ export const getJurisdiction = async (
     const jurisdiction = await JurisdictionRepository.readJurisdiction(jurisdiction_id, options)
     return ServiceResult(jurisdiction)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Reading Jurisdiction', RepositoryError(error))
+    const exception = ServiceException('Error Reading Jurisdiction', error)
     logger.error(exception, error)
     return exception
   }

--- a/packages/mds-jurisdiction-service/service/handlers/get-jurisdictions-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/get-jurisdictions-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { GetJurisdictionsOptions, JurisdictionDomainModel } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 
@@ -27,7 +26,7 @@ export const getJurisdictions = async (
     const jurisdicitons = await JurisdictionRepository.readJurisdictions(options)
     return ServiceResult(jurisdicitons)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Reading Jurisdictions', RepositoryError(error))
+    const exception = ServiceException('Error Reading Jurisdictions', error)
     logger.error(exception, error)
     return exception
   }

--- a/packages/mds-jurisdiction-service/service/handlers/update-jurisdiction-handler.ts
+++ b/packages/mds-jurisdiction-service/service/handlers/update-jurisdiction-handler.ts
@@ -16,7 +16,6 @@
 
 import { ServiceResponse, ServiceResult, ServiceException } from '@mds-core/mds-service-helpers'
 import logger from '@mds-core/mds-logger'
-import { RepositoryError } from '@mds-core/mds-repository'
 import { UpdateJurisdictionDomainModel, JurisdictionDomainModel, JurisdictionIdType } from '../../@types'
 import { JurisdictionRepository } from '../repository'
 
@@ -28,7 +27,7 @@ export const updateJurisdiction = async (
     const updated = await JurisdictionRepository.updateJurisdiction(jurisdiction_id, jurisdiction)
     return ServiceResult(updated)
   } catch (error) /* istanbul ignore next */ {
-    const exception = ServiceException('Error Updating Jurisdiction', RepositoryError(error))
+    const exception = ServiceException('Error Updating Jurisdiction', error)
     logger.error(exception, error)
     return exception
   }


### PR DESCRIPTION
## 📚 Purpose
- RepositoryError is a factory method used to wrap database errors
- It should not be called from the service handler methods

## 📦 Impacts:
- [x] mds-jurisdiction-service