### PR TITLE
Add support for read-only database user

### DIFF
--- a/packages/mds-db/client.ts
+++ b/packages/mds-db/client.ts
@@ -11,27 +11,29 @@ let writeableCachedClient: MDSPostgresClient | null = null
 let readOnlyCachedClient: MDSPostgresClient | null = null
 
 async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
-  const { PG_NAME, PG_USER, PG_PASS, PG_PORT, PG_MIGRATIONS = 'false' } = env
-  let PG_HOST: string | undefined
-  if (useWriteable) {
-    ;({ PG_HOST } = env)
-  } else {
-    PG_HOST = env.PG_HOST_READER || env.PG_HOST
-  }
-
-  const client_type: ClientType = useWriteable ? 'writeable' : 'readonly'
+  const {
+    PG_HOST,
+    PG_HOST_READER,
+    PG_MIGRATIONS = 'false',
+    PG_NAME,
+    PG_PASS,
+    PG_PASS_READER,
+    PG_PORT,
+    PG_USER,
+    PG_USER_READER
+  } = env
 
   const info = {
-    client_type,
+    client_type: useWriteable ? 'writeable' : 'readonly',
     database: PG_NAME,
-    user: PG_USER,
-    host: PG_HOST || 'localhost',
+    user: (useWriteable ? PG_USER : PG_USER_READER) || PG_USER,
+    host: (useWriteable ? PG_HOST : PG_HOST_READER) || PG_HOST || 'localhost',
     port: Number(PG_PORT) || 5432
   }
 
   logger.info('connecting to postgres:', ...Object.keys(info).map(key => (info as { [x: string]: unknown })[key]))
 
-  const client = configureClient({ ...info, password: PG_PASS })
+  const client = configureClient({ ...info, password: (useWriteable ? PG_PASS : PG_PASS_READER) || PG_PASS })
 
   try {
     await client.connect()

--- a/packages/mds-repository/connection.ts
+++ b/packages/mds-repository/connection.ts
@@ -54,15 +54,25 @@ export class ConnectionManager<TConnectionMode extends ConnectionMode> {
 
   private connectionOptions = (mode: TConnectionMode): ConnectionOptions => {
     const { connectionName, options } = this
-    const { PG_HOST, PG_HOST_READER, PG_PORT, PG_USER, PG_PASS, PG_NAME, PG_DEBUG = 'false' } = process.env
+    const {
+      PG_DEBUG = 'false',
+      PG_HOST,
+      PG_HOST_READER,
+      PG_NAME,
+      PG_PASS,
+      PG_PASS_READER,
+      PG_PORT,
+      PG_USER,
+      PG_USER_READER
+    } = process.env
 
     return {
       name: connectionName(mode),
       type: 'postgres',
       host: (mode === 'rw' ? PG_HOST : PG_HOST_READER) || PG_HOST || 'localhost',
       port: Number(PG_PORT) || 5432,
-      username: PG_USER,
-      password: PG_PASS,
+      username: (mode === 'rw' ? PG_USER : PG_USER_READER) || PG_USER,
+      password: (mode === 'rw' ? PG_PASS : PG_PASS_READER) || PG_PASS,
       database: PG_NAME,
       logging: loggingOption(PG_DEBUG.toLowerCase()),
       maxQueryExecutionTime: 3000,


### PR DESCRIPTION
## 📚 Purpose
MDS currently supports `PG_HOST`/`PG_HOST_READER` environment variables to be able to direct database read requests to dedicated read-only replicas. This PR extends this to include the notion of a read-only database user by introducing `PG_USER_READER` and `PG_PASS_READER` which can be used as an additional security measure to prevent database updates even if those credentials are used to connect to `PG_HOST`.

## 👌 Resolves:
- [x] ✨[CLOUD-228](https://lacunadotai.atlassian.net/browse/CLOUD-228) subtask of [CLOUD-206](https://lacunadotai.atlassian.net/browse/CLOUD-206)

## 📦 Impacts:
- [x] mds-db
- [x] mds-repository