### PR TITLE
[mds-utils] Extend parseObjectProperties to accept string arrays

### DIFF
--- a/packages/mds-agency/agency-candidate-request-handlers.ts
+++ b/packages/mds-agency/agency-candidate-request-handlers.ts
@@ -7,7 +7,9 @@ import { AgencyApiRequest, AgencyApiResponse } from './types'
 
 export const readAllVehicleIds = async (req: AgencyApiRequest, res: AgencyApiResponse) => {
   // read all the devices
-  const { provider_id: query_provider_id } = parseRequest(req).query('provider_id')
+  const {
+    provider_id: [query_provider_id]
+  } = parseRequest(req).query('provider_id')
 
   if (query_provider_id && !isUUID(query_provider_id)) {
     return res.status(400).send({

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -123,9 +123,11 @@ export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res:
 export const getVehicleById = async (req: AgencyApiGetVehicleByIdRequest, res: AgencyAipGetVehicleByIdResponse) => {
   const { device_id } = req.params
 
-  const { provider_id } = res.locals.scopes.includes('vehicles:read')
+  const {
+    provider_id: [provider_id]
+  } = res.locals.scopes.includes('vehicles:read')
     ? parseRequest(req).query('provider_id')
-    : res.locals
+    : { provider_id: [res.locals.provider_id] }
 
   const payload = await readPayload(device_id)
 
@@ -143,7 +145,10 @@ export const getVehiclesByProvider = async (
 ) => {
   const PAGE_SIZE = 1000
 
-  const { skip = 0, take = PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')
+  const {
+    skip: [skip = 0],
+    take: [take = PAGE_SIZE]
+  } = parseRequest(req, { parser: Number }).query('skip', 'take')
 
   const url = urls.format({
     protocol: req.get('x-forwarded-proto') || req.protocol,
@@ -152,9 +157,11 @@ export const getVehiclesByProvider = async (
   })
 
   // TODO: Replace with express middleware
-  const { provider_id } = res.locals.scopes.includes('vehicles:read')
+  const {
+    provider_id: [provider_id]
+  } = res.locals.scopes.includes('vehicles:read')
     ? parseRequest(req).query('provider_id')
-    : res.locals
+    : { provider_id: [res.locals.provider_id] }
 
   try {
     const response = await getVehicles(skip, take, url, req.query, provider_id)

--- a/packages/mds-agency/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/sandbox-admin-request-handlers.ts
@@ -46,7 +46,10 @@ export type AgencyApiRefreshCacheRequest = AgencyApiRequest & ApiRequestQuery<'s
 
 export const refreshCache = async (req: AgencyApiRefreshCacheRequest, res: AgencyApiResponse) => {
   // wipe the cache and rebuild from db
-  const { skip = 0, take = 10000000000 } = parseRequest(req, { parser: Number }).query('skip', 'take')
+  const {
+    skip: [skip = 0],
+    take: [take = 10000000000]
+  } = parseRequest(req, { parser: Number }).query('skip', 'take')
 
   try {
     const rows = await db.readDeviceIds()

--- a/packages/mds-api-helpers/index.ts
+++ b/packages/mds-api-helpers/index.ts
@@ -52,7 +52,10 @@ export const parseRequest = <T = string>(req: ApiRequest, options?: ParseObjectP
 
 export const parsePagingQueryParams = (req: ApiRequest) => {
   const [DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE] = [100, 1000]
-  const { skip = 0, take = DEFAULT_PAGE_SIZE } = parseRequest(req, { parser: Number }).query('skip', 'take')
+  const {
+    skip: [skip = 0],
+    take: [take = DEFAULT_PAGE_SIZE]
+  } = parseRequest(req, { parser: Number }).query('skip', 'take')
   return {
     skip: Number.isNaN(skip) ? 0 : Math.max(0, skip),
     take: Number.isNaN(take) ? DEFAULT_PAGE_SIZE : Math.min(take, MAX_PAGE_SIZE)

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -528,7 +528,9 @@ function api(app: express.Express): express.Express {
                 }
               }, {})
 
-            const { event_viewport_adjustment = seconds(30) } = parseRequest(req, {
+            const {
+              event_viewport_adjustment: [event_viewport_adjustment = seconds(30)]
+            } = parseRequest(req, {
               parser: x => seconds(Number(x))
             }).query('event_viewport_adjustment')
 
@@ -630,11 +632,11 @@ function api(app: express.Express): express.Express {
         const { scopes } = res.locals
         const { skip, take } = parsePagingQueryParams(req)
 
-        const { provider_id: queried_provider_id, provider_vehicle_id, audit_subject_id } = parseRequest(req).query(
-          'provider_id',
-          'provider_vehicle_id',
-          'audit_subject_id'
-        )
+        const {
+          provider_id: [queried_provider_id],
+          provider_vehicle_id: [provider_vehicle_id],
+          audit_subject_id: [audit_subject_id]
+        } = parseRequest(req).query('provider_id', 'provider_vehicle_id', 'audit_subject_id')
 
         const provider_id = scopes.includes('audits:read') ? queried_provider_id : res.locals.claims?.provider_id
 
@@ -645,8 +647,13 @@ function api(app: express.Express): express.Express {
           return res.status(500).send({ error: 'internal_server_error' })
         }
 
+        const {
+          start_time: [start_time],
+          end_time: [end_time]
+        } = parseRequest(req, { parser: Number }).query('start_time', 'end_time')
         const query = {
-          ...parseRequest(req, { parser: Number }).query('start_time', 'end_time'),
+          start_time,
+          end_time,
           skip,
           take,
           provider_id,
@@ -689,7 +696,11 @@ function api(app: express.Express): express.Express {
     checkAuditApiAccess(scopes => scopes.includes('audits:vehicles:read')),
     async (req: AuditApiGetVehicleRequest, res: GetAuditVehiclesResponse) => {
       const { skip, take } = { skip: 0, take: 10000 }
-      const { strict = true, bbox, provider_id } = {
+      const {
+        strict: [strict = true],
+        bbox: [bbox],
+        provider_id: [provider_id]
+      } = {
         ...parseRequest(req, { parser: JSON.parse }).query('strict', 'bbox'),
         ...parseRequest(req).query('provider_id')
       }

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -89,7 +89,10 @@ function api(app: express.Express): express.Express {
     pathPrefix('/snapshot/:policy_uuid'),
     async (req: ComplianceApiSnapshotRequest, res: ComplianceApiSnapshotResponse) => {
       const { provider_id, version } = res.locals
-      const { provider_id: queried_provider_id, timestamp } = {
+      const {
+        provider_id: [queried_provider_id],
+        timestamp: [timestamp]
+      } = {
         ...parseRequest(req).query('provider_id'),
         ...parseRequest(req, { parser: Number }).query('timestamp')
       }
@@ -145,7 +148,9 @@ function api(app: express.Express): express.Express {
   )
 
   app.get(pathPrefix('/count/:rule_id'), async (req: ComplianceApiCountRequest, res: ComplianceApiCountResponse) => {
-    const { timestamp } = {
+    const {
+      timestamp: [timestamp]
+    } = {
       ...parseRequest(req, { parser: Number }).query('timestamp')
     }
     const query_date = timestamp || now()

--- a/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdiction.ts
@@ -34,7 +34,9 @@ export const GetJurisdictionHandler = async (
 ) => {
   try {
     const { jurisdiction_id } = req.params
-    const { effective } = parseRequest(req, { parser: Number }).query('effective')
+    const {
+      effective: [effective]
+    } = parseRequest(req, { parser: Number }).query('effective')
     const jurisdiction = await JurisdictionServiceClient.getJurisdiction(jurisdiction_id, { effective })
     const { version } = res.locals
     return HasJurisdictionClaim(res)(jurisdiction)

--- a/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
+++ b/packages/mds-jurisdiction/handlers/get-jurisdictions.ts
@@ -31,7 +31,9 @@ export const GetJurisdictionsHandler = async (
   res: JurisdictionApiGetJurisdictionsResponse
 ) => {
   try {
-    const { effective } = parseRequest(req, { parser: Number }).query('effective')
+    const {
+      effective: [effective]
+    } = parseRequest(req, { parser: Number }).query('effective')
     const jurisdictions = await JurisdictionServiceClient.getJurisdictions({ effective })
     const { version } = res.locals
     return res.status(200).send({ version, jurisdictions: jurisdictions.filter(HasJurisdictionClaim(res)) })

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -85,9 +85,12 @@ function api(app: express.Express): express.Express {
           they are permitted to query for both published and unpublished policies.
           Otherwise, they can only read published.
         */
-        const { get_published = null, get_unpublished = null } = scopes.includes('policies:read')
+        const {
+          get_published: [get_published = null],
+          get_unpublished: [get_unpublished = null]
+        } = scopes.includes('policies:read')
           ? parseRequest(req, { parser: x => (x ? JSON.parse(x) : null) }).query('get_published', 'get_unpublished')
-          : { get_published: true }
+          : { get_published: [true], get_unpublished: [] }
 
         if (start_date > end_date) {
           throw new BadParamsError(`start_date ${start_date} > end_date ${end_date}`)
@@ -139,9 +142,12 @@ function api(app: express.Express): express.Express {
           they are permitted to query for both published and unpublished policies.
           Otherwise, they can only read published.
         */
-        const { get_published = null, get_unpublished = null } = scopes.includes('policies:read')
+        const {
+          get_published: [get_published = null],
+          get_unpublished: [get_unpublished = null]
+        } = scopes.includes('policies:read')
           ? parseRequest(req, { parser: x => (x ? JSON.parse(x) : null) }).query('get_published', 'get_unpublished')
-          : { get_published: true }
+          : { get_published: [true], get_unpublished: [] }
 
         const policies = await db.readPolicies({ policy_id, get_published, get_unpublished })
 


### PR DESCRIPTION
## 📚 Purpose
Express can sometimes pass query params in as `string`, but can also pass them in as `string[]` in the case that the user defines the given param multiple times (e.g. `?x=foo&x=bar`). This extends parseObjectProperties to handle these cases gracefully.

## 📦 Impacts:
[mds-utils]
Anything that uses parseRequest