### PR TITLE
Re-add .iyarc and exclude dot-prop advisory failing due to lerna dependency

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,0 +1,3 @@
+# Comma separated list of advisories to exclude
+# dot-prop https://npmjs.com/advisories/1213
+1213


### PR DESCRIPTION
## 📚 Purpose
Our audit check is currently catching a dot-prop advisory. Dot-prop is a dependency of Lerna, and while there is an issue to resolve in the Lerna repo, it has not been addressed yet.