### PR TITLE
Export common RPC declarations from top-level

### DIFF
--- a/packages/mds-jurisdiction-service/client/index.ts
+++ b/packages/mds-jurisdiction-service/client/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { ServiceClient } from '@mds-core/mds-service-helpers'
-import { RpcClient, RpcRequest } from '@mds-core/mds-rpc-common/client'
+import { RpcClient, RpcRequest } from '@mds-core/mds-rpc-common'
 import { JurisdictionServiceDefinition, JurisdictionService } from '../@types'
 
 const JurisdictionServiceRpcClient = RpcClient(JurisdictionServiceDefinition, {

--- a/packages/mds-jurisdiction-service/server/manager.ts
+++ b/packages/mds-jurisdiction-service/server/manager.ts
@@ -1,4 +1,4 @@
-import { RpcServer } from '@mds-core/mds-rpc-common/server'
+import { RpcServer } from '@mds-core/mds-rpc-common'
 import { JurisdictionServiceProvider } from '../service/provider'
 import { JurisdictionServiceDefinition } from '../@types'
 

--- a/packages/mds-rpc-common/@types/index.ts
+++ b/packages/mds-rpc-common/@types/index.ts
@@ -22,6 +22,10 @@ export type RpcRouteDefinition<M extends AnyFunction> = {
   response: ServiceResponse<ReturnType<M>>
 }
 
+export const RpcRoute = <M extends AnyFunction>(): RpcRouteDefinition<M> => {
+  return { request: {}, response: {} } as RpcRouteDefinition<M>
+}
+
 export type RpcServiceDefinition<S> = {
   [M in keyof S]: S[M] extends AnyFunction ? RpcRouteDefinition<S[M]> : never
 }

--- a/packages/mds-rpc-common/client/index.ts
+++ b/packages/mds-rpc-common/client/index.ts
@@ -22,7 +22,7 @@ import { ServiceError, ServiceResponse } from '@mds-core/mds-service-helpers'
 import { AnyFunction } from '@mds-core/mds-types'
 import { RpcServiceDefinition, RPC_HOST, RPC_PORT } from '../@types'
 
-interface RpcClientOptions {
+export interface RpcClientOptions {
   host: string
   port: string | number
 }
@@ -39,7 +39,7 @@ export const RpcClient = <S>(definition: RpcServiceDefinition<S>, options: Parti
   })
 }
 
-export const RpcClientError = (error: {}) =>
+const RpcClientError = (error: {}) =>
   ServiceError({
     type: 'ServiceUnavailable',
     message: error instanceof Error ? error.message : error.toString(),

--- a/packages/mds-rpc-common/index.ts
+++ b/packages/mds-rpc-common/index.ts
@@ -14,11 +14,6 @@
     limitations under the License.
  */
 
-import { AnyFunction } from '@mds-core/mds-types'
-import { RpcRouteDefinition } from './@types'
-
-export * from './@types'
-
-export const RpcRoute = <M extends AnyFunction>(): RpcRouteDefinition<M> => {
-  return { request: {}, response: {} } as RpcRouteDefinition<M>
-}
+export { RpcServiceDefinition, RpcRouteDefinition, RpcRoute } from './@types'
+export { RpcClientOptions, RpcClient, RpcRequest } from './client'
+export { RpcServerOptions, RpcServiceHandlers, RpcServer } from './server'

--- a/packages/mds-rpc-common/server/index.ts
+++ b/packages/mds-rpc-common/server/index.ts
@@ -31,12 +31,12 @@ import { Server } from 'http'
 import { ProcessManager } from '@mds-core/mds-service-helpers'
 import { RpcServiceDefinition, RPC_PORT, RPC_CONTENT_TYPE } from '../@types'
 
-interface RpcServiceHandlers {
+export interface RpcServiceHandlers {
   onStart: () => Promise<void>
   onStop: () => Promise<void>
 }
 
-interface RpcServerOptions {
+export interface RpcServerOptions {
   port: string | number
 }
 


### PR DESCRIPTION
## 📚 Purpose
With the prior module structure, some values were only available by including `/dist` in the import path after publishing. This PR moves those declarations to the top-level module export.

## 📦 Impacts:
- [x] mds-rpc-common
- [x] mds-jurisdiction-service