### PR TITLE
[mds-compliance] Extend Compliance Output

### DIFF
--- a/packages/mds-compliance/mds-compliance-cli.ts
+++ b/packages/mds-compliance/mds-compliance-cli.ts
@@ -16,8 +16,9 @@
 import * as fs from 'fs'
 import logger from '@mds-core/mds-logger'
 import * as yargs from 'yargs'
-import { Policy, Geography, ComplianceResponse, VehicleEvent, Device } from '@mds-core/mds-types'
+import { Policy, Geography, VehicleEvent, Device } from '@mds-core/mds-types'
 import { validateEvents, validateGeographies, validatePolicies } from '@mds-core/mds-schema-validators'
+import { ComplianceResponse } from './types'
 import { getSupersedingPolicies, processPolicy, getRecentEvents } from './mds-compliance-engine'
 
 const args = yargs

--- a/packages/mds-compliance/tests/engine-test.spec.ts
+++ b/packages/mds-compliance/tests/engine-test.spec.ts
@@ -379,7 +379,7 @@ describe('Verifies compliance engine processes by vehicle most recent event', as
             compliance.rule.rule_type === RULE_TYPES.count
           ) {
             test.assert.deepEqual(compliance.matches.length, 1)
-            test.assert.deepEqual(result.vehicles_in_violation[0].device_id, latest_device.device_id)
+            test.assert.deepEqual(result.vehicles_in_violation[0].device.device_id, latest_device.device_id)
           }
         })
       }

--- a/packages/mds-compliance/types.ts
+++ b/packages/mds-compliance/types.ts
@@ -1,4 +1,4 @@
-import { MatchedVehicle, VehicleEvent, UUID, Timestamp, ComplianceResponse, Policy } from '@mds-core/mds-types'
+import { VehicleEvent, UUID, Timestamp, Policy, Device, Rule } from '@mds-core/mds-types'
 import {
   ApiRequest,
   ApiClaims,
@@ -32,3 +32,41 @@ export type ComplianceApiCountResponse = ComplianceApiResponse<{
 export type MatchedVehiclePlusRule = MatchedVehicle & { rule_id: UUID }
 
 export type VehicleEventWithTelemetry = VehicleEvent & { telemetry: { gps: { lat: number; lng: number } } }
+export interface MatchedVehicle {
+  device: Device
+  event: VehicleEvent
+}
+
+export interface CountMatch {
+  measured: number
+  geography_id: UUID
+  matched_vehicles: MatchedVehicle[]
+}
+
+export interface TimeMatch {
+  measured: number
+  geography_id: UUID
+  matched_vehicle: MatchedVehicle
+}
+
+export interface SpeedMatch {
+  measured: number
+  geography_id: UUID
+  matched_vehicle: MatchedVehicle
+}
+
+export interface ReducedMatch {
+  measured: number
+  geography_id: UUID
+}
+
+export interface Compliance {
+  rule: Rule
+  matches: ReducedMatch[] | CountMatch[] | TimeMatch[] | SpeedMatch[]
+}
+export interface ComplianceResponse {
+  policy: Policy
+  compliance: Compliance[]
+  total_violations: number
+  vehicles_in_violation: MatchedVehiclePlusRule[]
+}

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -312,53 +312,6 @@ export interface PolicyMetadata {
   policy_metadata: Record<string, any>
 }
 
-export interface MatchedVehicle {
-  device_id: UUID
-  provider_id: UUID
-  vehicle_id: string
-  vehicle_type: VEHICLE_TYPE
-  vehicle_status: VEHICLE_STATUS
-  gps: {
-    lat: number
-    lng: number
-  }
-}
-
-export interface CountMatch {
-  measured: number
-  geography_id: UUID
-  matched_vehicles: MatchedVehicle[]
-}
-
-export interface TimeMatch {
-  measured: number
-  geography_id: UUID
-  matched_vehicle: MatchedVehicle
-}
-
-export interface SpeedMatch {
-  measured: number
-  geography_id: UUID
-  matched_vehicle: MatchedVehicle
-}
-
-export interface ReducedMatch {
-  measured: number
-  geography_id: UUID
-}
-
-export interface Compliance {
-  rule: Rule
-  matches: ReducedMatch[] | CountMatch[] | TimeMatch[] | SpeedMatch[]
-}
-
-export interface ComplianceResponse {
-  policy: Policy
-  compliance: Compliance[]
-  total_violations: number
-  vehicles_in_violation: { device_id: UUID; rule_id: UUID }[]
-}
-
 // We don't put the publish_date into the geography_json column
 // as we do with the Policy type, because we don't want to mess with
 // the geojson FeatureCollection type.


### PR DESCRIPTION
## 📚 Purpose
The output from Compliance today truncates some data as an artifact from when it used to live in AWS Lambda. This extends the information about vehicles which are in violation of a Rule to have much more comprehensive output (full device info + latest event/telemetry)

## 📦 Impacts:
- [mds-compliance]