### PR TITLE
Define new type aliases

### DIFF
--- a/packages/mds-repository/@types/index.ts
+++ b/packages/mds-repository/@types/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { InsertResult, UpdateResult } from 'typeorm'
-import { AnyFunction } from '@mds-core/mds-types'
+import { AnyFunction, Optional, NullableKeys } from '@mds-core/mds-types'
 
 export interface InsertReturning<T> extends InsertResult {
   raw: T[]
@@ -26,3 +26,6 @@ export interface UpdateReturning<T> extends UpdateResult {
 }
 
 export type Mixin<T extends AnyFunction> = InstanceType<ReturnType<T>>
+
+// Mark all nullable properties as optional (useful for create methods)
+export type DomainModelCreate<T> = Optional<T, NullableKeys<T>>

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -127,6 +127,9 @@ export type NullableProperties<T extends object> = {
   [P in keyof T]-?: T[P] extends null ? T[P] : Nullable<T[P]>
 }
 export type SingleOrArray<T> = T | T[]
+export type NullableKeys<T> = {
+  [P in keyof T]: null extends T[P] ? P : never
+}[keyof T]
 export type Optional<T, P extends keyof T> = Omit<T, P> & Partial<Pick<T, P>>
 export type NonEmptyArray<T> = [T, ...T[]]
 


### PR DESCRIPTION
## 📚 Purpose
These aliases can be used to define all nullable properties as being optional when performing inserts.

## 📦 Impacts:
- [x] mds-types