### PR TITLE
RPC Server REPL

### DIFF
--- a/container-images/mds-jurisdiction-service/Dockerfile
+++ b/container-images/mds-jurisdiction-service/Dockerfile
@@ -8,4 +8,4 @@ COPY dist/* /mds/
 
 WORKDIR /mds
 
-ENTRYPOINT ["/sbin/tini", "node", "--no-deprecation", "server.js"]
+ENTRYPOINT ["/sbin/tini", "node", "--no-deprecation", "--experimental-repl-await", "server.js"]

--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         - containerPort: 4000
           name: user-port
           protocol: TCP
+        - containerPort: 7375
+          name: repl-port
+          protocol: TCP
         volumeMounts:
         {{- if and $.Values.nats.enabled $.Values.nats.credentials }}
         - name: creds-volume

--- a/helm/mds/templates/service.yaml
+++ b/helm/mds/templates/service.yaml
@@ -12,5 +12,7 @@ spec:
   ports:
   - name: http-{{ $name }}
     port: 4000
+  - name: repl-{{ $name }}
+    port: 7375
 {{- end }}
 {{- end }}

--- a/packages/mds-jurisdiction-service/package.json
+++ b/packages/mds-jurisdiction-service/package.json
@@ -17,7 +17,7 @@
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "yarn typeorm schema:drop && DOTENV_CONFIG_PATH=../../.env nyc ts-mocha --project ../../tsconfig.json && yarn typeorm schema:drop",
-    "ts-node": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config",
+    "ts-node": "yarn build && DOTENV_CONFIG_PATH=../../.env node --experimental-repl-await -r ts-node/register -r dotenv/config",
     "typeorm": "yarn ts-node ./node_modules/.bin/typeorm",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn ts-node --"
   },

--- a/packages/mds-jurisdiction-service/server/manager.ts
+++ b/packages/mds-jurisdiction-service/server/manager.ts
@@ -23,9 +23,7 @@ export const JurisdictionServiceManager = RpcServer(
     port: process.env.JURISDICTION_SERVICE_RPC_PORT,
     repl: {
       port: process.env.JURISDICTION_SERVICE_REPL_PORT,
-      context: {
-        client: JurisdictionServiceClient
-      }
+      context: { ...JurisdictionServiceClient }
     }
   }
 )

--- a/packages/mds-jurisdiction-service/server/manager.ts
+++ b/packages/mds-jurisdiction-service/server/manager.ts
@@ -23,7 +23,7 @@ export const JurisdictionServiceManager = RpcServer(
     port: process.env.JURISDICTION_SERVICE_RPC_PORT,
     repl: {
       port: process.env.JURISDICTION_SERVICE_REPL_PORT,
-      context: { ...JurisdictionServiceClient }
+      context: { client: JurisdictionServiceClient }
     }
   }
 )

--- a/packages/mds-jurisdiction-service/server/manager.ts
+++ b/packages/mds-jurisdiction-service/server/manager.ts
@@ -1,5 +1,6 @@
 import { RpcServer } from '@mds-core/mds-rpc-common'
 import { JurisdictionServiceProvider } from '../service/provider'
+import { JurisdictionServiceClient } from '../client'
 import { JurisdictionServiceDefinition } from '../@types'
 
 export const JurisdictionServiceManager = RpcServer(
@@ -18,5 +19,13 @@ export const JurisdictionServiceManager = RpcServer(
     updateJurisdiction: async ([jurisdiction_id, update]) =>
       JurisdictionServiceProvider.updateJurisdiction(jurisdiction_id, update)
   },
-  { port: process.env.JURISDICTION_SERVICE_RPC_PORT }
+  {
+    port: process.env.JURISDICTION_SERVICE_RPC_PORT,
+    repl: {
+      port: process.env.JURISDICTION_SERVICE_REPL_PORT,
+      context: {
+        client: JurisdictionServiceClient
+      }
+    }
+  }
 )

--- a/packages/mds-rpc-common/@types/index.ts
+++ b/packages/mds-rpc-common/@types/index.ts
@@ -33,4 +33,4 @@ export type RpcServiceDefinition<S> = {
 export const RPC_HOST = 'http://localhost'
 export const RPC_PORT = 4000
 export const RPC_CONTENT_TYPE = 'application/grpc-web+json'
-export const REPL_PORT = 23 // telnet
+export const REPL_PORT = 6000

--- a/packages/mds-rpc-common/@types/index.ts
+++ b/packages/mds-rpc-common/@types/index.ts
@@ -33,3 +33,4 @@ export type RpcServiceDefinition<S> = {
 export const RPC_HOST = 'http://localhost'
 export const RPC_PORT = 4000
 export const RPC_CONTENT_TYPE = 'application/grpc-web+json'
+export const REPL_PORT = 23 // telnet

--- a/packages/mds-rpc-common/@types/index.ts
+++ b/packages/mds-rpc-common/@types/index.ts
@@ -33,4 +33,4 @@ export type RpcServiceDefinition<S> = {
 export const RPC_HOST = 'http://localhost'
 export const RPC_PORT = 4000
 export const RPC_CONTENT_TYPE = 'application/grpc-web+json'
-export const REPL_PORT = 6000
+export const REPL_PORT = 7375 // That spells REPL on your phone

--- a/packages/mds-rpc-common/@types/index.ts
+++ b/packages/mds-rpc-common/@types/index.ts
@@ -33,4 +33,4 @@ export type RpcServiceDefinition<S> = {
 export const RPC_HOST = 'http://localhost'
 export const RPC_PORT = 4000
 export const RPC_CONTENT_TYPE = 'application/grpc-web+json'
-export const REPL_PORT = 7375 // That spells REPL on your phone
+export const REPL_PORT = 7375 // That spells REPL

--- a/packages/mds-rpc-common/server/index.ts
+++ b/packages/mds-rpc-common/server/index.ts
@@ -15,6 +15,9 @@
  */
 
 import express from 'express'
