### PR TITLE
Add logging for X-Request-Id header to enable deep microservice tracing

### DIFF
--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -11,7 +11,7 @@ import { RequestLoggingMiddlewareOptions, RequestLoggingMiddleware } from './mid
 import { PrometheusMiddlewareOptions, PrometheusMiddleware } from './middleware/prometheus'
 import { serverVersion } from './utils'
 import { HealthRequestHandler } from './handlers/health'
-import { HttpContextMiddleware, RequestIdMiddleware } from './middleware/http-context'
+import { HttpContextMiddlewares } from './middleware/http-context'
 
 export interface ApiServerOptions {
   authorization: AuthorizationMiddlewareOptions
@@ -59,8 +59,7 @@ export const ApiServer = (
    * Placed after the other middleware to avoid causing collisions
    * see express-http-context's README for more information
    */
-  app.use(HttpContextMiddleware())
-  app.use(RequestIdMiddleware())
+  app.use(...HttpContextMiddlewares())
 
   // Health Route
   app.get(pathPrefix('/health'), HealthRequestHandler)

--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -49,18 +49,17 @@ export const ApiServer = (
     AuthorizationMiddleware(options.authorization)
   )
 
-  /* Prometheus Middleware
+  /** Prometheus Middleware
    * Placed after the other middleware so it can label metrics with additional
    * properties added by the other middleware.
    */
   app.use(PrometheusMiddleware(options.prometheus))
 
-  /* HTTP Context Middleware
+  /** HTTP Context Middleware
    * Placed after the other middleware to avoid causing collisions
    * see express-http-context's README for more information
    */
   app.use(HttpContextMiddleware())
-
   app.use(RequestIdMiddleware())
 
   // Health Route

--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -11,7 +11,7 @@ import { RequestLoggingMiddlewareOptions, RequestLoggingMiddleware } from './mid
 import { PrometheusMiddlewareOptions, PrometheusMiddleware } from './middleware/prometheus'
 import { serverVersion } from './utils'
 import { HealthRequestHandler } from './handlers/health'
-import { HttpContextMiddlewares } from './middleware/http-context'
+import { HttpContextMiddleware } from './middleware/http-context'
 
 export interface ApiServerOptions {
   authorization: AuthorizationMiddlewareOptions
@@ -59,7 +59,7 @@ export const ApiServer = (
    * Placed after the other middleware to avoid causing collisions
    * see express-http-context's README for more information
    */
-  app.use(...HttpContextMiddlewares())
+  app.use(...HttpContextMiddleware())
 
   // Health Route
   app.get(pathPrefix('/health'), HealthRequestHandler)

--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -11,6 +11,7 @@ import { RequestLoggingMiddlewareOptions, RequestLoggingMiddleware } from './mid
 import { PrometheusMiddlewareOptions, PrometheusMiddleware } from './middleware/prometheus'
 import { serverVersion } from './utils'
 import { HealthRequestHandler } from './handlers/health'
+import { HttpContextMiddleware, RequestIdMiddleware } from './middleware/http-context'
 
 export interface ApiServerOptions {
   authorization: AuthorizationMiddlewareOptions
@@ -53,6 +54,14 @@ export const ApiServer = (
    * properties added by the other middleware.
    */
   app.use(PrometheusMiddleware(options.prometheus))
+
+  /* HTTP Context Middleware
+   * Placed after the other middleware to avoid causing collisions
+   * see express-http-context's README for more information
+   */
+  app.use(HttpContextMiddleware())
+
+  app.use(RequestIdMiddleware())
 
   // Health Route
   app.get(pathPrefix('/health'), HealthRequestHandler)

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -2,13 +2,17 @@ import httpContext from 'express-http-context'
 import express from 'express'
 import { ApiRequest, ApiResponse } from '../@types'
 
-export const HttpContextMiddleware = () => httpContext.middleware
+const HttpContextMiddleware = httpContext.middleware
 
 /**
  * Middleware that extracts the X-Request-Id header set by the gateway,
  * and includes it in contextual logs for a given request.
  */
-export const RequestIdMiddleware = () => (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
+const RequestIdMiddleware = (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
   httpContext.set('x-request-id', req.get('x-request-id'))
   return next()
+}
+
+export const HttpContextMiddlewares = () => {
+  return [HttpContextMiddleware, RequestIdMiddleware]
 }

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -1,5 +1,6 @@
 import httpContext from 'express-http-context'
 import express from 'express'
+import log from '@mds-core/mds-logger'
 import { ApiRequest, ApiResponse } from '../@types'
 
 /**
@@ -7,7 +8,12 @@ import { ApiRequest, ApiResponse } from '../@types'
  * and includes it in contextual logs for a given request.
  */
 const RequestIdMiddleware = (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
-  httpContext.set('x-request-id', req.get('x-request-id'))
+  const xRequestId = req.get('x-request-id')
+  if (xRequestId) {
+    httpContext.set('x-request-id', xRequestId)
+  } else {
+    log.warn('X-Request-Id is not set! If you expect it, please check your ingress gateway configuration.')
+  }
   return next()
 }
 

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -5,6 +5,6 @@ import { ApiRequest, ApiResponse } from '../@types'
 export const HttpContextMiddleware = () => httpContext.middleware
 
 export const RequestIdMiddleware = () => (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
-  httpContext.set('x-request-id', res.get('x-request-id'))
+  httpContext.set('x-request-id', req.get('x-request-id'))
   return next()
 }

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -2,8 +2,6 @@ import httpContext from 'express-http-context'
 import express from 'express'
 import { ApiRequest, ApiResponse } from '../@types'
 
-const HttpContextMiddleware = httpContext.middleware
-
 /**
  * Middleware that extracts the X-Request-Id header set by the gateway,
  * and includes it in contextual logs for a given request.
@@ -13,6 +11,6 @@ const RequestIdMiddleware = (req: ApiRequest, res: ApiResponse, next: express.Ne
   return next()
 }
 
-export const HttpContextMiddlewares = () => {
-  return [HttpContextMiddleware, RequestIdMiddleware]
+export const HttpContextMiddleware = () => {
+  return [httpContext.middleware, RequestIdMiddleware]
 }

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -4,6 +4,10 @@ import { ApiRequest, ApiResponse } from '../@types'
 
 export const HttpContextMiddleware = () => httpContext.middleware
 
+/**
+ * Middleware that extracts the X-Request-Id header set by the gateway,
+ * and includes it in contextual logs for a given request.
+ */
 export const RequestIdMiddleware = () => (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
   httpContext.set('x-request-id', req.get('x-request-id'))
   return next()

--- a/packages/mds-api-server/middleware/http-context.ts
+++ b/packages/mds-api-server/middleware/http-context.ts
@@ -1,0 +1,10 @@
+import httpContext from 'express-http-context'
+import express from 'express'
+import { ApiRequest, ApiResponse } from '../@types'
+
+export const HttpContextMiddleware = () => httpContext.middleware
+
+export const RequestIdMiddleware = () => (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
+  httpContext.set('x-request-id', res.get('x-request-id'))
+  return next()
+}

--- a/packages/mds-api-server/package.json
+++ b/packages/mds-api-server/package.json
@@ -31,6 +31,7 @@
     "compression": "1.7.4",
     "cors": "2.8.5",
     "express": "4.17.1",
+    "express-http-context": "1.2.4",
     "express-prom-bundle": "6.1.0",
     "morgan": "1.10.0",
     "prom-client": "12.0.0"

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -33,7 +33,7 @@ const log = (level: LogLevel, ...args: unknown[]): string[] => {
     const ISOTimestamp = new Date(timestamp).toISOString()
     const requestId = httpContext.get('x-request-id')
 
-    logger[level](level.toUpperCase(), ISOTimestamp, timestamp, requestId,...redacted)
+    logger[level](level.toUpperCase(), ISOTimestamp, timestamp, ...(requestId ? [requestId] : []), ...redacted)
   }
   return redacted
 }

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -14,6 +14,8 @@
     limitations under the License.
  */
 
+import httpContext from 'express-http-context'
+
 const logger: Pick<Console, 'info' | 'warn' | 'error'> = console
 type LogLevel = keyof typeof logger
 
@@ -29,8 +31,9 @@ const log = (level: LogLevel, ...args: unknown[]): string[] => {
   if (redacted.length) {
     const timestamp = Date.now()
     const ISOTimestamp = new Date(timestamp).toISOString()
+    const requestId = httpContext.get('x-request-id')
 
-    logger[level](level.toUpperCase(), ISOTimestamp, timestamp, ...redacted)
+    logger[level](level.toUpperCase(), ISOTimestamp, timestamp, requestId,...redacted)
   }
   return redacted
 }

--- a/packages/mds-logger/package.json
+++ b/packages/mds-logger/package.json
@@ -13,7 +13,9 @@
   ],
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "express-http-context": "1.2.4"
+  },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,13 @@
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
+"@types/cls-hooked@^4.2.1":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.0.tgz#290fa14946b88b11e65d68e487eda78a4d5a927e"
+  integrity sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1295,7 +1302,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/express@*", "@types/express@4.17.7":
+"@types/express@*", "@types/express@4.17.7", "@types/express@^4.16.0":
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.7.tgz#42045be6475636d9801369cd4418ef65cdb0dd59"
   integrity sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==
@@ -2214,6 +2221,13 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
+
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
@@ -2970,6 +2984,15 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -3782,6 +3805,13 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emitter-listener@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -4321,6 +4351,15 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
+
+express-http-context@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/express-http-context/-/express-http-context-1.2.4.tgz#49769d0e260836278996e728d9a3e7f3735f0531"
+  integrity sha512-jPpBbF1MWWdRcUU1rxsX0CPnA8ueEj8xgWvpRGHoXWGI4l5KqhPY4Bq+Gt6s2IhqHQQ0g0wIvJ3jFfbUuJJycQ==
+  dependencies:
+    "@types/cls-hooked" "^4.2.1"
+    "@types/express" "^4.16.0"
+    cls-hooked "^4.2.2"
 
 express-prom-bundle@6.1.0:
   version "6.1.0"
@@ -9135,6 +9174,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
 should-equal@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-2.0.0.tgz#6072cf83047360867e68e98b09d71143d04ee0c3"
@@ -9469,6 +9513,11 @@ ssri@^6.0.0, ssri@^6.0.1:
   integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
   dependencies:
     figgy-pudding "^3.5.1"
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
## 📚 Purpose
There is currently no information added to log messages which allows tracing of a particular request. This PR makes it such that logs in mds-logger will have the X-Request-Id header propegated to all log messages in the context of a given HTTP request, so we can trace logs through our different microservices. This header is set currently by istio, but could also be set by something like nginx. 

## 👌 Resolves:

## 📦 Impacts:
[mds-api-server]
[mds-logger]
[everything]

## ✅ PR Checklist
- [x] Clean up prototype code (make more composable, etc)
- [x] Test in k8s