### PR TITLE
Joi schema for Geography doesn't match interface

### DIFF
--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -141,9 +141,11 @@ const featureCollectionSchema = Joi.object()
 
 export const geographySchema = Joi.object().keys({
   geography_id: Joi.string().guid().required(),
+  name: Joi.string().required(),
   geography_json: featureCollectionSchema,
-  previous_geography_ids: Joi.array().items(Joi.string().guid()).allow(null),
-  name: Joi.string().required()
+  prev_geographies: Joi.array().items(Joi.string().guid()).allow(null),
+  effective_date: timestampSchema,
+  description: Joi.string()
 })
 
 const geographiesSchema = Joi.array().items(geographySchema)


### PR DESCRIPTION
## 📚 Purpose
Trying to save a Geography containing a description or an effective_date would fail because those properties weren't included in the schema definition used by the validator.