### PR TITLE
[mds-web-sockets] Don't doubly-stringify things

### DIFF
--- a/packages/mds-web-sockets/package.json
+++ b/packages/mds-web-sockets/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "client": "yarn watch client",
-    "server": "yarn watch launch_server",
-    "start": "yarn watch launch_server",
+    "server": "yarn watch server",
+    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --lines 50 ts-mocha --project ../../tsconfig.json --exit",

--- a/packages/mds-web-sockets/ws-server.ts
+++ b/packages/mds-web-sockets/ws-server.ts
@@ -101,7 +101,7 @@ export const WebSocketServer = async <T extends readonly string[]>(entityTypes?:
 
   const processor = async (err: Nullable<NatsError>, msg: Msg) => {
     const entity = msg.subject.split('.')?.[1]
-    await pushToClients(entity, JSON.stringify(msg.data))
+    await pushToClients(entity, msg.data)
   }
 
   await Promise.all(


### PR DESCRIPTION
## 📚 Purpose
When we consume data from the NATS interface, it already comes through in stringified-form. Currently, the processor we define in web-sockets to consume that data does an additional stringification. This PR removes the additional stringification.

Additionally, also fixes some launch-config issues.

## 📦 Impacts:
mds-web-sockets