### PR TITLE
Add foreign key to naming strategy

### DIFF
--- a/packages/mds-repository/naming-strategies/mds-naming-strategy.ts
+++ b/packages/mds-repository/naming-strategies/mds-naming-strategy.ts
@@ -31,4 +31,8 @@ export class MdsNamingStrategy extends DefaultNamingStrategy implements NamingSt
   uniqueConstraintName(tableOrName: Table | string, columnNames: string[]): string {
     return ['uc', ...columnNames, tableName(tableOrName)].join('_')
   }
+
+  foreignKeyName(tableOrName: Table | string, columnNames: string[]): string {
+    return ['fk', ...columnNames, tableName(tableOrName)].join('_')
+  }
 }

--- a/packages/mds-repository/tests/naming-strategies.spec.ts
+++ b/packages/mds-repository/tests/naming-strategies.spec.ts
@@ -34,4 +34,9 @@ describe('Test Naming Strategy', () => {
     test.value(strategy.uniqueConstraintName('table', ['column'])).is('uc_column_table')
     done()
   })
+
+  it('Foreign Key Naming Strategy', done => {
+    test.value(strategy.foreignKeyName('table', ['column'])).is('fk_column_table')
+    done()
+  })
 })


### PR DESCRIPTION
## 📚 Purpose
Control the naming of Foreign Keys generated by migrations.

## 📦 Impacts:
- [x] mds-repository