### PR TITLE
Ignore npm advisory 1556 due to isomorphic-fetch being a dead package

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,1 +1,2 @@
 # Comma separated list of advisories to exclude
+1556

--- a/.iyarc
+++ b/.iyarc
@@ -1,2 +1,3 @@
 # Comma separated list of advisories to exclude
+# https://npmjs.com/advisories/1556
 1556


### PR DESCRIPTION
## 📚 Purpose
Auditing for vulnerabilities is failing (and resulting in all builds failing) due to a recent NPM advisory https://www.npmjs.com/advisories/1556. Unfortunately, though `node-fetch` has been patched, a dependency of `rpc_ts`, `isomorphic-fetch`, requires version `^1.0.1`, which has not received this security patch. Considering `isomorphic-fetch` is a pretty dead package, it is unlikely this fix will ever land.