### PR TITLE
Remove deprecated pathsFor utility function

### DIFF
--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -202,7 +202,7 @@ describe('Tests API', () => {
   // it('verifies post device missing mfgr', (done) => {
   //     let badVehicle = deepCopy(TEST_VEHICLE)
   //     delete badVehicle.mfgr
-  //     request.post(pathsFor('/vehicles'))
+  //     request.post(pathPrefix('/vehicles'))
   //         .set('Authorization', AUTH)
   //         .send(badVehicle)
   //         .expect(400).end((err, result) => {
@@ -248,7 +248,7 @@ describe('Tests API', () => {
   // it('verifies post device missing year', (done) => {
   //     let badVehicle = deepCopy(TEST_VEHICLE)
   //     delete badVehicle.year
-  //     request.post(pathsFor('/vehicles'))
+  //     request.post(pathPrefix('/vehicles'))
   //         .set('Authorization', AUTH)
   //         .send(badVehicle)
   //         .expect(400).end((err, result) => {

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -371,12 +371,12 @@ describe('Tests Compliance API:', () => {
   //       telemetry.push(makeTelemetryInArea(device, now(), CITY_OF_LA, 10))
   //     })
   //     request
-  //       .get(pathsFor('/test/initialize'))
+  //       .get(pathPrefix('/test/initialize'))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end(() => {
   //         provider_request
-  //           .post(pathsFor('/test/seed'))
+  //           .post(pathPrefix('/test/seed'))
   //           .set('Authorization', PROVIDER_AUTH)
   //           .send({ devices, events, telemetry })
   //           .expect(201)
@@ -404,7 +404,7 @@ describe('Tests Compliance API:', () => {
 
   //   it('Verifies violation of count compliance (under)', done => {
   //     request
-  //       .get(pathsFor(`/snapshot/${COUNT_POLICY_UUID}`))
+  //       .get(pathPrefix(`/snapshot/${COUNT_POLICY_UUID}`))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end((err, result) => {
@@ -418,7 +418,7 @@ describe('Tests Compliance API:', () => {
 
   //   afterEach(done => {
   //     agency_request
-  //       .get(pathsFor('/test/shutdown'))
+  //       .get(pathPrefix('/test/shutdown'))
   //       .set('Authorization', ADMIN_AUTH)
   //       .expect(200)
   //       .end(err => {

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -35,7 +35,7 @@ import {
 import logger from '@mds-core/mds-logger'
 import { MultiPolygon, Polygon, FeatureCollection, Geometry, Feature } from 'geojson'
 
-import { isArray, deprecate } from 'util'
+import { isArray } from 'util'
 import { getNextState } from './state-machine'
 import { parseRelative, getCurrentDate } from './date-time-utils'
 
@@ -472,10 +472,6 @@ function pathPrefix(path: string): string {
   return PATH_PREFIX ? `${PATH_PREFIX}${path}` : path
 }
 
-const pathsFor = deprecate(function pathsFor(path: string): string[] {
-  return [...new Set([path, pathPrefix(path), pathPrefix(`/dev${path}`)])]
-}, 'The function "pathsFor" has been deprecated, please use "pathPrefix" instead')
-
 function isInsideBoundingBox(telemetry: Telemetry | undefined | null, bbox: BoundingBox): boolean {
   if (telemetry && telemetry.gps) {
     const { lat, lng } = telemetry.gps
@@ -638,7 +634,6 @@ export {
   csv,
   inc,
   pathPrefix,
-  pathsFor,
   isInsideBoundingBox,
   head,
   tail,


### PR DESCRIPTION
## 📚 Purpose
Remove deprecated `pathsFor` utility. All code has been converted to use `pathPrefix` instead.

## 📦 Impacts:
- [x] mds-utils