+import http from 'http'
+import net from 'net'
+import REPL from 'repl'
 import { ServiceHandlerFor } from 'rpc_ts/lib/server/server'
 import { cleanEnv, port as validatePort } from 'envalid'
 import { ModuleRpcProtocolServer } from 'rpc_ts/lib/protocol/server'
@@ -27,10 +30,7 @@ import {
   RawBodyParserMiddleware
 } from '@mds-core/mds-api-server'
 import { Nullable } from '@mds-core/mds-types'
-import http from 'http'
 import { ProcessManager } from '@mds-core/mds-service-helpers'
-import net from 'net'
-import REPL from 'repl'
 import { RpcServiceDefinition, RPC_PORT, RPC_CONTENT_TYPE, REPL_PORT } from '../@types'
 
 export interface RpcServiceHandlers {

--- a/packages/mds-rpc-common/server/index.ts
+++ b/packages/mds-rpc-common/server/index.ts
@@ -82,9 +82,11 @@ export const RpcServer = <S>(
                 REPL.start({
                   prompt: `${process.env.npm_package_name} REPL> `,
                   input: socket,
-                  output: socket
+                  output: socket,
+                  ignoreUndefined: true,
+                  terminal: true
                 }).context,
-                options.repl?.context ?? {}
+                { context: options.repl?.context ?? {} }
               )
             })
             .listen(replPort)

--- a/packages/mds-rpc-common/server/index.ts
+++ b/packages/mds-rpc-common/server/index.ts
@@ -79,7 +79,7 @@ export const RpcServer = <S>(
             .createServer(socket => {
               Object.assign(
                 REPL.start({
-                  prompt: `${process.env.npm_package_name}:REPL> `,
+                  prompt: `${process.env.npm_package_name} REPL> `,
                   input: socket,
                   output: socket
                 }).context,

--- a/packages/mds-rpc-common/tests/index.spec.ts
+++ b/packages/mds-rpc-common/tests/index.spec.ts
@@ -40,7 +40,8 @@ const TestServer = RpcServer(
   {
     length: async ([word]) =>
       word && word.length > 0 ? ServiceResult(word.length) : ServiceError({ type: 'NotFoundError', message: 'No Word' })
-  }
+  },
+  { repl: { context: {} } }
 ).controller()
 
 describe('Test RPC Client', () => {


### PR DESCRIPTION
## 📚 Purpose
Support remote REPL for RPC Servers. This is a draft. Needs some additional work, but this is the general idea. This allows you to connect to a service pod via `telnet` and issue commands from the REPL using the client instance attached to the context.
```
telnet localhost 8011
Trying ::1...
Connected to localhost.
Escape character is '^]'.
@mds-core/mds-jurisdiction-service REPL> await getJurisdictions()
[]
@mds-core/mds-jurisdiction-service REPL>
```