### PR TITLE
VehicleEvent transformers

### DIFF
--- a/packages/mds-types/tests/transformers.spec.ts
+++ b/packages/mds-types/tests/transformers.spec.ts
@@ -1,30 +1,84 @@
 import test from 'unit.js'
 import { uuid, now } from '@mds-core/mds-utils'
 import { Timestamp, VEHICLE_EVENT } from '../index'
-import { VehicleEvent_v0_4_0, VehicleEvent_v1_0_0, v0_4_1_to_v1_0_0 } from '../transformers'
+import { VehicleEvent_v0_4_1, VehicleEvent_v1_0_0, v0_4_1_to_v1_0_0, v1_0_0_to_v0_4_0 } from '../transformers'
+
+const TIME = now()
+const DEVICE_ID = uuid()
+const PROVIDER_ID = uuid()
 
 describe('Test transformers', () => {
   it('validates the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {
-    const time = now()
-    const device_id = uuid()
-    const provider_id = uuid()
-    const event: VehicleEvent_v0_4_0 = {
-      device_id,
-      provider_id,
-      timestamp: time,
+    const event: VehicleEvent_v0_4_1 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
       event_type: 'provider_pick_up',
       event_type_reason: 'low_battery',
-      recorded: time
+      recorded: TIME
     }
 
     const transformedEvent = v0_4_1_to_v1_0_0(event)
     test.value(transformedEvent, {
-      device_id,
-      provider_id,
-      timestamp: time,
-      vehicle_state: ['provider_pick_up'],
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      vehicle_state: 'provider_pick_up',
       event_types: ['low_battery'],
-      recorded: time
+      recorded: TIME
+    })
+    done()
+  })
+
+  it('validates the transformation between v1.0.0 VehicleEvent and v0.4.0 VehicleEvent when there are multiple event types', done => {
+    const event: VehicleEvent_v1_0_0 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      vehicle_state: 'provider_pick_up',
+      event_types: ['low_battery', 'maintenance'],
+      recorded: TIME
+    }
+
+    const v0_4_1_events = v1_0_0_to_v0_4_0(event)
+    test.value(v0_4_1_events, [
+      {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'provider_pick_up',
+        event_type_reason: 'low_battery',
+        recorded: TIME
+      },
+      {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'provider_pick_up',
+        event_type_reason: 'maintenance',
+        recorded: TIME
+      }
+    ])
+    done()
+  })
+
+  it('validates the transformation between v1.0.0 VehicleType and v0.4.0 VehicleType when there are no event_types', done => {
+    const event: VehicleEvent_v1_0_0 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      vehicle_state: 'provider_pick_up',
+      event_types: [],
+      recorded: TIME
+    }
+    const transformedEvent = v1_0_0_to_v0_4_0(event)
+    test.value(transformedEvent, {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      event_type: 'provider_pick_up',
+      event_type_reason: null,
+      recorded: TIME
     })
     done()
   })

--- a/packages/mds-types/tests/transformers.spec.ts
+++ b/packages/mds-types/tests/transformers.spec.ts
@@ -1,0 +1,31 @@
+import test from 'unit.js'
+import { uuid, now } from '@mds-core/mds-utils'
+import { Timestamp, VEHICLE_EVENT } from '../index'
+import { VehicleEvent_v0_4_0, VehicleEvent_v1_0_0, v0_4_1_to_v1_0_0 } from '../transformers'
+
+describe('Test transformers', () => {
+  it('validates the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {
+    const time = now()
+    const device_id = uuid()
+    const provider_id = uuid()
+    const event: VehicleEvent_v0_4_0 = {
+      device_id,
+      provider_id,
+      timestamp: time,
+      event_type: 'provider_pick_up',
+      event_type_reason: 'low_battery',
+      recorded: time
+    }
+
+    const transformedEvent = v0_4_1_to_v1_0_0(event)
+    test.value(transformedEvent, {
+      device_id,
+      provider_id,
+      timestamp: time,
+      vehicle_state: ['provider_pick_up'],
+      event_types: ['low_battery'],
+      recorded: time
+    })
+    done()
+  })
+})

