### PR TITLE
[mds-api-server] Refactor & add helper type on top of ApiResponse

### DIFF
--- a/packages/mds-api-server/@types/index.ts
+++ b/packages/mds-api-server/@types/index.ts
@@ -32,7 +32,7 @@ export type ApiError = { error: unknown; error_description?: string; error_detai
 export type ApiResponse<B = {}> = Omit<express.Response<B | ApiError>, 'locals'> & { locals: unknown }
 
 /**
- * Extracts the body generic for APIResponse, in addition to possible error values.
+ * Extracts the body generic (B) for an APIResponse, in addition to possible error values.
  * Useful for frontend applications attempting to use the response payloads defined for Express.
  */
 export type ExtractApiResponseBody<P> = P extends ApiResponse<infer T> ? T | ApiError : never

--- a/packages/mds-api-server/@types/index.ts
+++ b/packages/mds-api-server/@types/index.ts
@@ -22,14 +22,20 @@ export type ApiRequestQuery<S extends string, M extends string[] = never> = {
 }
 
 /**
+ * Standard format for API errors
+ */
+export type ApiError = { error: unknown; error_description?: string; error_details?: string[] } | { errors: unknown[] }
+
+/**
  * B: Type of response body (res.send)
  */
-export type ApiResponse<B = {}> = Omit<
-  express.Response<
-    B | { error: unknown; error_description?: string; error_details?: string[] } | { errors: unknown[] }
-  >,
-  'locals'
-> & { locals: unknown }
+export type ApiResponse<B = {}> = Omit<express.Response<B | ApiError>, 'locals'> & { locals: unknown }
+
+/**
+ * Extracts the body generic for APIResponse, in addition to possible error values.
+ * Useful for frontend applications attempting to use the response payloads defined for Express.
+ */
+export type ExtractApiResponseBody<P> = P extends ApiResponse<infer T> ? T | ApiError : never
 
 /**
  * L: Type of response locals (res.locals)


### PR DESCRIPTION
## 📚 Purpose
Add ApiError type for standard error format and use in ApiResponse, add new ExtractApiResponseBody type which can be used for taking an extension of ApiResponse, and returns the B (body) generic or ApiError. This can be useful when attempting to leverage the existing express types we have in the BE from a FE application.

## 📦 Impacts:
mds-api-server