### PR TITLE
Deprecate pathsFor in favor of pathPrefix

### DIFF
--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -7,7 +7,7 @@ import express from 'express'
 
 import logger from '@mds-core/mds-logger'
 import { isProviderId } from '@mds-core/mds-providers'
-import { isUUID, pathsFor } from '@mds-core/mds-utils'
+import { isUUID, pathPrefix } from '@mds-core/mds-utils'
 import { checkAccess, AccessTokenScopeValidator } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse, AgencyApiAccessTokenScopes } from './types'
 import {
@@ -79,32 +79,32 @@ function api(app: express.Express): express.Express {
    * Endpoint to register vehicles
    * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---register Register}
    */
-  app.post(pathsFor('/vehicles'), registerVehicle)
+  app.post(pathPrefix('/vehicles'), registerVehicle)
 
   /**
    * Read back a vehicle.
    */
-  app.get(pathsFor('/vehicles/:device_id'), validateDeviceId, getVehicleById)
+  app.get(pathPrefix('/vehicles/:device_id'), validateDeviceId, getVehicleById)
 
   /**
    * Read back all the vehicles for this provider_id, with pagination
    */
-  app.get(pathsFor('/vehicles'), getVehiclesByProvider)
+  app.get(pathPrefix('/vehicles'), getVehiclesByProvider)
 
   // update the vehicle_id
-  app.put(pathsFor('/vehicles/:device_id'), validateDeviceId, updateVehicle)
+  app.put(pathPrefix('/vehicles/:device_id'), validateDeviceId, updateVehicle)
 
   /**
    * Endpoint to submit vehicle events
    * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---event Events}
    */
-  app.post(pathsFor('/vehicles/:device_id/event'), validateDeviceId, submitVehicleEvent)
+  app.post(pathPrefix('/vehicles/:device_id/event'), validateDeviceId, submitVehicleEvent)
 
   /**
    * Endpoint to submit telemetry
    * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
    */
-  app.post(pathsFor('/vehicles/telemetry'), submitVehicleTelemetry)
+  app.post(pathPrefix('/vehicles/telemetry'), submitVehicleTelemetry)
 
   // ///////////////////// begin Agency candidate endpoints ///////////////////////
 
@@ -112,7 +112,7 @@ function api(app: express.Express): express.Express {
    * Not currently in Agency spec.  Ability to read back all vehicle IDs.
    */
   app.get(
-    pathsFor('/admin/vehicle_ids'),
+    pathPrefix('/admin/vehicle_ids'),
     checkAgencyApiAccess(scopes => scopes.includes('admin:all')),
     readAllVehicleIds
   )
@@ -120,34 +120,34 @@ function api(app: express.Express): express.Express {
   // /////////////////// end Agency candidate endpoints ////////////////////
 
   app.get(
-    pathsFor('/admin/cache/info'),
+    pathPrefix('/admin/cache/info'),
     checkAgencyApiAccess(scopes => scopes.includes('admin:all')),
     getCacheInfo
   )
 
   // wipe a device -- sandbox or admin use only
   app.get(
-    pathsFor('/admin/wipe/:device_id'),
+    pathPrefix('/admin/wipe/:device_id'),
     checkAgencyApiAccess(scopes => scopes.includes('admin:all')),
     validateDeviceId,
     wipeDevice
   )
 
   app.get(
-    pathsFor('/admin/cache/refresh'),
+    pathPrefix('/admin/cache/refresh'),
     checkAgencyApiAccess(scopes => scopes.includes('admin:all')),
     refreshCache
   )
 
   app.post(
-    pathsFor('/stops'),
+    pathPrefix('/stops'),
     checkAgencyApiAccess(scopes => scopes.includes('admin:all')),
     registerStop
   )
 
-  app.get(pathsFor('/stops/:stop_id'), readStop)
+  app.get(pathPrefix('/stops/:stop_id'), readStop)
 
-  app.get(pathsFor('/stops'), readStops)
+  app.get(pathPrefix('/stops'), readStops)
 
   return app
 }

--- a/packages/mds-agency/server.ts
+++ b/packages/mds-agency/server.ts
@@ -17,4 +17,4 @@
 import { HttpServer, ApiServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.AGENCY_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.AGENCY_API_HTTP_PORT })

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -47,7 +47,7 @@ import { shutdown as socketShutdown } from '@mds-core/mds-web-sockets'
 import { makeDevices, makeEvents, GEOGRAPHY_UUID, LA_CITY_BOUNDARY, JUMP_TEST_DEVICE_1 } from '@mds-core/mds-test-data'
 import { ApiServer } from '@mds-core/mds-api-server'
 import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from '@mds-core/mds-providers'
-
+import { pathPrefix } from '@mds-core/mds-utils'
 import { api } from '../api'
 
 /* eslint-disable-next-line no-console */
@@ -140,7 +140,7 @@ after(async () => {
 describe('Tests API', () => {
   it('verifies unable to access admin if not scoped', done => {
     request
-      .get('/admin/cache/info')
+      .get(pathPrefix('/admin/cache/info'))
       .set('Authorization', AUTH_NO_SCOPE)
       .expect(403)
       .end((err, result) => {
@@ -152,7 +152,7 @@ describe('Tests API', () => {
 
   it('verifies post device failure nothing in body', done => {
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .expect(400)
       .end((err, result) => {
@@ -164,7 +164,7 @@ describe('Tests API', () => {
   })
   it('verifies get non-existent device', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
       .set('Authorization', AUTH)
       .expect(404)
       .end((err, result) => {
@@ -175,7 +175,7 @@ describe('Tests API', () => {
   })
   it('verifies get non-existent device from cache', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}?cached=true`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}?cached=true`))
       .set('Authorization', AUTH)
       .expect(404)
       .end((err, result) => {
@@ -188,7 +188,7 @@ describe('Tests API', () => {
     const badVehicle = deepCopy(TEST_VEHICLE)
     badVehicle.device_id = 'bad'
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -202,7 +202,7 @@ describe('Tests API', () => {
   // it('verifies post device missing mfgr', (done) => {
   //     let badVehicle = deepCopy(TEST_VEHICLE)
   //     delete badVehicle.mfgr
-  //     request.post('/vehicles')
+  //     request.post(pathsFor('/vehicles'))
   //         .set('Authorization', AUTH)
   //         .send(badVehicle)
   //         .expect(400).end((err, result) => {
@@ -216,7 +216,7 @@ describe('Tests API', () => {
     const badVehicle = deepCopy(TEST_VEHICLE)
     delete badVehicle.propulsion
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -233,7 +233,7 @@ describe('Tests API', () => {
     // @ts-ignore: Spoofing garbage data
     badVehicle.propulsion = ['hamster']
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -248,7 +248,7 @@ describe('Tests API', () => {
   // it('verifies post device missing year', (done) => {
   //     let badVehicle = deepCopy(TEST_VEHICLE)
   //     delete badVehicle.year
-  //     request.post('/vehicles')
+  //     request.post(pathsFor('/vehicles'))
   //         .set('Authorization', AUTH)
   //         .send(badVehicle)
   //         .expect(400).end((err, result) => {
@@ -263,7 +263,7 @@ describe('Tests API', () => {
     // @ts-ignore: Spoofing garbage data
     badVehicle.year = 'hamster'
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -279,7 +279,7 @@ describe('Tests API', () => {
     const badVehicle = deepCopy(TEST_VEHICLE)
     badVehicle.year = 3000
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -295,7 +295,7 @@ describe('Tests API', () => {
     const badVehicle = deepCopy(TEST_VEHICLE)
     delete badVehicle.type
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -311,7 +311,7 @@ describe('Tests API', () => {
     // @ts-ignore: Spoofing garbage data
     badVehicle.type = 'hamster'
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(badVehicle)
       .expect(400)
@@ -326,7 +326,7 @@ describe('Tests API', () => {
 
   it('verifies post device success', done => {
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(TEST_VEHICLE)
       .expect(201)
@@ -338,7 +338,7 @@ describe('Tests API', () => {
   })
   it('verifies read back all devices from db', done => {
     request
-      .get('/vehicles')
+      .get(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -353,7 +353,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback success (database)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -367,7 +367,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback success (cache)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}?cached=true`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}?cached=true`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -381,7 +381,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback failure (provider mismatch database)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
       .set('Authorization', AUTH2)
       .expect(404)
       .end((err, result) => {
@@ -392,7 +392,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback failure (provider mismatch cache)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}?cached=true`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}?cached=true`))
       .set('Authorization', AUTH2)
       .expect(404)
       .end((err, result) => {
@@ -403,7 +403,7 @@ describe('Tests API', () => {
   })
   it('verifies post same device fails as expected', done => {
     request
-      .post('/vehicles')
+      .post(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .send(TEST_VEHICLE)
       .expect(409)
@@ -417,7 +417,7 @@ describe('Tests API', () => {
   const NEW_VEHICLE_ID = 'new-vehicle-id'
   it('verifies put update success', done => {
     request
-      .put(`/vehicles/${TEST_VEHICLE.device_id}`)
+      .put(pathPrefix(`/vehicles/${TEST_VEHICLE.device_id}`))
       .set('Authorization', AUTH)
       .send({
         vehicle_id: NEW_VEHICLE_ID
@@ -432,7 +432,7 @@ describe('Tests API', () => {
   })
   it('verifies put update failure (provider mismatch)', done => {
     request
-      .put(`/vehicles/${TEST_VEHICLE.device_id}`)
+      .put(pathPrefix(`/vehicles/${TEST_VEHICLE.device_id}`))
       .set('Authorization', AUTH2)
       .send({
         vehicle_id: NEW_VEHICLE_ID
@@ -446,7 +446,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback success after update (database)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -457,7 +457,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback success after update (cache)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}?cached=true`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}?cached=true`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -468,7 +468,7 @@ describe('Tests API', () => {
   })
   it('verifies put bogus device_id fail', done => {
     request
-      .put('/vehicles/' + 'hamster')
+      .put(pathPrefix('/vehicles/' + 'hamster'))
       .set('Authorization', AUTH)
       .send({
         vehicle_id: 'new-vehicle-id'
@@ -483,7 +483,7 @@ describe('Tests API', () => {
   })
   it('verifies put non-existent device_id fail', done => {
     request
-      .put(`/vehicles/${TRIP_UUID}`)
+      .put(pathPrefix(`/vehicles/${TRIP_UUID}`))
       .set('Authorization', AUTH)
       .send({
         vehicle_id: 'new-vehicle-id'
@@ -497,7 +497,7 @@ describe('Tests API', () => {
   })
   it('verifies read back all device_ids from db', done => {
     request
-      .get('/admin/vehicle_ids')
+      .get(pathPrefix('/admin/vehicle_ids'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -507,7 +507,7 @@ describe('Tests API', () => {
   })
   it('verifies read back for non-existent provider fails', done => {
     request
-      .get('/admin/vehicle_ids?provider_id=123potato')
+      .get(pathPrefix('/admin/vehicle_ids?provider_id=123potato'))
       .set('Authorization', AUTH)
       .expect(400)
       .end((err, result) => {
@@ -523,7 +523,7 @@ describe('Tests API', () => {
 
   it('refreshes the cache', done => {
     request
-      .get('/admin/cache/refresh')
+      .get(pathPrefix('/admin/cache/refresh'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -538,7 +538,7 @@ describe('Tests API', () => {
 
   it('verifies service_start success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'service_start',
@@ -555,7 +555,7 @@ describe('Tests API', () => {
 
   it('verifies read back all devices from db', done => {
     request
-      .get('/vehicles')
+      .get(pathPrefix('/vehicles'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -570,7 +570,7 @@ describe('Tests API', () => {
 
   it('verifies service_end success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.service_end,
@@ -587,7 +587,7 @@ describe('Tests API', () => {
   // status
   it('verifies post device status deregister success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send(test_event)
       .expect(201)
@@ -604,7 +604,7 @@ describe('Tests API', () => {
 
   it('verifies post device status bogus event', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'BOGUS',
@@ -619,7 +619,7 @@ describe('Tests API', () => {
   })
   it('verifies post device status bogus DEVICE_UUID', done => {
     request
-      .post('/vehicles/' + 'bogus' + '/event')
+      .post(pathPrefix('/vehicles/' + 'bogus' + '/event'))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -635,7 +635,7 @@ describe('Tests API', () => {
   })
   it('verifies post device status provider mismatch', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH2)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -651,7 +651,7 @@ describe('Tests API', () => {
   })
   it('verifies post device status missing timestamp', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -667,7 +667,7 @@ describe('Tests API', () => {
   })
   it('verifies post device status bad timestamp', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'provider_drop_off',
@@ -684,7 +684,7 @@ describe('Tests API', () => {
   })
   it('verifies post device maintenance event', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -698,7 +698,7 @@ describe('Tests API', () => {
   })
   it('verifies post duplicate event fails as expected', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -716,7 +716,7 @@ describe('Tests API', () => {
   })
   it('verifies post event to non-existent vehicle fails as expected', done => {
     request
-      .post(`/vehicles/${TRIP_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${TRIP_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -732,7 +732,7 @@ describe('Tests API', () => {
   })
   it('verifies post event with bad event_type_reason fails', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.provider_pick_up,
@@ -751,7 +751,7 @@ describe('Tests API', () => {
   // start_trip
   it('verifies post start trip success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_start',
@@ -766,7 +766,7 @@ describe('Tests API', () => {
   })
   it('verifies post start trip without trip-id fails', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_start',
@@ -782,7 +782,7 @@ describe('Tests API', () => {
   })
   it('verifies post trip leave success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_leave',
@@ -797,7 +797,7 @@ describe('Tests API', () => {
   })
   it('verifies post trip enter success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_enter',
@@ -812,7 +812,7 @@ describe('Tests API', () => {
   })
   it('verifies post end trip success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -834,7 +834,7 @@ describe('Tests API', () => {
 
   it('verifies post reserve success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.reserve,
@@ -849,7 +849,7 @@ describe('Tests API', () => {
   })
   it('verifies post reserve cancellation success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.cancel_reservation,
@@ -868,7 +868,7 @@ describe('Tests API', () => {
 
   it('verifies post start trip missing event', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         // event_type: 'trip_start',
@@ -890,7 +890,7 @@ describe('Tests API', () => {
 
   it('verifies post trip start missing location', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_start',
@@ -908,7 +908,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad trip_id', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -930,7 +930,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad latitude', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -952,7 +952,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad altitude', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -974,7 +974,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad accuracy', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -995,7 +995,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad speed', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -1016,7 +1016,7 @@ describe('Tests API', () => {
 
   it('verifies post trip end fail bad satellites', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -1033,7 +1033,7 @@ describe('Tests API', () => {
   })
   it('verifies post end trip missing location', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: 'trip_end',
@@ -1056,7 +1056,7 @@ describe('Tests API', () => {
   log('lateTimestamp', lateTimestamp)
   it('verifies late-event service-end (rebalance) success', done => {
     request
-      .post(`/vehicles/${DEVICE_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.service_end,
@@ -1088,7 +1088,7 @@ describe('Tests API', () => {
   // tests this particular uuid
   it('verifies wierd uuid', done => {
     request
-      .post(`/vehicles/${WEIRD_UUID}/event`)
+      .post(pathPrefix(`/vehicles/${WEIRD_UUID}/event`))
       .set('Authorization', AUTH)
       .send({
         event_type: VEHICLE_EVENTS.service_end,
@@ -1105,7 +1105,7 @@ describe('Tests API', () => {
 
   it('verifies post telemetry', done => {
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [TEST_TELEMETRY, TEST_TELEMETRY2]
@@ -1122,7 +1122,7 @@ describe('Tests API', () => {
   })
   it('verifies posting the same telemetry does not break things', done => {
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [TEST_TELEMETRY, TEST_TELEMETRY2]
@@ -1154,7 +1154,7 @@ describe('Tests API', () => {
     // @ts-ignore: Spoofing garbage data
     badTelemetry.device_id = 'bogus'
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [badTelemetry]
@@ -1175,7 +1175,7 @@ describe('Tests API', () => {
     badTelemetry.gps.lat = 'bogus'
 
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [badTelemetry]
@@ -1197,7 +1197,7 @@ describe('Tests API', () => {
     badTelemetry.gps.lng = 'bogus'
 
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [badTelemetry]
@@ -1219,7 +1219,7 @@ describe('Tests API', () => {
     badTelemetry.charge = 'bogus'
 
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [badTelemetry]
@@ -1241,7 +1241,7 @@ describe('Tests API', () => {
     badTelemetry.timestamp = 'bogus'
 
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
       .send({
         data: [badTelemetry]
@@ -1259,7 +1259,7 @@ describe('Tests API', () => {
   })
   it('verifies post telemetry with mismatched provider', done => {
     request
-      .post('/vehicles/telemetry')
+      .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH2)
       .send({
         data: [TEST_TELEMETRY]
@@ -1277,7 +1277,7 @@ describe('Tests API', () => {
   })
   it('verifies get device readback w/telemetry success (database)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1295,7 +1295,7 @@ describe('Tests API', () => {
 
   it('verifies get device readback w/telemetry success (cache)', done => {
     request
-      .get(`/vehicles/${DEVICE_UUID}?cached=true`)
+      .get(pathPrefix(`/vehicles/${DEVICE_UUID}?cached=true`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1312,21 +1312,24 @@ describe('Tests API', () => {
   })
 
   it('verifies get device defaults to `deregister` if cache misses reads for associated events', async () => {
-    await request.post('/vehicles').set('Authorization', AUTH).send(JUMP_TEST_DEVICE_1).expect(201)
+    await request.post(pathPrefix('/vehicles')).set('Authorization', AUTH).send(JUMP_TEST_DEVICE_1).expect(201)
 
     await request
-      .post(`/vehicles/${JUMP_TEST_DEVICE_1_ID}/event`)
+      .post(pathPrefix(`/vehicles/${JUMP_TEST_DEVICE_1_ID}/event`))
       .set('Authorization', AUTH)
       .send({ device_id: JUMP_TEST_DEVICE_1, timestamp: now(), event_type: VEHICLE_EVENTS.deregister })
       .expect(201)
 
-    const result = await request.get(`/vehicles/${JUMP_TEST_DEVICE_1_ID}`).set('Authorization', AUTH).expect(200)
+    const result = await request
+      .get(pathPrefix(`/vehicles/${JUMP_TEST_DEVICE_1_ID}`))
+      .set('Authorization', AUTH)
+      .expect(200)
     test.assert(result.body.status === VEHICLE_STATUSES.inactive)
     test.assert(result.body.prev_event === VEHICLE_EVENTS.deregister)
   })
 
   it('get multiple devices endpoint has vehicle status default to `inactive` if event is missing for a device', async () => {
-    const result = await request.get(`/vehicles/`).set('Authorization', AUTH).expect(200)
+    const result = await request.get(pathPrefix(`/vehicles/`)).set('Authorization', AUTH).expect(200)
     const ids = result.body.vehicles.map((device: any) => device.device_id)
     test.assert(ids.includes(JUMP_TEST_DEVICE_1_ID))
     result.body.vehicles.map((device: any) => {
@@ -1338,7 +1341,7 @@ describe('Tests API', () => {
 
   it('gets cache info', done => {
     request
-      .get('/admin/cache/info')
+      .get(pathPrefix('/admin/cache/info'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1349,7 +1352,7 @@ describe('Tests API', () => {
 
   it('refreshes the cache', done => {
     request
-      .get('/admin/cache/refresh')
+      .get(pathPrefix('/admin/cache/refresh'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1359,7 +1362,7 @@ describe('Tests API', () => {
   })
   it('wipes a vehicle via admin', done => {
     request
-      .get(`/admin/wipe/${TEST_VEHICLE.device_id}`)
+      .get(pathPrefix(`/admin/wipe/${TEST_VEHICLE.device_id}`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1369,7 +1372,7 @@ describe('Tests API', () => {
   })
   it('wipes a vehicle via admin that has already been wiped', done => {
     request
-      .get(`/admin/wipe/${TEST_VEHICLE.device_id}`)
+      .get(pathPrefix(`/admin/wipe/${TEST_VEHICLE.device_id}`))
       .set('Authorization', AUTH)
       .expect(404)
       .end((err, result) => {
@@ -1379,7 +1382,7 @@ describe('Tests API', () => {
   })
   it('fails to wipe a vehicle via admin', done => {
     request
-      .get('/admin/wipe/' + 'bogus')
+      .get(pathPrefix('/admin/wipe/' + 'bogus'))
       .set('Authorization', AUTH)
       .expect(400)
       .end((err, result) => {
@@ -1400,7 +1403,7 @@ describe('Tests pagination', async () => {
 
   it('verifies paging links when read back all devices from db', done => {
     request
-      .get('/vehicles?skip=2&take=5&foo=bar')
+      .get(pathPrefix('/vehicles?skip=2&take=5&foo=bar'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1416,7 +1419,7 @@ describe('Tests pagination', async () => {
 
   it('verifies reading past the end of the vehicles', done => {
     request
-      .get('/vehicles?skip=20000&take=5')
+      .get(pathPrefix('/vehicles?skip=20000&take=5'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1430,7 +1433,7 @@ describe('Tests pagination', async () => {
   it('verifies vehicles access for all providers with vehicles:read scope', done => {
     const VEHICLES_READ_AUTH = `basic ${Buffer.from(`${TEST2_PROVIDER_ID}|vehicles:read`).toString('base64')}`
     request
-      .get(`/vehicles?provider_id=${TEST1_PROVIDER_ID}`)
+      .get(pathPrefix(`/vehicles?provider_id=${TEST1_PROVIDER_ID}`))
       .set('Authorization', VEHICLES_READ_AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1444,7 +1447,7 @@ describe('Tests pagination', async () => {
   it('verifies no vehicles access for all providers without vehicles:read scope', done => {
     const VEHICLES_READ_AUTH = `basic ${Buffer.from(`${TEST2_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
     request
-      .get(`/vehicles?provider_id=${TEST1_PROVIDER_ID}`)
+      .get(pathPrefix(`/vehicles?provider_id=${TEST1_PROVIDER_ID}`))
       .set('Authorization', VEHICLES_READ_AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1488,18 +1491,18 @@ describe('Tests Stops', async () => {
   })
 
   it('verifies failing to POST a stop (garbage data)', async () => {
-    await request.post(`/stops`).set('Authorization', AUTH).send({ foo: 'bar' }).expect(400)
+    await request.post(pathPrefix(`/stops`)).set('Authorization', AUTH).send({ foo: 'bar' }).expect(400)
   })
 
   it('verifies successfully POSTing a stop', async () => {
     await db.writeGeography(LAGeography)
     await db.publishGeography({ geography_id: GEOGRAPHY_UUID, publish_date: now() })
-    await request.post(`/stops`).set('Authorization', AUTH).send(TEST_STOP).expect(201)
+    await request.post(pathPrefix(`/stops`)).set('Authorization', AUTH).send(TEST_STOP).expect(201)
   })
 
   it('verifies successfully GETing a stop', done => {
     request
-      .get(`/stops/${TEST_STOP.stop_id}`)
+      .get(pathPrefix(`/stops/${TEST_STOP.stop_id}`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -1510,7 +1513,7 @@ describe('Tests Stops', async () => {
 
   it('verifies successfully GETing all stops', done => {
     request
-      .get(`/stops`)
+      .get(pathPrefix(`/stops`))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser'
 import express from 'express'
 import CorsMiddleware from 'cors'
 import logger from '@mds-core/mds-logger'
-import { pathsFor, AuthorizationError } from '@mds-core/mds-utils'
+import { pathPrefix, AuthorizationError } from '@mds-core/mds-utils'
 import {
   AuthorizationHeaderApiAuthorizer,
   ApiAuthorizer,
@@ -282,7 +282,7 @@ export const ApiServer = (
   )
 
   // Health Route
-  app.get(pathsFor('/health'), HealthRequestHandler)
+  app.get(pathPrefix('/health'), HealthRequestHandler)
 
   return api(app)
 }

--- a/packages/mds-api-server/tests/index.spec.ts
+++ b/packages/mds-api-server/tests/index.spec.ts
@@ -18,6 +18,7 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
+import { pathPrefix } from '@mds-core/mds-utils'
 import { ApiServer, HttpServer, ApiVersionMiddleware, ApiVersionedResponse } from '../index'
 
 const TEST_API_MIME_TYPE = 'application/vnd.mds.test+json'
@@ -61,7 +62,7 @@ describe('Testing API Server', () => {
 
   it('verifies health', done => {
     request
-      .get('/health')
+      .get(pathPrefix('/health'))
       .expect(200)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -18,7 +18,7 @@ import db from '@mds-core/mds-db'
 import express from 'express'
 import {
   uuid,
-  pathsFor,
+  pathPrefix,
   seconds,
   AuthorizationError,
   ConflictError,
@@ -158,7 +158,7 @@ function api(app: express.Express): express.Express {
   /**
    * Audit middleware to load the audit into locals using the audit_trip_id
    */
-  app.use(pathsFor('/trips/:audit_trip_id'), async (req: AuditApiTripRequest, res: AuditApiResponse, next) => {
+  app.use(pathPrefix('/trips/:audit_trip_id'), async (req: AuditApiTripRequest, res: AuditApiResponse, next) => {
     try {
       const { audit_trip_id } = req.params
       if (isValidAuditTripId(audit_trip_id)) {
@@ -184,7 +184,7 @@ function api(app: express.Express): express.Express {
    * @param {UUID} audit_trip_id unique ID of this audit record (client-generated)
    */
   app.post(
-    pathsFor('/trips/:audit_trip_id/start'),
+    pathPrefix('/trips/:audit_trip_id/start'),
     checkAuditApiAccess(scopes => scopes.includes('audits:write')),
     async (req: AuditApiAuditStartRequest, res: PostAuditTripStartResponse) => {
       try {
@@ -269,7 +269,7 @@ function api(app: express.Express): express.Express {
    * @param {string} device_id device_id
    */
   app.post(
-    pathsFor('/trips/:audit_trip_id/vehicle/event'),
+    pathPrefix('/trips/:audit_trip_id/vehicle/event'),
     checkAuditApiAccess(scopes => scopes.includes('audits:write')),
     async (req: AuditApiVehicleEventRequest, res: PostAuditTripVehicleEventResponse) => {
       try {
@@ -319,7 +319,7 @@ function api(app: express.Express): express.Express {
    * @param {UUID} audit_trip_id unique ID of this audit record (client-generated)
    */
   app.post(
-    pathsFor('/trips/:audit_trip_id/vehicle/telemetry'),
+    pathPrefix('/trips/:audit_trip_id/vehicle/telemetry'),
     checkAuditApiAccess(scopes => scopes.includes('audits:write')),
     async (req: AuditApiVehicleTelemetryRequest, res: PostAuditTripTelemetryResponse) => {
       try {
@@ -365,7 +365,7 @@ function api(app: express.Express): express.Express {
    * @param {UUID} audit_trip_id unique ID of this audit record (client-generated)
    */
   app.post(
-    [...pathsFor('/trips/:audit_trip_id/note'), ...pathsFor('/trips/:audit_trip_id/event')],
+    [pathPrefix('/trips/:audit_trip_id/note'), pathPrefix('/trips/:audit_trip_id/event')],
     checkAuditApiAccess(scopes => scopes.includes('audits:write')),
     async (req: AuditApiAuditNoteRequest, res: PostAuditTripNoteResponse | PostAuditTripEventResponse) => {
       try {
@@ -431,7 +431,7 @@ function api(app: express.Express): express.Express {
    * @param {UUID} audit_trip_id unique ID of this audit record (client-generated)
    */
   app.post(
-    pathsFor('/trips/:audit_trip_id/end'),
+    pathPrefix('/trips/:audit_trip_id/end'),
     checkAuditApiAccess(scopes => scopes.includes('audits:write')),
     async (req: AuditApiAuditEndRequest, res: PostAuditTripEndResponse) => {
       try {
@@ -480,7 +480,7 @@ function api(app: express.Express): express.Express {
    * @param {UUID} audit_trip_id unique ID of this audit record (client-generated)
    */
   app.get(
-    pathsFor('/trips/:audit_trip_id'),
+    pathPrefix('/trips/:audit_trip_id'),
     checkAuditApiAccess(scopes => scopes.includes('audits:read')),
     async (req: AuditApiGetTripRequest, res: GetAuditTripDetailsResponse) => {
       try {
@@ -594,7 +594,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.delete(
-    pathsFor('/trips/:audit_trip_id'),
+    pathPrefix('/trips/:audit_trip_id'),
     checkAuditApiAccess(scopes => scopes.includes('audits:delete')),
     async (req: AuditApiTripRequest, res: DeleteAuditTripResponse) => {
       try {
@@ -623,7 +623,7 @@ function api(app: express.Express): express.Express {
    * read back multiple audit records
    */
   app.get(
-    pathsFor('/trips'),
+    pathPrefix('/trips'),
     checkAuditApiAccess(scopes => scopes.includes('audits:read') || scopes.includes('audits:read:provider')),
     async (req: AuditApiGetTripsRequest, res: GetAuditTripsDetailsResponse) => {
       try {
@@ -685,7 +685,7 @@ function api(app: express.Express): express.Express {
    * read back cached vehicle information for vehicles in bbox
    */
   app.get(
-    pathsFor('/vehicles'),
+    pathPrefix('/vehicles'),
     checkAuditApiAccess(scopes => scopes.includes('audits:vehicles:read')),
     async (req: AuditApiGetVehicleRequest, res: GetAuditVehiclesResponse) => {
       const { skip, take } = { skip: 0, take: 10000 }
@@ -716,7 +716,7 @@ function api(app: express.Express): express.Express {
    * read back cached information for a single vehicle
    */
   app.get(
-    pathsFor('/vehicles/:provider_id/vin/:vin'),
+    pathPrefix('/vehicles/:provider_id/vin/:vin'),
     async (req: AuditApiGetVehicleRequest, res: GetVehicleByVinResponse) => {
       const { provider_id, vin } = req.params
       try {
@@ -739,7 +739,7 @@ function api(app: express.Express): express.Express {
    * attach media to an audit, uploaded as multipart/form-data
    */
   app.post(
-    pathsFor('/trips/:audit_trip_id/attach/:mimetype'),
+    pathPrefix('/trips/:audit_trip_id/attach/:mimetype'),
     multipartFormUpload,
     async (req, res: PostAuditAttachmentResponse) => {
       const { audit, audit_trip_id } = res.locals
@@ -773,7 +773,7 @@ function api(app: express.Express): express.Express {
   /**
    * delete media from an audit
    */
-  app.delete(pathsFor('/trips/:audit_trip_id/attachment/:attachment_id'), async (req, res) => {
+  app.delete(pathPrefix('/trips/:audit_trip_id/attachment/:attachment_id'), async (req, res) => {
     const { audit_trip_id, attachment_id } = req.params
     try {
       await deleteAuditAttachment(audit_trip_id, attachment_id)

--- a/packages/mds-audit/server.ts
+++ b/packages/mds-audit/server.ts
@@ -17,4 +17,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.AUDIT_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.AUDIT_API_HTTP_PORT })

--- a/packages/mds-audit/tests/api.spec.ts
+++ b/packages/mds-audit/tests/api.spec.ts
@@ -36,7 +36,7 @@ import {
   VEHICLE_TYPES
 } from '@mds-core/mds-types'
 import { makeEventsWithTelemetry, makeDevices, makeTelemetryInArea, SCOPED_AUTH } from '@mds-core/mds-test-data'
-import { NotFoundError, now, rangeRandomInt, uuid } from '@mds-core/mds-utils'
+import { NotFoundError, now, rangeRandomInt, uuid, pathPrefix } from '@mds-core/mds-utils'
 import cache from '@mds-core/mds-agency-cache'
 import test from 'unit.js'
 import { ApiServer } from '@mds-core/mds-api-server'
@@ -131,7 +131,7 @@ describe('Testing API', () => {
 
   it('verify audit start (matching vehicle)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/start`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/start`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         audit_event_id: uuid(),
@@ -155,7 +155,7 @@ describe('Testing API', () => {
 
   it('verify audit start (conflict)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/start`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/start`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .expect(409)
       .end((err, result) => {
@@ -166,7 +166,7 @@ describe('Testing API', () => {
 
   it('verify audit start (no scope)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/start`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/start`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .expect(403)
       .end((err, result) => {
@@ -177,7 +177,7 @@ describe('Testing API', () => {
 
   it('verify audit issue event', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/event`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/event`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         audit_event_id: uuid(),
@@ -197,7 +197,7 @@ describe('Testing API', () => {
 
   it('verify audit issue event (no scope)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/event`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/event`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .send({
         audit_event_id: uuid(),
@@ -217,7 +217,7 @@ describe('Testing API', () => {
 
   it('verify trip start event', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/vehicle/event`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/vehicle/event`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         event_type: VEHICLE_EVENTS.trip_start,
@@ -236,7 +236,7 @@ describe('Testing API', () => {
 
   it('verify audit telemetry', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/vehicle/telemetry`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/vehicle/telemetry`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         telemetry: telemetry(),
@@ -253,7 +253,7 @@ describe('Testing API', () => {
 
   it('verify audit telemetry (no scope)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/vehicle/telemetry`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/vehicle/telemetry`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .send({
         telemetry: telemetry(),
@@ -269,7 +269,7 @@ describe('Testing API', () => {
 
   it('verify trip end event', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/vehicle/event`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/vehicle/event`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         event_type: VEHICLE_EVENTS.trip_end,
@@ -287,7 +287,7 @@ describe('Testing API', () => {
 
   it('verify audit summary event', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/event`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/event`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         audit_event_id: uuid(),
@@ -307,7 +307,7 @@ describe('Testing API', () => {
 
   it('verify audit end', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/end`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/end`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         audit_event_id: uuid(),
@@ -325,7 +325,7 @@ describe('Testing API', () => {
 
   it('verify audit end (no scope)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id}/end`)
+      .post(pathPrefix(`/trips/${audit_trip_id}/end`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .send({
         audit_event_id: uuid(),
@@ -340,12 +340,12 @@ describe('Testing API', () => {
       })
   })
 
-  const routes = ['note', 'vehicle/event', 'vehicle/telemetry', 'end'].map(path => `/audit/trips/${uuid()}/${path}`)
+  const routes = ['note', 'vehicle/event', 'vehicle/telemetry', 'end'].map(path => `/trips/${uuid()}/${path}`)
 
   routes.forEach(route =>
     it(`verify post audit (not found) ${route}`, done => {
       request
-        .post(route)
+        .post(pathPrefix(route))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .expect(404)
         .end((err, result) => {
@@ -358,7 +358,7 @@ describe('Testing API', () => {
 
   it('verify get audit (matched vehicle)', done => {
     request
-      .get(`/audit/trips/${audit_trip_id}`)
+      .get(pathPrefix(`/trips/${audit_trip_id}`))
       .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
       .expect(200)
       .end((err, result) => {
@@ -376,7 +376,7 @@ describe('Testing API', () => {
 
   it(`verify get audit (no scope)`, done => {
     request
-      .get(`/audit/trips/${uuid()}`)
+      .get(pathPrefix(`/trips/${uuid()}`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .expect(403)
       .end((err, result) => {
@@ -388,7 +388,7 @@ describe('Testing API', () => {
 
   it(`verify get audit (not found)`, done => {
     request
-      .get(`/audit/trips/${uuid()}`)
+      .get(pathPrefix(`/trips/${uuid()}`))
       .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
       .expect(404)
       .end((err, result) => {
@@ -400,7 +400,7 @@ describe('Testing API', () => {
 
   it(`verify list audits (no scope)`, done => {
     request
-      .get(`/audit/trips`)
+      .get(pathPrefix(`/trips`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .expect(403)
       .end((err, result) => {
@@ -427,7 +427,7 @@ describe('Testing API', () => {
   queries.forEach(({ filter, query, count }) =>
     it(`verify list audits (Filter: ${filter}, Count: ${count})`, done => {
       request
-        .get(`/audit/trips${query}`)
+        .get(pathPrefix(`/trips${query}`))
         .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -442,7 +442,7 @@ describe('Testing API', () => {
 
   it('verify delete audit (no scope)', done => {
     request
-      .delete(`/audit/trips/${uuid()}`)
+      .delete(pathPrefix(`/trips/${uuid()}`))
       .set('Authorization', SCOPED_AUTH([], ''))
       .expect(403)
       .end((err, result) => {
@@ -454,7 +454,7 @@ describe('Testing API', () => {
 
   it('verify delete audit (not found)', done => {
     request
-      .delete(`/audit/trips/${uuid()}`)
+      .delete(pathPrefix(`/trips/${uuid()}`))
       .set('Authorization', SCOPED_AUTH(['audits:delete'], audit_subject_id))
       .expect(404)
       .end((err, result) => {
@@ -466,7 +466,7 @@ describe('Testing API', () => {
 
   it('verify delete audit', done => {
     request
-      .delete(`/audit/trips/${audit_trip_id}`)
+      .delete(pathPrefix(`/trips/${audit_trip_id}`))
       .set('Authorization', SCOPED_AUTH(['audits:delete'], audit_subject_id))
       .expect(200)
       .end((err, result) => {
@@ -479,7 +479,7 @@ describe('Testing API', () => {
 
   it('verify audit start (missing vehicle)', done => {
     request
-      .post(`/audit/trips/${audit_trip_id_2}/start`)
+      .post(pathPrefix(`/trips/${audit_trip_id_2}/start`))
       .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
       .send({
         audit_event_id: uuid(),
@@ -502,7 +502,7 @@ describe('Testing API', () => {
 
   it('verify get audit (missing vehicle)', done => {
     request
-      .get(`/audit/trips/${audit_trip_id_2}`)
+      .get(pathPrefix(`/trips/${audit_trip_id_2}`))
       .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
       .expect(200)
       .end((err, result) => {
@@ -525,7 +525,7 @@ describe('Testing API', () => {
   vehicles.forEach(vehicle_id =>
     it(`verify vehicle matching ${vehicle_id}`, done => {
       request
-        .post(`/audit/trips/${uuid()}/start`)
+        .post(pathPrefix(`/trips/${uuid()}/start`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .send({
           audit_event_id: uuid(),
@@ -581,7 +581,7 @@ describe('Testing API', () => {
         [-118.452283, 33.96299]
       ] // BBOX encompasses the entirity of CANALS
       request
-        .get(`/vehicles?bbox=${JSON.stringify(bbox)}`)
+        .get(pathPrefix(`/vehicles?bbox=${JSON.stringify(bbox)}`))
         .set('Authorization', SCOPED_AUTH(['audits:vehicles:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -599,7 +599,7 @@ describe('Testing API', () => {
 
     it('Verify get vehicle by vehicle_id and provider_id', done => {
       request
-        .get(`/audit/vehicles/${devices_a[0].provider_id}/vin/${devices_a[0].vehicle_id}`)
+        .get(pathPrefix(`/vehicles/${devices_a[0].provider_id}/vin/${devices_a[0].vehicle_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:vehicles:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -618,7 +618,7 @@ describe('Testing API', () => {
 
     it('Verify get vehicle by vehicle_id and provider_id (not found)', done => {
       request
-        .get(`/audit/vehicles/${uuid()}/vin/${devices_a[0].vehicle_id}`)
+        .get(pathPrefix(`/vehicles/${uuid()}/vin/${devices_a[0].vehicle_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:vehicles:read'], audit_subject_id))
         .expect(404)
         .end((err, result) => {
@@ -630,7 +630,7 @@ describe('Testing API', () => {
 
     it('Verify get vehicle by vehicle_id and provider_id (no event or telemetry)', done => {
       request
-        .get(`/audit/vehicles/${devices_c[0].provider_id}/vin/${devices_c[0].vehicle_id}`)
+        .get(pathPrefix(`/vehicles/${devices_c[0].provider_id}/vin/${devices_c[0].vehicle_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:vehicles:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -643,7 +643,7 @@ describe('Testing API', () => {
 
     it('Verify get vehicle by vehicle_id and provider_id (duplicate device)', done => {
       request
-        .get(`/audit/vehicles/${devices_c[0].provider_id}/vin/${devices_c[0].vehicle_id}`)
+        .get(pathPrefix(`/vehicles/${devices_c[0].provider_id}/vin/${devices_c[0].vehicle_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:vehicles:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -709,7 +709,7 @@ describe('Testing API', () => {
 
     it('verify get audit by id with attachments', done => {
       request
-        .get(`/audit/trips/${audit_trip_id}`)
+        .get(pathPrefix(`/trips/${audit_trip_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -722,7 +722,7 @@ describe('Testing API', () => {
 
     it('verify get trips with attachments', done => {
       request
-        .get('/audit/trips')
+        .get(pathPrefix('/trips'))
         .set('Authorization', SCOPED_AUTH(['audits:read'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -737,7 +737,7 @@ describe('Testing API', () => {
 
     it('verify provider can get own trips', done => {
       request
-        .get('/audit/trips')
+        .get(pathPrefix('/trips'))
         .set('Authorization', SCOPED_AUTH(['audits:read:provider'], provider_id))
         .expect(200)
         .end((err, result) => {
@@ -753,7 +753,7 @@ describe('Testing API', () => {
 
     it("verify provider cannot get others' trips", done => {
       request
-        .get('/audit/trips')
+        .get(pathPrefix('/trips'))
         .set('Authorization', SCOPED_AUTH(['audits:read:provider'], uuid())) // Generate arbitrary provider_id
         .expect(200)
         .end((err, result) => {
@@ -765,7 +765,7 @@ describe('Testing API', () => {
 
     it('verify post attachment (audit not found)', done => {
       request
-        .post(`/trips/${uuid()}/attach/image%2Fpng`)
+        .post(pathPrefix(`/trips/${uuid()}/attach/image%2Fpng`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .send({}) // TODO: include file
         .expect(404)
@@ -803,7 +803,7 @@ describe('Testing API', () => {
     attachmentTests.forEach(testCase =>
       it(`verify post bad attachment (${testCase.name})`, done => {
         request
-          .post(`/trips/${audit_trip_id}/attach/image%2Fpng`)
+          .post(pathPrefix(`/trips/${audit_trip_id}/attach/image%2Fpng`))
           .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
           .attach('file', `./tests/${testCase.file}`)
           .expect(testCase.status)
@@ -826,7 +826,7 @@ describe('Testing API', () => {
       } as Attachment)
       Sinon.replace(attachments, 'writeAttachment', fake)
       request
-        .post(`/trips/${audit_trip_id}/attach/image%2Fpng`)
+        .post(pathPrefix(`/trips/${audit_trip_id}/attach/image%2Fpng`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .attach('file', `./tests/sample.png`)
         .expect(200)
@@ -842,7 +842,7 @@ describe('Testing API', () => {
       const fake = Sinon.fake.returns(null)
       Sinon.replace(attachments, 'writeAttachment', fake)
       request
-        .post(`/trips/${audit_trip_id}/attach/image%2Fpng`)
+        .post(pathPrefix(`/trips/${audit_trip_id}/attach/image%2Fpng`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .attach('file', `./tests/sample.png`)
         .expect(500)
@@ -856,7 +856,7 @@ describe('Testing API', () => {
       const fake = Sinon.fake.returns(null)
       Sinon.replace(attachments, 'deleteAuditAttachment', fake)
       request
-        .delete(`/trips/${audit_trip_id}/attachment/${attachment_id}`)
+        .delete(pathPrefix(`/trips/${audit_trip_id}/attachment/${attachment_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .expect(200)
         .end((err, result) => {
@@ -869,7 +869,7 @@ describe('Testing API', () => {
       const fake = Sinon.fake.throws(new NotFoundError())
       Sinon.replace(attachments, 'deleteAuditAttachment', fake)
       request
-        .delete(`/trips/${audit_trip_id}/attachment/${attachment_id}`)
+        .delete(pathPrefix(`/trips/${audit_trip_id}/attachment/${attachment_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .expect(404)
         .end((err, result) => {
@@ -882,7 +882,7 @@ describe('Testing API', () => {
       const fake = Sinon.fake.throws(new Error())
       Sinon.replace(attachments, 'deleteAuditAttachment', fake)
       request
-        .delete(`/trips/${audit_trip_id}/attachment/${attachment_id}`)
+        .delete(pathPrefix(`/trips/${audit_trip_id}/attachment/${attachment_id}`))
         .set('Authorization', SCOPED_AUTH(['audits:write'], audit_subject_id))
         .expect(500)
         .end((err, result) => {

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -21,7 +21,7 @@ import logger from '@mds-core/mds-logger'
 import {
   isUUID,
   now,
-  pathsFor,
+  pathPrefix,
   getPolygon,
   pointInShape,
   isInStatesOrEvents,
@@ -86,7 +86,7 @@ function api(app: express.Express): express.Express {
   })
 
   app.get(
-    pathsFor('/snapshot/:policy_uuid'),
+    pathPrefix('/snapshot/:policy_uuid'),
     async (req: ComplianceApiSnapshotRequest, res: ComplianceApiSnapshotResponse) => {
       const { provider_id, version } = res.locals
       const { provider_id: queried_provider_id, timestamp } = {
@@ -144,7 +144,7 @@ function api(app: express.Express): express.Express {
     }
   )
 
-  app.get(pathsFor('/count/:rule_id'), async (req: ComplianceApiCountRequest, res: ComplianceApiCountResponse) => {
+  app.get(pathPrefix('/count/:rule_id'), async (req: ComplianceApiCountRequest, res: ComplianceApiCountResponse) => {
     const { timestamp } = {
       ...parseRequest(req, { parser: Number }).query('timestamp')
     }

--- a/packages/mds-compliance/server.ts
+++ b/packages/mds-compliance/server.ts
@@ -14,4 +14,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.COMPLIANCE_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.COMPLIANCE_API_HTTP_PORT })

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -20,7 +20,7 @@ import cache from '@mds-core/mds-agency-cache'
 import db from '@mds-core/mds-db'
 import stream from '@mds-core/mds-stream'
 import supertest from 'supertest'
-import { now, uuid, minutes } from '@mds-core/mds-utils'
+import { now, uuid, minutes, pathPrefix } from '@mds-core/mds-utils'
 import {
   Telemetry,
   Device,
@@ -258,7 +258,7 @@ describe('Tests Compliance API:', () => {
     beforeEach(done => {
       Promise.all([db.initialize(), cache.initialize()]).then(() => {
         agency_request
-          .post('/vehicles')
+          .post(pathPrefix('/vehicles'))
           .set('Authorization', ADMIN_AUTH)
           .send(TEST_VEHICLE)
           .expect(201)
@@ -290,7 +290,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies initial policy hit OK', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -301,7 +301,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies cannot query invalid policy_id', done => {
       request
-        .get(`/snapshot/potato`)
+        .get(pathPrefix(`/snapshot/potato`))
         .set('Authorization', ADMIN_AUTH)
         .expect(400)
         .end((err, result) => {
@@ -312,7 +312,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies cannot query valid UUID, but invalid policy_id', done => {
       request
-        .get(`/snapshot/f4a07b35-98dd-4234-93c7-199ea54083c3`)
+        .get(pathPrefix(`/snapshot/f4a07b35-98dd-4234-93c7-199ea54083c3`))
         .set('Authorization', ADMIN_AUTH)
         .expect(404)
         .end((err, result) => {
@@ -344,7 +344,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies count in compliance', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -371,12 +371,12 @@ describe('Tests Compliance API:', () => {
   //       telemetry.push(makeTelemetryInArea(device, now(), CITY_OF_LA, 10))
   //     })
   //     request
-  //       .get('/test/initialize')
+  //       .get(pathsFor('/test/initialize'))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end(() => {
   //         provider_request
-  //           .post('/test/seed')
+  //           .post(pathsFor('/test/seed'))
   //           .set('Authorization', PROVIDER_AUTH)
   //           .send({ devices, events, telemetry })
   //           .expect(201)
@@ -404,7 +404,7 @@ describe('Tests Compliance API:', () => {
 
   //   it('Verifies violation of count compliance (under)', done => {
   //     request
-  //       .get(`/snapshot/${COUNT_POLICY_UUID}`)
+  //       .get(pathsFor(`/snapshot/${COUNT_POLICY_UUID}`))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end((err, result) => {
@@ -418,7 +418,7 @@ describe('Tests Compliance API:', () => {
 
   //   afterEach(done => {
   //     agency_request
-  //       .get('/test/shutdown')
+  //       .get(pathsFor('/test/shutdown'))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end(err => {
@@ -451,7 +451,7 @@ describe('Tests Compliance API:', () => {
     it('Verifies violation of count compliance (over) and filters results by provider_id', async () => {
       // Admins should be able to see violations across all providers
       const adminResult = await request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
       test.assert.deepEqual(adminResult.body.compliance[0].matches[0].measured, 10)
@@ -463,7 +463,7 @@ describe('Tests Compliance API:', () => {
       // Admins should be able to query for a specific provider's compliance results
       // and only see the number of violations for that provider
       const provider1Result = await request
-        .get(`/snapshot/${COUNT_POLICY_UUID}?provider_id=${TEST1_PROVIDER_ID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}?provider_id=${TEST1_PROVIDER_ID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
       test.assert.deepEqual(provider1Result.body.compliance[0].matches[0].measured, 10)
@@ -474,7 +474,7 @@ describe('Tests Compliance API:', () => {
 
       // If a policy applies to every provider, a provider will see only its own compliance results.
       const jumpResult = await request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', JUMP_PROVIDER_AUTH)
         .expect(200)
       test.assert.deepEqual(jumpResult.body.compliance[0].matches[0].measured, 10)
@@ -508,7 +508,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies OK time compliance', done => {
       request
-        .get(`/snapshot/${TIME_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${TIME_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -545,7 +545,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies violation of time compliance', done => {
       request
-        .get(`/snapshot/${TIME_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${TIME_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -564,7 +564,7 @@ describe('Tests Compliance API:', () => {
     it('Checks for a valid UUID, but not present in db', done => {
       Promise.all([db.initialize(), cache.initialize()]).then(async () => {
         request
-          .get(`/snapshot/${TIME_POLICY_UUID}`)
+          .get(pathPrefix(`/snapshot/${TIME_POLICY_UUID}`))
           .set('Authorization', ADMIN_AUTH)
           .expect(404)
           .end(err => {
@@ -597,7 +597,7 @@ describe('Tests Compliance API:', () => {
     it('Verifies on a tuesday that vehicles are allowed', done => {
       MockDate.set('2019-05-21T20:00:00.000Z')
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_2}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_2}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -610,7 +610,7 @@ describe('Tests Compliance API:', () => {
     it('Verifies on a saturday that vehicles are not allowed', done => {
       MockDate.set('2019-05-25T20:00:00.000Z')
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_2}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_2}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -648,7 +648,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies violation for particular event', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_3}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_3}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -686,7 +686,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies compliance for particular event', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_3}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_3}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -797,7 +797,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verify 22 vehicles are matched within the first rule (inside of allowed zones), and 10 in the second (because they have not been previously matched).', done => {
       request
-        .get(`/snapshot/${VENICE_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${VENICE_POLICY_UUID}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -845,7 +845,7 @@ describe('Tests Compliance API:', () => {
 
     it('Historical check reports 5 violations', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_4}?timestamp=${yesterday + 200}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_4}?timestamp=${yesterday + 200}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -857,7 +857,7 @@ describe('Tests Compliance API:', () => {
 
     it('Current check reports 0 violations', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID_4}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID_4}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -899,7 +899,7 @@ describe('Tests Compliance API:', () => {
 
     it('Test count endpoint, expecting events', done => {
       request
-        .get(`/count/47c8c7d4-14b5-43a3-b9a5-a32ecc2fb2c6`)
+        .get(pathPrefix(`/count/47c8c7d4-14b5-43a3-b9a5-a32ecc2fb2c6`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -912,7 +912,7 @@ describe('Tests Compliance API:', () => {
 
     it('Test count endpoint, expecting no events', done => {
       request
-        .get(`/count/47c8c7d4-14b5-43a3-b9a5-a32ecc2fb2c6?timestamp=${START_ONE_MONTH_AGO}`)
+        .get(pathPrefix(`/count/47c8c7d4-14b5-43a3-b9a5-a32ecc2fb2c6?timestamp=${START_ONE_MONTH_AGO}`))
         .set('Authorization', ADMIN_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -924,7 +924,7 @@ describe('Tests Compliance API:', () => {
 
     it('Test count endpoint failure with bad rule_id', done => {
       request
-        .get(`/count/33ca0ee8-e74b-419d-88d3-aaaf05ac0509`)
+        .get(pathPrefix(`/count/33ca0ee8-e74b-419d-88d3-aaaf05ac0509`))
         .set('Authorization', ADMIN_AUTH)
         .expect(404)
         .end(err => {
@@ -954,7 +954,7 @@ describe('Tests Compliance API:', () => {
 
     it("Verifies scoped provider can access policy's compliance", done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', TEST2_PROVIDER_AUTH)
         .expect(200)
         .end((err, result) => {
@@ -966,7 +966,7 @@ describe('Tests Compliance API:', () => {
 
     it("Verifies non-scoped provider cannot access policy's compliance", done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_UUID}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
         .set('Authorization', MOCHA_PROVIDER_AUTH)
         .expect(401)
         .end((err, result) => {
@@ -1002,7 +1002,7 @@ describe('Tests Compliance API:', () => {
 
     it('Verifies max 0 single rule policy operates as expected', done => {
       request
-        .get(`/snapshot/${COUNT_POLICY_JSON_5.policy_id}`)
+        .get(pathPrefix(`/snapshot/${COUNT_POLICY_JSON_5.policy_id}`))
         .set('Authorization', TEST2_PROVIDER_AUTH)
         .expect(200)
         .end((err, result) => {

--- a/packages/mds-daily/api.ts
+++ b/packages/mds-daily/api.ts
@@ -19,7 +19,7 @@ import express from 'express'
 import logger from '@mds-core/mds-logger'
 import cache from '@mds-core/mds-agency-cache'
 import { providerName, isProviderId } from '@mds-core/mds-providers'
-import { isUUID, pathsFor, now } from '@mds-core/mds-utils'
+import { isUUID, pathPrefix, now } from '@mds-core/mds-utils'
 import { checkAccess, AccessTokenScopeValidator } from '@mds-core/mds-api-server'
 import { DailyApiRequest, DailyApiResponse, DailyApiAccessTokenScopes } from './types'
 import {
@@ -92,14 +92,14 @@ function api(app: express.Express): express.Express {
   // ///////////////////// begin daily endpoints ///////////////////////
 
   app.get(
-    pathsFor('/admin/vehicle_counts'),
+    pathPrefix('/admin/vehicle_counts'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getVehicleCounts
   )
 
   // read all the latest events out of the cache
   app.get(
-    pathsFor('/admin/events'),
+    pathPrefix('/admin/events'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     async (req: DailyApiRequest, res: DailyApiResponse) => {
       const start = now()
@@ -114,14 +114,14 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/admin/last_day_trips_by_provider'),
+    pathPrefix('/admin/last_day_trips_by_provider'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getLastDayTripsByProvider
   )
 
   // get raw trip data for analysis
   app.get(
-    pathsFor('/admin/raw_trip_data/:trip_id'),
+    pathPrefix('/admin/raw_trip_data/:trip_id'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getRawTripData
   )
@@ -133,49 +133,49 @@ function api(app: express.Express): express.Express {
   // by asking the DB for that information.
   // This function is ludicrously long as it is.
   app.get(
-    pathsFor('/admin/last_day_stats_by_provider'),
+    pathPrefix('/admin/last_day_stats_by_provider'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getLastDayStatsByProvider
   )
 
   app.get(
-    pathsFor('/admin/time_since_last_event'),
+    pathPrefix('/admin/time_since_last_event'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getTimeSinceLastEventHandler
   )
 
   app.get(
-    pathsFor('/admin/num_vehicles_registered_last_24_hours'),
+    pathPrefix('/admin/num_vehicles_registered_last_24_hours'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getNumVehiclesRegisteredLast24HoursHandler
   )
 
   app.get(
-    pathsFor('/admin/num_event_last_24_hours'),
+    pathPrefix('/admin/num_event_last_24_hours'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getNumEventsLast24HoursHandler
   )
 
   app.get(
-    pathsFor('/admin/trip_counts_since'),
+    pathPrefix('/admin/trip_counts_since'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getTripCountsSinceHandler
   )
 
   app.get(
-    pathsFor('/admin/event_counts_per_provider_since'),
+    pathPrefix('/admin/event_counts_per_provider_since'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getEventCountsPerProviderSinceHandler
   )
 
   app.get(
-    pathsFor('/admin/telemetry_counts_per_provider_since'),
+    pathPrefix('/admin/telemetry_counts_per_provider_since'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getTelemetryCountsPerProviderSinceHandler
   )
 
   app.get(
-    pathsFor('/admin/conformance_last_24_hours'),
+    pathPrefix('/admin/conformance_last_24_hours'),
     checkDailyApiAccess(scopes => scopes.includes('admin:all')),
     getConformanceLast24HoursHandler
   )

--- a/packages/mds-daily/server.ts
+++ b/packages/mds-daily/server.ts
@@ -17,4 +17,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.DAILY_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.DAILY_API_HTTP_PORT })

--- a/packages/mds-daily/tests/daily.spec.ts
+++ b/packages/mds-daily/tests/daily.spec.ts
@@ -35,6 +35,7 @@ import { makeDevices } from '@mds-core/mds-test-data'
 import { ApiServer } from '@mds-core/mds-api-server'
 import { TEST1_PROVIDER_ID } from '@mds-core/mds-providers'
 import Sinon from 'sinon'
+import { pathPrefix } from '@mds-core/mds-utils'
 import { agencyMiddleware, api } from '../api'
 import { dbHelperFail } from '../request-handlers'
 
@@ -159,7 +160,7 @@ after(async () => {
 describe('Tests API', () => {
   it('gets vehicle counts per provider', done => {
     request
-      .get('/admin/vehicle_counts')
+      .get(pathPrefix('/admin/vehicle_counts'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -214,7 +215,7 @@ describe('Tests API', () => {
 
   it('verifies 8 total events, and 4 are non-conformant', done => {
     request
-      .get('/admin/last_day_stats_by_provider')
+      .get(pathPrefix('/admin/last_day_stats_by_provider'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {
@@ -233,7 +234,7 @@ describe('Tests API', () => {
     // These outer two promises are here to help check that old telemetry/event data
     // added by the call to .seed later don't show up in the final results
     request
-      .get('/admin/last_day_stats_by_provider')
+      .get(pathPrefix('/admin/last_day_stats_by_provider'))
       .set('Authorization', AUTH)
       .expect(200)
       .end((err, result) => {

--- a/packages/mds-geography-author/api.ts
+++ b/packages/mds-geography-author/api.ts
@@ -2,7 +2,7 @@ import express, { NextFunction } from 'express'
 import db from '@mds-core/mds-db'
 
 import {
-  pathsFor,
+  pathPrefix,
   ServerError,
   NotFoundError,
   DependencyMissingError,
@@ -42,7 +42,7 @@ function api(app: express.Express): express.Express {
   app.use(GeographyAuthorApiVersionMiddleware)
 
   app.get(
-    pathsFor('/geographies/meta/'),
+    pathPrefix('/geographies/meta/'),
     checkGeographyAuthorApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
@@ -101,7 +101,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.post(
-    pathsFor('/geographies/'),
+    pathPrefix('/geographies/'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
       req: GeographyAuthorApiPostGeographyRequest,
@@ -134,7 +134,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.put(
-    pathsFor('/geographies/:geography_id'),
+    pathPrefix('/geographies/:geography_id'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
       req: GeographyAuthorApiPutGeographyRequest,
@@ -163,7 +163,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.delete(
-    pathsFor('/geographies/:geography_id'),
+    pathPrefix('/geographies/:geography_id'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
       req: GeographyAuthorApiDeleteGeographyRequest,
@@ -204,7 +204,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/geographies/:geography_id/meta'),
+    pathPrefix('/geographies/:geography_id/meta'),
     checkGeographyAuthorApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
@@ -235,7 +235,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.put(
-    pathsFor('/geographies/:geography_id/meta'),
+    pathPrefix('/geographies/:geography_id/meta'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:write')),
     async (
       req: GeographyAuthorApiPutGeographyMetadataRequest,
@@ -266,7 +266,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.put(
-    pathsFor('/geographies/:geography_id/publish'),
+    pathPrefix('/geographies/:geography_id/publish'),
     checkGeographyAuthorApiAccess(scopes => scopes.includes('geographies:publish')),
     async (
       req: GeographyAuthorApiPublishGeographyRequest,

--- a/packages/mds-geography-author/server.ts
+++ b/packages/mds-geography-author/server.ts
@@ -15,4 +15,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.GEOGRAPHY_AUTHOR_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.GEOGRAPHY_AUTHOR_API_HTTP_PORT })

--- a/packages/mds-geography-author/tests/api.spec.ts
+++ b/packages/mds-geography-author/tests/api.spec.ts
@@ -28,7 +28,7 @@ import sinon from 'sinon'
 import supertest from 'supertest'
 import test from 'unit.js'
 import db from '@mds-core/mds-db'
-import { uuid } from '@mds-core/mds-utils'
+import { uuid, pathPrefix } from '@mds-core/mds-utils'
 import { ApiServer } from '@mds-core/mds-api-server'
 import {
   POLICY_UUID,
@@ -71,7 +71,7 @@ describe('Tests app', () => {
     it('cannot POST one current geography (no auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', EMPTY_SCOPE)
         .send(geography)
         .expect(403)
@@ -83,7 +83,7 @@ describe('Tests app', () => {
     it('cannot POST one current geography (wrong auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(geography)
         .expect(403)
@@ -95,7 +95,7 @@ describe('Tests app', () => {
     it('creates one current geography', done => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(201)
@@ -108,7 +108,7 @@ describe('Tests app', () => {
     it('cannot update one geography (no auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: DISTRICT_SEVEN }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', EMPTY_SCOPE)
         .send(geography)
         .expect(403)
@@ -120,7 +120,7 @@ describe('Tests app', () => {
     it('cannot update one geography (wrong auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: DISTRICT_SEVEN }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(geography)
         .expect(403)
@@ -132,7 +132,7 @@ describe('Tests app', () => {
     it('verifies updating one geography', done => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: DISTRICT_SEVEN }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(201)
@@ -145,7 +145,7 @@ describe('Tests app', () => {
     it('cannot PUT geography (no auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: 'garbage_json' }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', EMPTY_SCOPE)
         .send(geography)
         .expect(403)
@@ -157,7 +157,7 @@ describe('Tests app', () => {
     it('cannot PUT geography (wrong auth)', done => {
       const geography = { geography_id: GEOGRAPHY_UUID, geography_json: 'garbage_json' }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(geography)
         .expect(403)
@@ -169,7 +169,7 @@ describe('Tests app', () => {
     it('verifies cannot PUT bad geography', done => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: 'garbage_json' }
       request
-        .put(`/geographies/${GEOGRAPHY_UUID}`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(400)
@@ -182,7 +182,7 @@ describe('Tests app', () => {
     it('verifies cannot PUT non-existent geography', done => {
       const geography = { name: 'LA', geography_id: POLICY_UUID, geography_json: DISTRICT_SEVEN }
       request
-        .put(`/geographies/${POLICY_UUID}`)
+        .put(pathPrefix(`/geographies/${POLICY_UUID}`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(404)
@@ -195,7 +195,7 @@ describe('Tests app', () => {
     it('verifies cannot POST invalid geography', done => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: 'garbage_json' }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(400)
@@ -208,7 +208,7 @@ describe('Tests app', () => {
     it('cannot POST duplicate geography', done => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(409)
@@ -221,7 +221,7 @@ describe('Tests app', () => {
     it('can publish a geography (correct auth)', async () => {
       await db.writeGeography({ name: 'Geography 2', geography_id: GEOGRAPHY2_UUID, geography_json: DISTRICT_SEVEN })
       const result = await request
-        .put(`/geographies/${GEOGRAPHY2_UUID}/publish`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY2_UUID}/publish`))
         .set('Authorization', GEOGRAPHIES_PUBLISH_SCOPE)
         .expect(200)
       test.value(result).hasHeader('content-type', APP_JSON)
@@ -231,18 +231,27 @@ describe('Tests app', () => {
     })
 
     it('cannot publish a geography (wrong auth)', async () => {
-      await request.put(`/geographies/${GEOGRAPHY2_UUID}/publish`).set('Authorization', EMPTY_SCOPE).expect(403)
+      await request
+        .put(pathPrefix(`/geographies/${GEOGRAPHY2_UUID}/publish`))
+        .set('Authorization', EMPTY_SCOPE)
+        .expect(403)
     })
 
     it('cannot delete a geography (incorrect auth)', async () => {
-      await request.delete(`/geographies/${GEOGRAPHY2_UUID}`).set('Authorization', EMPTY_SCOPE).expect(403)
+      await request
+        .delete(pathPrefix(`/geographies/${GEOGRAPHY2_UUID}`))
+        .set('Authorization', EMPTY_SCOPE)
+        .expect(403)
     })
 
     it('can delete a geography (correct auth)', async () => {
       const testUUID = uuid()
       await db.writeGeography({ geography_id: testUUID, geography_json: LA_CITY_BOUNDARY, name: 'testafoo' })
       await db.writeGeographyMetadata({ geography_id: testUUID, geography_metadata: { foo: 'afoo' } })
-      await request.delete(`/geographies/${testUUID}`).set('Authorization', GEOGRAPHIES_WRITE_SCOPE).expect(200)
+      await request
+        .delete(pathPrefix(`/geographies/${testUUID}`))
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .expect(200)
       await assert.rejects(
         async () => {
           await db.readSingleGeography(testUUID)
@@ -258,14 +267,20 @@ describe('Tests app', () => {
     })
 
     it('cannot delete a published geography (correct auth)', async () => {
-      await request.delete(`/geographies/${GEOGRAPHY2_UUID}`).set('Authorization', GEOGRAPHIES_WRITE_SCOPE).expect(405)
+      await request
+        .delete(pathPrefix(`/geographies/${GEOGRAPHY2_UUID}`))
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .expect(405)
     })
 
     it('sends the correct error code if something blows up on the backend during delete', async () => {
       sandbox.stub(db, 'deleteGeography').callsFake(function stubAThrow() {
         throw new Error('random backend err')
       })
-      await request.delete(`/geographies/${GEOGRAPHY_UUID}`).set('Authorization', GEOGRAPHIES_WRITE_SCOPE).expect(500)
+      await request
+        .delete(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
+        .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
+        .expect(500)
     })
   })
 
@@ -289,7 +304,7 @@ describe('Tests app', () => {
 
     it('cannot GET geography metadata (no auth)', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', EMPTY_SCOPE)
         .expect(403)
         .end(err => {
@@ -299,7 +314,7 @@ describe('Tests app', () => {
 
     it('cannot GET geography metadata (wrong auth)', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .expect(403)
         .end(err => {
@@ -310,7 +325,7 @@ describe('Tests app', () => {
     it('cannot PUT geography metadata to create (no auth)', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       await request
-        .put(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', EMPTY_SCOPE)
         .send({ geography_id: GEOGRAPHY_UUID, geography_metadata: metadata })
         .expect(403)
@@ -319,7 +334,7 @@ describe('Tests app', () => {
     it('cannot PUT geography metadata to create (wrong auth)', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       await request
-        .put(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send({ geography_id: GEOGRAPHY_UUID, geography_metadata: metadata })
         .expect(403)
@@ -330,7 +345,7 @@ describe('Tests app', () => {
         throw new Error('err')
       })
       await request
-        .get(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(404)
     })
@@ -338,7 +353,7 @@ describe('Tests app', () => {
     it('verifies PUTing geography metadata to create', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       const requestResult = await request
-        .put(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send({ geography_id: GEOGRAPHY_UUID, geography_metadata: metadata })
         .expect(201)
@@ -350,7 +365,7 @@ describe('Tests app', () => {
     it('verifies PUTing geography metadata to edit', async () => {
       const metadata = { some_arbitrary_thing: 'beep' }
       await request
-        .put(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .put(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send({ geography_id: GEOGRAPHY_UUID, geography_metadata: metadata })
         .expect(200)
@@ -362,7 +377,7 @@ describe('Tests app', () => {
       const metadata = { some_arbitrary_thing: 'beep' }
       const nonexistentGeoUUID = uuid()
       await request
-        .put(`/geographies/${nonexistentGeoUUID}/meta`)
+        .put(pathPrefix(`/geographies/${nonexistentGeoUUID}/meta`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send({ geography_id: nonexistentGeoUUID, geography_metadata: metadata })
         .expect(404)
@@ -372,7 +387,7 @@ describe('Tests app', () => {
       await db.writeGeographyMetadata({ geography_id: GEOGRAPHY2_UUID, geography_metadata: { earth: 'isround' } })
 
       const result = await request
-        .get(`/geographies/meta`)
+        .get(pathPrefix(`/geographies/meta`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.data.geography_metadata.length === 2)
@@ -382,7 +397,7 @@ describe('Tests app', () => {
 
     it('retrieves only metadata for published geographies, with the unpublished scope and get_published param', async () => {
       const result = await request
-        .get(`/geographies/meta?get_published=true`)
+        .get(pathPrefix(`/geographies/meta?get_published=true`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.data.geography_metadata.length === 1)
@@ -392,7 +407,7 @@ describe('Tests app', () => {
 
     it('correctly retrieves geography metadata when using the param get_unpublished', async () => {
       const result = await request
-        .get(`/geographies/meta?get_unpublished=true`)
+        .get(pathPrefix(`/geographies/meta?get_unpublished=true`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.data.geography_metadata.length === 1)
@@ -402,7 +417,7 @@ describe('Tests app', () => {
 
     it('retrieves all metadata when both scopes are used', async () => {
       const result = await request
-        .get(`/geographies/meta`)
+        .get(pathPrefix(`/geographies/meta`))
         .set('Authorization', GEOGRAPHIES_BOTH_READ_SCOPES)
         .expect(200)
       test.assert(result.body.data.geography_metadata.length === 2)
@@ -412,7 +427,7 @@ describe('Tests app', () => {
 
     it('retrieves only metadata for published geographies with both read scopes and the get_published param', async () => {
       const result = await request
-        .get(`/geographies/meta?get_published=true`)
+        .get(pathPrefix(`/geographies/meta?get_published=true`))
         .set('Authorization', GEOGRAPHIES_BOTH_READ_SCOPES)
         .expect(200)
       test.assert(result.body.data.geography_metadata.length === 1)
@@ -422,7 +437,7 @@ describe('Tests app', () => {
 
     it('filters out unpublished geo metadata if only the get_published scope is set', async () => {
       const result = await request
-        .get(`/geographies/meta`)
+        .get(pathPrefix(`/geographies/meta`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.version === GEOGRAPHY_AUTHOR_API_DEFAULT_VERSION)
@@ -432,22 +447,28 @@ describe('Tests app', () => {
 
     it('throws an error if only the get_published scope is set and get_unpublished param is set', async () => {
       await request
-        .get(`/geographies/meta?get_unpublished=true`)
+        .get(pathPrefix(`/geographies/meta?get_unpublished=true`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(403)
     })
 
     it('cannot do bulk geography metadata reads (wrong auth)', async () => {
-      await request.get(`/geographies/meta?get_unpublished=false`).set('Authorization', EVENTS_READ_SCOPE).expect(403)
+      await request
+        .get(pathPrefix(`/geographies/meta?get_unpublished=false`))
+        .set('Authorization', EVENTS_READ_SCOPE)
+        .expect(403)
     })
 
     it('cannot do bulk geography metadata reads (no auth)', async () => {
-      await request.get(`/geographies/meta?get_published=false`).set('Authorization', EMPTY_SCOPE).expect(403)
+      await request
+        .get(pathPrefix(`/geographies/meta?get_published=false`))
+        .set('Authorization', EMPTY_SCOPE)
+        .expect(403)
     })
 
     it('verifies GETing a published geography metadata throws a permission error if the scope is wrong', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(403)
         .end(err => {
@@ -457,7 +478,7 @@ describe('Tests app', () => {
 
     it('verifies GETing a published geography metadata if the scope is geographies:read:unpublished', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}/meta`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}/meta`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -468,7 +489,7 @@ describe('Tests app', () => {
     it('verifies cannot GET non-existent geography metadata', done => {
       const nonexistentID = uuid()
       request
-        .get(`/geographies/${nonexistentID}/meta`)
+        .get(pathPrefix(`/geographies/${nonexistentID}/meta`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(404)
         .end((err, result) => {
@@ -486,7 +507,7 @@ describe('Tests app', () => {
         geography_json: LA_CITY_BOUNDARY
       }
       request
-        .put(`/geographies/${geography.geography_id}`)
+        .put(pathPrefix(`/geographies/${geography.geography_id}`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(400)
@@ -506,7 +527,7 @@ describe('Tests app', () => {
         geography_json: LA_CITY_BOUNDARY
       }
       request
-        .post(`/geographies`)
+        .post(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .send(geography)
         .expect(400)
@@ -520,7 +541,7 @@ describe('Tests app', () => {
 
     it('fails to hit non-existent endpoint with a 404', done => {
       request
-        .get(`/foobar`)
+        .get(pathPrefix(`/foobar`))
         .set('Authorization', GEOGRAPHIES_WRITE_SCOPE)
         .expect(404)
         .end(err => {

--- a/packages/mds-geography/api.ts
+++ b/packages/mds-geography/api.ts
@@ -1,7 +1,7 @@
 import express, { NextFunction } from 'express'
 import db from '@mds-core/mds-db'
 
-import { pathsFor, ServerError, NotFoundError, InsufficientPermissionsError } from '@mds-core/mds-utils'
+import { pathPrefix, ServerError, NotFoundError, InsufficientPermissionsError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 
 import { checkAccess, AccessTokenScopeValidator, ApiResponse, ApiRequest } from '@mds-core/mds-api-server'
@@ -21,7 +21,7 @@ function api(app: express.Express): express.Express {
   app.use(GeographyApiVersionMiddleware)
 
   app.get(
-    pathsFor('/geographies/:geography_id'),
+    pathPrefix('/geographies/:geography_id'),
     checkGeographyApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),
@@ -49,7 +49,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/geographies'),
+    pathPrefix('/geographies'),
     checkGeographyApiAccess(scopes => {
       return scopes.includes('geographies:read:published') || scopes.includes('geographies:read:unpublished')
     }),

--- a/packages/mds-geography/server.ts
+++ b/packages/mds-geography/server.ts
@@ -14,4 +14,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.GEOGRAPHY_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.GEOGRAPHY_API_HTTP_PORT })

--- a/packages/mds-geography/tests/api.spec.ts
+++ b/packages/mds-geography/tests/api.spec.ts
@@ -37,6 +37,7 @@ import {
   DISTRICT_SEVEN,
   SCOPED_AUTH
 } from '@mds-core/mds-test-data'
+import { pathPrefix } from '@mds-core/mds-utils'
 import { api } from '../api'
 import { GEOGRAPHY_API_DEFAULT_VERSION } from '../types'
 
@@ -63,7 +64,7 @@ describe('Tests app', () => {
       const geography = { name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY }
       await db.writeGeography(geography)
       const result = await request
-        .get(`/geographies/${GEOGRAPHY_UUID}`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
       test.assert(result.body.data.geography.geography_id === GEOGRAPHY_UUID)
@@ -73,7 +74,7 @@ describe('Tests app', () => {
 
     it('cannot GET an unpublished geography with the published scope', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(403)
         .end(err => {
@@ -83,7 +84,7 @@ describe('Tests app', () => {
 
     it('cannot GET a nonexistent geography', done => {
       request
-        .get(`/geographies/${POLICY_UUID}`)
+        .get(pathPrefix(`/geographies/${POLICY_UUID}`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(404)
         .end(err => {
@@ -93,7 +94,7 @@ describe('Tests app', () => {
 
     it('cannot GET geographies (no auth)', done => {
       request
-        .get(`/geographies/`)
+        .get(pathPrefix(`/geographies/`))
         .set('Authorization', EMPTY_SCOPE)
         .expect(403)
         .end(err => {
@@ -103,7 +104,7 @@ describe('Tests app', () => {
 
     it('cannot GET geographies (wrong auth)', done => {
       request
-        .get(`/geographies/`)
+        .get(pathPrefix(`/geographies/`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .expect(403)
         .end(err => {
@@ -113,7 +114,7 @@ describe('Tests app', () => {
 
     it('can GET geographies, full version', done => {
       request
-        .get(`/geographies/`)
+        .get(pathPrefix(`/geographies/`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -128,7 +129,7 @@ describe('Tests app', () => {
 
     it('can GET geographies, summarized version', done => {
       request
-        .get(`/geographies?summary=true`)
+        .get(pathPrefix(`/geographies?summary=true`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -144,14 +145,14 @@ describe('Tests app', () => {
       await db.writeGeography({ name: 'Geography 2', geography_id: GEOGRAPHY2_UUID, geography_json: DISTRICT_SEVEN })
       await db.publishGeography({ geography_id: GEOGRAPHY2_UUID })
       await request
-        .get(`/geographies/${GEOGRAPHY2_UUID}`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY2_UUID}`))
         .set('Authorization', GEOGRAPHIES_BOTH_READ_SCOPES)
         .expect(200)
     })
 
     it('can GET one unpublished geography with unpublished scope', done => {
       request
-        .get(`/geographies/${GEOGRAPHY_UUID}`)
+        .get(pathPrefix(`/geographies/${GEOGRAPHY_UUID}`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -163,7 +164,7 @@ describe('Tests app', () => {
 
     it('can get all geographies, with the unpublished scope', done => {
       request
-        .get(`/geographies`)
+        .get(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -175,7 +176,7 @@ describe('Tests app', () => {
 
     it('can filter for published geographies, with the unpublished scope and get_published parameter', done => {
       request
-        .get(`/geographies?get_published=true`)
+        .get(pathPrefix(`/geographies?get_published=true`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -187,7 +188,7 @@ describe('Tests app', () => {
 
     it('can filter for unpublished geographies, with the unpublished scope and get_unpublished parameter', done => {
       request
-        .get(`/geographies?get_unpublished=true`)
+        .get(pathPrefix(`/geographies?get_unpublished=true`))
         .set('Authorization', GEOGRAPHIES_READ_UNPUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -199,7 +200,7 @@ describe('Tests app', () => {
 
     it('can only GET published geographies, with only the published scope', done => {
       request
-        .get(`/geographies`)
+        .get(pathPrefix(`/geographies`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -211,14 +212,14 @@ describe('Tests app', () => {
 
     it('throws an error if only the get_published scope is set and get_unpublished param is set', async () => {
       await request
-        .get(`/geographies?get_unpublished=true`)
+        .get(pathPrefix(`/geographies?get_unpublished=true`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(403)
     })
 
     it('fails to hit non-existent endpoint with a 404', done => {
       request
-        .get(`/foobar`)
+        .get(pathPrefix(`/foobar`))
         .set('Authorization', GEOGRAPHIES_READ_PUBLISHED_SCOPE)
         .expect(404)
         .end(err => {

--- a/packages/mds-jurisdiction/api.ts
+++ b/packages/mds-jurisdiction/api.ts
@@ -15,7 +15,7 @@
  */
 
 import express from 'express'
-import { pathsFor } from '@mds-core/mds-utils'
+import { pathPrefix } from '@mds-core/mds-utils'
 import { checkAccess, AccessTokenScopeValidator } from '@mds-core/mds-api-server'
 import { JurisdictionApiVersionMiddleware } from './middleware'
 import {
@@ -34,31 +34,31 @@ export const api = (app: express.Express): express.Express =>
   app
     .use(JurisdictionApiVersionMiddleware)
     .get(
-      pathsFor('/jurisdictions'),
+      pathPrefix('/jurisdictions'),
       checkJurisdictionApiAccess(
         scopes => scopes.includes('jurisdictions:read') || scopes.includes('jurisdictions:read:claim')
       ),
       GetJurisdictionsHandler
     )
     .get(
-      pathsFor('/jurisdictions/:jurisdiction_id'),
+      pathPrefix('/jurisdictions/:jurisdiction_id'),
       checkJurisdictionApiAccess(
         scopes => scopes.includes('jurisdictions:read') || scopes.includes('jurisdictions:read:claim')
       ),
       GetJurisdictionHandler
     )
     .post(
-      pathsFor('/jurisdictions'),
+      pathPrefix('/jurisdictions'),
       checkJurisdictionApiAccess(scopes => scopes.includes('jurisdictions:write')),
       CreateJurisdictionHandler
     )
     .put(
-      pathsFor('/jurisdictions/:jurisdiction_id'),
+      pathPrefix('/jurisdictions/:jurisdiction_id'),
       checkJurisdictionApiAccess(scopes => scopes.includes('jurisdictions:write')),
       UpdateJurisdictionHandler
     )
     .delete(
-      pathsFor('/jurisdictions/:jurisdiction_id'),
+      pathPrefix('/jurisdictions/:jurisdiction_id'),
       checkJurisdictionApiAccess(scopes => scopes.includes('jurisdictions:write')),
       DeleteJurisdictionHandler
     )

--- a/packages/mds-jurisdiction/server.ts
+++ b/packages/mds-jurisdiction/server.ts
@@ -17,4 +17,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.JURISDICTION_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.JURISDICTION_API_HTTP_PORT })

--- a/packages/mds-jurisdiction/tests/api.spec.ts
+++ b/packages/mds-jurisdiction/tests/api.spec.ts
@@ -17,7 +17,7 @@
 import supertest from 'supertest'
 import test from 'unit.js'
 import { ApiServer } from '@mds-core/mds-api-server'
-import { uuid } from '@mds-core/mds-utils'
+import { uuid, pathPrefix } from '@mds-core/mds-utils'
 import { JurisdictionServiceProvider } from '@mds-core/mds-jurisdiction-service/service/provider'
 import { SCOPED_AUTH } from '@mds-core/mds-test-data'
 import { JurisdictionDomainModel } from '@mds-core/mds-jurisdiction-service'
@@ -43,7 +43,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Create Single Jurisdiction', async () => {
     const result = await request
-      .post('/jurisdictions')
+      .post(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send(JURISDICTION0)
       .expect(201)
@@ -53,12 +53,12 @@ describe('Test Jurisdiction API', () => {
   })
 
   it('Create Single Jurisdiction (forbidden)', async () => {
-    await request.post('/jurisdictions').send(JURISDICTION0).expect(403)
+    await request.post(pathPrefix('/jurisdictions')).send(JURISDICTION0).expect(403)
   })
 
   it('Create Single Jurisdiction (conflict)', async () => {
     await request
-      .post('/jurisdictions')
+      .post(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send(JURISDICTION0)
       .expect(409)
@@ -67,7 +67,7 @@ describe('Test Jurisdiction API', () => {
   it('Create Single Jurisdiction (validation error)', async () => {
     const { agency_key, ...dto } = JURISDICTION1
     await request
-      .post('/jurisdictions')
+      .post(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send(dto)
       .expect(400)
@@ -75,7 +75,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Create Multiple Jurisdictions', async () => {
     const result = await request
-      .post('/jurisdictions')
+      .post(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send([JURISDICTION1, JURISDICTION2])
       .expect(201)
@@ -88,7 +88,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Update Single Jurisdiction (conflict error)', async () => {
     await request
-      .put(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .put(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send({ ...JURISDICTION1, jurisdiction_id: uuid() })
       .expect(409)
@@ -96,7 +96,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Update Single Jurisdiction (validation error)', async () => {
     await request
-      .put(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .put(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send({ ...JURISDICTION1, timestamp: 0 })
       .expect(400)
@@ -104,7 +104,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Update Single Jurisdiction (not found)', async () => {
     await request
-      .put(`/jurisdictions/${uuid()}`)
+      .put(pathPrefix(`/jurisdictions/${uuid()}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .expect(404)
   })
@@ -112,7 +112,7 @@ describe('Test Jurisdiction API', () => {
   it('Update Single Jurisdiction', async () => {
     const updated_agency_key = `${JURISDICTION1.agency_key}-updated`
     const result = await request
-      .put(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .put(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .send({ ...JURISDICTION1, agency_key: updated_agency_key })
       .expect(200)
@@ -123,7 +123,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Get One Jurisdiction', async () => {
     const result = await request
-      .get(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`)
+      .get(pathPrefix(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read']))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
@@ -131,19 +131,19 @@ describe('Test Jurisdiction API', () => {
   })
 
   it('Get One Jurisdiction (no scope)', async () => {
-    await request.get(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`).expect(403)
+    await request.get(pathPrefix(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`)).expect(403)
   })
 
   it('Get One Jurisdiction (incorrect jurisdiction claim)', async () => {
     await request
-      .get(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`)
+      .get(pathPrefix(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim'], JURISDICTION1.agency_key))
       .expect(403)
   })
 
   it('Get One Jurisdiction (proper jurisdiction claim)', async () => {
     const result = await request
-      .get(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`)
+      .get(pathPrefix(`/jurisdictions/${JURISDICTION2.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim'], JURISDICTION2.agency_key))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
@@ -152,7 +152,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Get Multiple Jurisdictions', async () => {
     const result = await request
-      .get('/jurisdictions')
+      .get(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read']))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
@@ -170,12 +170,12 @@ describe('Test Jurisdiction API', () => {
   })
 
   it('Get Multiple Jurisdictions (no scope)', async () => {
-    await request.get('/jurisdictions').expect(403)
+    await request.get(pathPrefix('/jurisdictions')).expect(403)
   })
 
   it('Get Multiple Jurisdictions (no jurisdictions claim)', async () => {
     const result = await request
-      .get('/jurisdictions')
+      .get(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim']))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
@@ -184,7 +184,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Get Multiple Jurisdictions (jurisdictions claim)', async () => {
     const result = await request
-      .get('/jurisdictions')
+      .get(pathPrefix('/jurisdictions'))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read:claim'], JURISDICTION2.agency_key))
       .expect(200)
     test.object(result.body).hasProperty('version', JURISDICTION_API_DEFAULT_VERSION)
@@ -193,7 +193,7 @@ describe('Test Jurisdiction API', () => {
 
   it('Delete One Jurisdiction', async () => {
     const result = await request
-      .delete(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .delete(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .expect(200)
     test.object(result.body).hasProperty('jurisdiction_id', JURISDICTION1.jurisdiction_id)
@@ -201,14 +201,14 @@ describe('Test Jurisdiction API', () => {
 
   it('Delete One Jurisdiction (not found)', async () => {
     await request
-      .delete(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .delete(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:write']))
       .expect(404)
   })
 
   it('Get One Jurisdiction (not found)', async () => {
     await request
-      .get(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`)
+      .get(pathPrefix(`/jurisdictions/${JURISDICTION1.jurisdiction_id}`))
       .set('Authorization', SCOPED_AUTH(['jurisdictions:read']))
       .expect(404)
   })

--- a/packages/mds-policy-author/api.ts
+++ b/packages/mds-policy-author/api.ts
@@ -17,7 +17,7 @@
 import express, { NextFunction } from 'express'
 import {
   uuid,
-  pathsFor,
+  pathPrefix,
   AlreadyPublishedError,
   BadParamsError,
   NotFoundError,
@@ -58,7 +58,7 @@ function api(app: express.Express): express.Express {
   app.use(PolicyAuthorApiVersionMiddleware)
 
   app.post(
-    pathsFor('/policies'),
+    pathPrefix('/policies'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
     async (
       req: PolicyAuthorApiPostPolicyRequest,
@@ -87,7 +87,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.post(
-    pathsFor('/policies/:policy_id/publish'),
+    pathPrefix('/policies/:policy_id/publish'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:publish')),
     async (
       req: PolicyAuthorApiPublishPolicyRequest,
@@ -122,7 +122,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.put(
-    pathsFor('/policies/:policy_id'),
+    pathPrefix('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
     async (
       req: PolicyAuthorApiEditPolicyRequest,
@@ -155,7 +155,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.delete(
-    pathsFor('/policies/:policy_id'),
+    pathPrefix('/policies/:policy_id'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:delete')),
     async (
       req: PolicyAuthorApiDeletePolicyRequest,
@@ -177,7 +177,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/policies/meta/'),
+    pathPrefix('/policies/meta/'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
     async (
       req: PolicyAuthorApiGetPolicyMetadataRequest,
@@ -217,7 +217,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/policies/:policy_id/meta'),
+    pathPrefix('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:read')),
     async (
       req: PolicyAuthorApiGetPolicyMetadatumRequest,
@@ -247,7 +247,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.put(
-    pathsFor('/policies/:policy_id/meta'),
+    pathPrefix('/policies/:policy_id/meta'),
     checkPolicyAuthorApiAccess(scopes => scopes.includes('policies:write')),
     async (
       req: PolicyAuthorApiEditPolicyMetadataRequest,

--- a/packages/mds-policy-author/server.ts
+++ b/packages/mds-policy-author/server.ts
@@ -14,4 +14,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.POLICY_AUTHOR_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.POLICY_AUTHOR_API_HTTP_PORT })

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -27,7 +27,7 @@ import should from 'should'
 import supertest from 'supertest'
 import test from 'unit.js'
 import db from '@mds-core/mds-db'
-import { clone, isUUID, uuid } from '@mds-core/mds-utils'
+import { clone, isUUID, uuid, pathPrefix } from '@mds-core/mds-utils'
 import { Policy } from '@mds-core/mds-types'
 import { ApiServer } from '@mds-core/mds-api-server'
 import {
@@ -73,7 +73,7 @@ describe('Tests app', () => {
     it('cannot create one current policy (no authorization)', done => {
       const policy = POLICY_JSON_WITHOUT_PUBLISH_DATE
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', EMPTY_SCOPE)
         .send(policy)
         .expect(403)
@@ -85,7 +85,7 @@ describe('Tests app', () => {
     it('cannot create one current policy (wrong authorization)', done => {
       const policy = POLICY_JSON_WITHOUT_PUBLISH_DATE
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(policy)
         .expect(403)
@@ -99,7 +99,7 @@ describe('Tests app', () => {
       delete bad_policy_json.rules[0].rule_type
       const bad_policy = bad_policy_json
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(bad_policy)
         .expect(400)
@@ -114,7 +114,7 @@ describe('Tests app', () => {
     it('verifies cannot PUT policy (no auth)', done => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       request
-        .put(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`)
+        .put(pathPrefix(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`))
         .set('Authorization', EMPTY_SCOPE)
         .send(policy)
         .expect(403)
@@ -127,7 +127,7 @@ describe('Tests app', () => {
     it('verifies cannot PUT policy (wrong auth)', done => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       request
-        .put(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`)
+        .put(pathPrefix(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(policy)
         .expect(403)
@@ -139,7 +139,7 @@ describe('Tests app', () => {
 
     it('verifies cannot PUT non-existent policy', done => {
       request
-        .put(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`)
+        .put(pathPrefix(`/policies/d2e31798-f22f-4034-ad36-1f88621b276a`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(POLICY_JSON_WITHOUT_PUBLISH_DATE)
         .expect(404)
@@ -151,7 +151,7 @@ describe('Tests app', () => {
 
     it('fails to hit non-existent endpoint with a 404', done => {
       request
-        .get(`/foobar`)
+        .get(pathPrefix(`/foobar`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .expect(404)
         .end(err => {
@@ -162,7 +162,7 @@ describe('Tests app', () => {
     it('creates one current policy', done => {
       const policy = POLICY_JSON_WITHOUT_PUBLISH_DATE
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy)
         .expect(201)
@@ -176,7 +176,7 @@ describe('Tests app', () => {
     it('verifies cannot POST duplicate policy', done => {
       const policy = POLICY_JSON_WITHOUT_PUBLISH_DATE
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy)
         .expect(409)
@@ -191,7 +191,7 @@ describe('Tests app', () => {
       delete bad_policy_json.rules[0].rule_type
       const bad_policy = bad_policy_json
       await request
-        .put(`/policies/${POLICY_UUID}`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(bad_policy)
         .expect(400)
@@ -201,7 +201,7 @@ describe('Tests app', () => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       policy.name = 'a shiny new name'
       const apiResult = await request
-        .put(`/policies/${POLICY_UUID}`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy)
         .expect(200)
@@ -219,7 +219,7 @@ describe('Tests app', () => {
     it('creates one past policy', done => {
       const policy2 = POLICY2_JSON
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy2)
         .expect(201)
@@ -234,7 +234,7 @@ describe('Tests app', () => {
       // TODO guts
       const policy3 = POLICY3_JSON
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy3)
         .expect(201)
@@ -247,7 +247,7 @@ describe('Tests app', () => {
 
     it('verifies cannot publish a policy (no auth)', done => {
       request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', EMPTY_SCOPE)
         .expect(403)
         .end(err => {
@@ -257,7 +257,7 @@ describe('Tests app', () => {
 
     it('verifies cannot publish a policy (wrong auth)', done => {
       request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .expect(403)
         .end(err => {
@@ -267,7 +267,7 @@ describe('Tests app', () => {
 
     it('verifies cannot publish a policy with missing geographies', done => {
       request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(404)
         .end((err, result) => {
@@ -278,7 +278,7 @@ describe('Tests app', () => {
 
     it('verifies cannot publish a policy that was never POSTed', done => {
       request
-        .post(`/policies/${GEOGRAPHY_UUID}/publish`)
+        .post(pathPrefix(`/policies/${GEOGRAPHY_UUID}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(404)
         .end((err, result) => {
@@ -290,7 +290,7 @@ describe('Tests app', () => {
     it('cannot publish a policy if the geo is not published', async () => {
       await db.writeGeography({ name: 'LA', geography_id: GEOGRAPHY_UUID, geography_json: LA_CITY_BOUNDARY })
       const result = await request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(424)
       test.value(result).hasHeader('content-type', APP_JSON)
@@ -299,7 +299,7 @@ describe('Tests app', () => {
     it('can publish a policy if the geo is published', async () => {
       await db.publishGeography({ geography_id: GEOGRAPHY_UUID })
       const result = await request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(200)
       test.value(result).hasHeader('content-type', APP_JSON)
@@ -307,7 +307,7 @@ describe('Tests app', () => {
 
     it('cannot double-publish a policy', done => {
       request
-        .post(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(409)
         .end((err, result) => {
@@ -320,7 +320,7 @@ describe('Tests app', () => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       policy.name = 'an even shinier new name'
       request
-        .put(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`)
+        .put(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`))
         .set('Authorization', EMPTY_SCOPE)
         .send(policy)
         .expect(403)
@@ -333,7 +333,7 @@ describe('Tests app', () => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       policy.name = 'an even shinier new name'
       request
-        .put(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`)
+        .put(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send(policy)
         .expect(403)
@@ -346,7 +346,7 @@ describe('Tests app', () => {
       const policy = clone(POLICY_JSON_WITHOUT_PUBLISH_DATE)
       policy.name = 'an even shinier new name'
       request
-        .put(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`)
+        .put(pathPrefix(`/policies/${POLICY_JSON_WITHOUT_PUBLISH_DATE.policy_id}`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(policy)
         .expect(409)
@@ -358,7 +358,7 @@ describe('Tests app', () => {
 
     it('cannot delete an unpublished policy (no auth)', done => {
       request
-        .delete(`/policies/${POLICY2_UUID}`)
+        .delete(pathPrefix(`/policies/${POLICY2_UUID}`))
         .set('Authorization', EMPTY_SCOPE)
         .expect(403)
         .end(async err => {
@@ -368,7 +368,7 @@ describe('Tests app', () => {
 
     it('cannot delete an unpublished policy (wrong auth)', done => {
       request
-        .delete(`/policies/${POLICY2_UUID}`)
+        .delete(pathPrefix(`/policies/${POLICY2_UUID}`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .expect(403)
         .end(async err => {
@@ -378,7 +378,7 @@ describe('Tests app', () => {
 
     it('can delete an unpublished policy', done => {
       request
-        .delete(`/policies/${POLICY2_UUID}`)
+        .delete(pathPrefix(`/policies/${POLICY2_UUID}`))
         .set('Authorization', POLICIES_DELETE_SCOPE)
         .expect(200)
         .end(async (err, result) => {
@@ -395,7 +395,7 @@ describe('Tests app', () => {
 
     it('cannot delete a published policy', done => {
       request
-        .delete(`/policies/${POLICY_UUID}`)
+        .delete(pathPrefix(`/policies/${POLICY_UUID}`))
         .set('Authorization', POLICIES_DELETE_SCOPE)
         .expect(404)
         .end(err => {
@@ -406,7 +406,7 @@ describe('Tests app', () => {
     it('cannot publish a policy if the start_date would precede the publish_date', async () => {
       await db.writePolicy(POLICY2_JSON)
       const result = await request
-        .post(`/policies/${POLICY2_JSON.policy_id}/publish`)
+        .post(pathPrefix(`/policies/${POLICY2_JSON.policy_id}/publish`))
         .set('Authorization', POLICIES_PUBLISH_SCOPE)
         .expect(409)
       test.value(result.body.error.reason, 'Policies cannot be published after their start_date')
@@ -414,7 +414,7 @@ describe('Tests app', () => {
 
     it('cannot GET policy metadata (no entries exist)', done => {
       request
-        .get(`/policies/meta`)
+        .get(pathPrefix(`/policies/meta`))
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(404)
         .end(err => {
@@ -425,7 +425,7 @@ describe('Tests app', () => {
     it('cannot PUTing policy metadata to create (no auth)', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       await request
-        .put(`/policies/${POLICY_UUID}/meta`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', EMPTY_SCOPE)
         .send({ policy_id: POLICY_UUID, policy_metadata: metadata })
         .expect(403)
@@ -434,7 +434,7 @@ describe('Tests app', () => {
     it('cannot PUTing policy metadata to create (wrong auth)', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       await request
-        .put(`/policies/${POLICY_UUID}/meta`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .send({ policy_id: POLICY_UUID, policy_metadata: metadata })
         .expect(403)
@@ -443,7 +443,7 @@ describe('Tests app', () => {
     it('verifies PUTing policy metadata to create', async () => {
       const metadata = { some_arbitrary_thing: 'boop' }
       const apiResult = await request
-        .put(`/policies/${POLICY_UUID}/meta`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send({ policy_id: POLICY_UUID, policy_metadata: metadata })
         .expect(201)
@@ -455,7 +455,7 @@ describe('Tests app', () => {
     it('verifies PUTing policy metadata to edit', async () => {
       const metadata = { some_arbitrary_thing: 'beep' }
       const apiResult = await request
-        .put(`/policies/${POLICY_UUID}/meta`)
+        .put(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send({ policy_id: POLICY_UUID, policy_metadata: metadata })
         .expect(200)
@@ -466,7 +466,7 @@ describe('Tests app', () => {
 
     it('cannot GET policy metadata (no auth)', done => {
       request
-        .get(`/policies/${POLICY_UUID}/meta`)
+        .get(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', EMPTY_SCOPE)
         .expect(403)
         .end(err => {
@@ -476,7 +476,7 @@ describe('Tests app', () => {
 
     it('cannot GET policy metadata (wrong auth)', done => {
       request
-        .get(`/policies/${POLICY_UUID}/meta`)
+        .get(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', EVENTS_READ_SCOPE)
         .expect(403)
         .end(err => {
@@ -486,7 +486,7 @@ describe('Tests app', () => {
 
     it('verifies GETing policy metadata when given a policy_id', done => {
       request
-        .get(`/policies/${POLICY_UUID}/meta`)
+        .get(pathPrefix(`/policies/${POLICY_UUID}/meta`))
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(200)
         .end((err, result) => {
@@ -499,7 +499,7 @@ describe('Tests app', () => {
 
     it('verifies cannot GET non-uuid policy_id metadata', done => {
       request
-        .get(`/policies/beepbapboop/meta`)
+        .get(pathPrefix(`/policies/beepbapboop/meta`))
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(400)
         .end((err, result) => {
@@ -510,7 +510,7 @@ describe('Tests app', () => {
 
     it('verifies cannot GET non-existent policy metadata', done => {
       request
-        .get(`/policies/${uuid()}/meta`)
+        .get(pathPrefix(`/policies/${uuid()}/meta`))
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(404)
         .end((err, result) => {
@@ -520,22 +520,25 @@ describe('Tests app', () => {
     })
 
     it('cannot GET policy metadata (no auth)', async () => {
-      await request.get(`/policies/meta`).set('Authorization', EMPTY_SCOPE).expect(403)
+      await request.get(pathPrefix(`/policies/meta`)).set('Authorization', EMPTY_SCOPE).expect(403)
     })
 
     it('cannot GET policy metadata (wrong auth)', async () => {
-      await request.get(`/policies/meta`).set('Authorization', EVENTS_READ_SCOPE).expect(403)
+      await request.get(pathPrefix(`/policies/meta`)).set('Authorization', EVENTS_READ_SCOPE).expect(403)
     })
 
     it('cannot GET policy metadata with both get_published and get_unpublished set to true', async () => {
       await request
-        .get(`/policies/meta?get_published=true&get_unpublished=true`)
+        .get(pathPrefix(`/policies/meta?get_published=true&get_unpublished=true`))
         .set('Authorization', POLICIES_READ_SCOPE)
         .expect(400)
     })
 
     it('verifies GETting policy metadata with the same params as for bulk policy reads', async () => {
-      const result = await request.get(`/policies/meta`).set('Authorization', POLICIES_READ_SCOPE).expect(200)
+      const result = await request
+        .get(pathPrefix(`/policies/meta`))
+        .set('Authorization', POLICIES_READ_SCOPE)
+        .expect(200)
       test.assert(result.body.data.policy_metadata.length === 1)
       test.value(result.body.version).is(POLICY_AUTHOR_API_DEFAULT_VERSION)
       test.value(result).hasHeader('content-type', APP_JSON)
@@ -543,7 +546,7 @@ describe('Tests app', () => {
 
     it('generates a UUID for a policy that has no UUID', done => {
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(POLICY_JSON_MISSING_POLICY_ID)
         .expect(201)
@@ -557,7 +560,7 @@ describe('Tests app', () => {
 
     it('Cannot PUT a policy with publish_date set', done => {
       request
-        .put(`/policies/${PUBLISHED_POLICY.policy_id}`)
+        .put(pathPrefix(`/policies/${PUBLISHED_POLICY.policy_id}`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(PUBLISHED_POLICY)
         .expect(400)
@@ -571,7 +574,7 @@ describe('Tests app', () => {
 
     it('Cannot POST a policy with publish_date set', done => {
       request
-        .post(`/policies`)
+        .post(pathPrefix(`/policies`))
         .set('Authorization', POLICIES_WRITE_SCOPE)
         .send(PUBLISHED_POLICY)
         .expect(400)

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -18,7 +18,7 @@ import express, { NextFunction } from 'express'
 // import { isProviderId, providerName } from '@mds-core/mds-providers'
 import { Policy, UUID } from '@mds-core/mds-types'
 import db from '@mds-core/mds-db'
-import { now, pathsFor, NotFoundError, isUUID, BadParamsError, ServerError } from '@mds-core/mds-utils'
+import { now, pathPrefix, NotFoundError, isUUID, BadParamsError, ServerError } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 import { parseRequest } from '@mds-core/mds-api-helpers'
 import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
@@ -74,7 +74,7 @@ function api(app: express.Express): express.Express {
   })
 
   app.get(
-    pathsFor('/policies'),
+    pathPrefix('/policies'),
     async (req: PolicyApiGetPoliciesRequest, res: PolicyApiGetPoliciesResponse, next: express.NextFunction) => {
       const { start_date = now(), end_date = now() } = req.query
       const { scopes } = res.locals
@@ -124,7 +124,7 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(
-    pathsFor('/policies/:policy_id'),
+    pathPrefix('/policies/:policy_id'),
     async (req: PolicyApiGetPolicyRequest, res: PolicyApiGetPolicyResponse, next: express.NextFunction) => {
       const { policy_id } = req.params
       const { scopes } = res.locals
@@ -164,7 +164,7 @@ function api(app: express.Express): express.Express {
     }
   )
 
-  app.get(pathsFor('/schema/policy'), (req, res) => {
+  app.get(pathPrefix('/schema/policy'), (req, res) => {
     res.status(200).send(policySchemaJson)
   })
 

--- a/packages/mds-policy/server.ts
+++ b/packages/mds-policy/server.ts
@@ -14,4 +14,4 @@
 import { ApiServer, HttpServer } from '@mds-core/mds-api-server'
 import { api } from './api'
 
-HttpServer(ApiServer(api), { port: process.env.POLICY_API_PORT })
+HttpServer(ApiServer(api), { port: process.env.POLICY_API_HTTP_PORT })

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -35,7 +35,7 @@ import {
 import logger from '@mds-core/mds-logger'
 import { MultiPolygon, Polygon, FeatureCollection, Geometry, Feature } from 'geojson'
 
-import { isArray } from 'util'
+import { isArray, deprecate } from 'util'
 import { getNextState } from './state-machine'
 import { parseRelative, getCurrentDate } from './date-time-utils'
 
@@ -467,10 +467,14 @@ function inc(map: { [key: string]: number }, key: string) {
   return Object.assign(map, { [key]: map[key] ? map[key] + 1 : 1 })
 }
 
-function pathsFor(path: string): string[] {
+function pathPrefix(path: string): string {
   const { PATH_PREFIX } = process.env
-  return [path, PATH_PREFIX + path, `${PATH_PREFIX}/dev${path}`]
+  return PATH_PREFIX ? `${PATH_PREFIX}${path}` : path
 }
+
+const pathsFor = deprecate(function pathsFor(path: string): string[] {
+  return [...new Set([path, pathPrefix(path), pathPrefix(`/dev${path}`)])]
+}, 'The function "pathsFor" has been deprecated, please use "pathPrefix" instead')
 
 function isInsideBoundingBox(telemetry: Telemetry | undefined | null, bbox: BoundingBox): boolean {
   if (telemetry && telemetry.gps) {
@@ -633,6 +637,7 @@ export {
   yesterday,
   csv,
   inc,
+  pathPrefix,
   pathsFor,
   isInsideBoundingBox,
   head,


### PR DESCRIPTION
## 📚 Purpose
Deprecate the `pathsFor` function that binds an API route to an array of paths. The `pathPrefix` function should be used instead, not only in the API route handlers, but also when making API calls from unit tests. All of our tooling is PATH_PREFIX aware already. This will also allow certain Express middleware that don't support path arrays to also work with our PATH_PREFIX setting (e.g. Prometheus metrics).

A deprecation warning was added to the old `pathsFor` function to discourage future use.

## 📦 Impacts:
- [x] mds-utils
- [x] All APIs and unit tests that make requests to them