--- a/packages/mds-types/transformers.ts
+++ b/packages/mds-types/transformers.ts
@@ -1,4 +1,4 @@
-import { UUID, Timestamp, VEHICLE_EVENT, Telemetry, VEHICLE_REASON } from '../index'
+import { UUID, Timestamp, VEHICLE_EVENT, Telemetry, VEHICLE_REASON } from './index'
 
 export interface VehicleEvent_v0_4_1 {
   device_id: UUID
@@ -21,7 +21,7 @@ export interface VehicleEvent_v1_0_0 {
   timestamp: Timestamp
   timestamp_long?: string | null
   delta?: Timestamp | null
-  vehicle_state: VEHICLE_EVENT[]
+  vehicle_state: VEHICLE_EVENT
   event_types: VEHICLE_REASON[]
   telemetry_timestamp?: Timestamp | null
   telemetry?: Telemetry | null
@@ -51,12 +51,37 @@ export function v0_4_1_to_v1_0_0(event: VehicleEvent_v0_4_1): VehicleEvent_v1_0_
     timestamp,
     timestamp_long,
     delta,
-    vehicle_state: [event_type],
-    event_types: [event_type_reason],
+    vehicle_state: event_type,
+    event_types: event_type_reason ? [event_type_reason] : [],
     telemetry_timestamp,
     telemetry,
     trip_id,
     service_area_id,
     recorded
   }
+}
+
+function v1_0_0_to_v0_4_0_helper(event: VehicleEvent_v1_0_0, event_type: VEHICLE_REASON | null): VehicleEvent_v0_4_1 {
+  return {
+    device_id: event.device_id,
+    provider_id: event.provider_id,
+    timestamp: event.timestamp,
+    timestamp_long: event.timestamp_long,
+    delta: event.delta,
+    event_type: event.vehicle_state,
+    event_type_reason: event_type,
+    telemetry_timestamp: event.telemetry_timestamp,
+    trip_id: event.trip_id,
+    service_area_id: event.service_area_id,
+    recorded: event.recorded
+  }
+}
+
+export function v1_0_0_to_v0_4_0(event: VehicleEvent_v1_0_0): VehicleEvent_v0_4_1[] {
+  if (event.event_types.length > 0) {
+    return event.event_types.map(event_type => {
+      return v1_0_0_to_v0_4_0_helper(event, event_type)
+    })
+  }
+  return [v1_0_0_to_v0_4_0_helper(event, null)]
 }

--- a/packages/mds-types/transformers.ts
+++ b/packages/mds-types/transformers.ts
@@ -1,0 +1,62 @@
+import { UUID, Timestamp, VEHICLE_EVENT, Telemetry, VEHICLE_REASON } from '../index'
+
+export interface VehicleEvent_v0_4_1 {
+  device_id: UUID
+  provider_id: UUID
+  timestamp: Timestamp
+  timestamp_long?: string | null
+  delta?: Timestamp | null
+  event_type: VEHICLE_EVENT
+  event_type_reason?: VEHICLE_REASON | null
+  telemetry_timestamp?: Timestamp | null
+  telemetry?: Telemetry | null
+  trip_id?: UUID | null
+  service_area_id?: UUID | null
+  recorded: Timestamp
+}
+
+export interface VehicleEvent_v1_0_0 {
+  device_id: UUID
+  provider_id: UUID
+  timestamp: Timestamp
+  timestamp_long?: string | null
+  delta?: Timestamp | null
+  vehicle_state: VEHICLE_EVENT[]
+  event_types: VEHICLE_REASON[]
+  telemetry_timestamp?: Timestamp | null
+  telemetry?: Telemetry | null
+  trip_id?: UUID | null
+  service_area_id?: UUID | null
+  recorded: Timestamp
+}
+
+export function v0_4_1_to_v1_0_0(event: VehicleEvent_v0_4_1): VehicleEvent_v1_0_0 {
+  const {
+    device_id,
+    provider_id,
+    timestamp,
+    timestamp_long = null,
+    delta = null,
+    event_type,
+    event_type_reason = null,
+    telemetry_timestamp = null,
+    telemetry = null,
+    trip_id = null,
+    service_area_id = null,
+    recorded
+  } = event
+  return {
+    device_id,
+    provider_id,
+    timestamp,
+    timestamp_long,
+    delta,
+    vehicle_state: [event_type],
+    event_types: [event_type_reason],
+    telemetry_timestamp,
+    telemetry,
+    trip_id,
+    service_area_id,
+    recorded
+  }
+}


### PR DESCRIPTION
## 📚 Purpose

There are small but significant changes to the `VehicleEvent` type in 1.0.0. We'll want to be able to support both 1.0.0 and 0.4.1, which means being able to convert between each of these types.

I'm open to renaming the `VehicleEvent_v1.0.0` type to plain old `VehicleEvent` in the future.

## 👌 Resolves:
- [ ] 🐛 JRA-834 fixes bug
- [ ] ✨ JRA-756 implements new feature

## 📦 Impacts:
*[list of packages]*

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs