### PR TITLE
Reorder middleware to remove prometheus request logging

### DIFF
--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -42,24 +42,25 @@ export const ApiServer = (
   // Middleware
   app.use(
     CompressionMiddleware(options.compression),
-    RequestLoggingMiddleware(options.requestLogging),
     CorsMiddleware(options.cors),
     JsonBodyParserMiddleware(options.jsonBodyParser),
     MaintenanceModeMiddleware(options.maintenanceMode),
-    AuthorizationMiddleware(options.authorization)
+    AuthorizationMiddleware(options.authorization),
+    /** Prometheus Middleware
+     * Placed after the other middleware so it can label metrics with additional
+     * properties added by the other middleware.
+     */
+    PrometheusMiddleware(options.prometheus),
+    /** Request Logging Middleware
+     * Placed after Prometheus middleware to avoid excessive logging
+     */
+    RequestLoggingMiddleware(options.requestLogging),
+    /** HTTP Context Middleware
+     * Placed after the other middleware to avoid causing collisions
+     * see express-http-context's README for more information
+     */
+    ...HttpContextMiddleware()
   )
-
-  /** Prometheus Middleware
-   * Placed after the other middleware so it can label metrics with additional
-   * properties added by the other middleware.
-   */
-  app.use(PrometheusMiddleware(options.prometheus))
-
-  /** HTTP Context Middleware
-   * Placed after the other middleware to avoid causing collisions
-   * see express-http-context's README for more information
-   */
-  app.use(...HttpContextMiddleware())
 
   // Health Route
   app.get(pathPrefix('/health'), HealthRequestHandler)

--- a/packages/mds-api-server/api-server.ts
+++ b/packages/mds-api-server/api-server.ts
@@ -44,7 +44,6 @@ export const ApiServer = (
     CompressionMiddleware(options.compression),
     CorsMiddleware(options.cors),
     JsonBodyParserMiddleware(options.jsonBodyParser),
-    MaintenanceModeMiddleware(options.maintenanceMode),
     AuthorizationMiddleware(options.authorization),
     /** Prometheus Middleware
      * Placed after the other middleware so it can label metrics with additional
@@ -55,6 +54,7 @@ export const ApiServer = (
      * Placed after Prometheus middleware to avoid excessive logging
      */
     RequestLoggingMiddleware(options.requestLogging),
+    MaintenanceModeMiddleware(options.maintenanceMode),
     /** HTTP Context Middleware
      * Placed after the other middleware to avoid causing collisions
      * see express-http-context's README for more information

--- a/packages/mds-rpc-common/server/index.ts
+++ b/packages/mds-rpc-common/server/index.ts
@@ -57,8 +57,8 @@ export const RpcServer = <S>(
         await onStart()
         server = HttpServer(
           express()
-            .use(RequestLoggingMiddleware())
             .use(PrometheusMiddleware())
+            .use(RequestLoggingMiddleware())
             .use(RawBodyParserMiddleware({ type: RPC_CONTENT_TYPE }))
             .get('/health', HealthRequestHandler)
             .use(ModuleRpcProtocolServer.registerRpcRoutes(definition, routes)),


### PR DESCRIPTION
## 📚 Purpose
Changing the order of the middleware binding to eliminate the `GET /prometheus` logs that appear every 60 seconds.
<img width="757" alt="Screen Shot 2020-08-12 at 3 11 41 PM" src="https://user-images.githubusercontent.com/3439869/90058550-ddfdb280-dcaf-11ea-9bcf-f60703de0777.png">