### PR TITLE
Make Policy typedef less prescriptive

### DIFF
--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -90,16 +90,13 @@ const ruleSchema = Joi.object().keys({
     .required(),
   rule_units: Joi.string().valid('seconds', 'minutes', 'hours', 'mph', 'kph'),
   geographies: Joi.array().items(Joi.string().guid()),
-  statuses: Joi.object()
-    .keys({
-      available: Joi.array(),
-      reserved: Joi.array(),
-      unavailable: Joi.array(),
-      removed: Joi.array(),
-      inactive: Joi.array(),
-      trip: Joi.array(),
-      elsewhere: Joi.array()
-    })
+  states: Joi.object()
+    .keys(
+      VEHICLE_STATES.reduce(
+        (acc, state) => Object.assign(acc, { [state]: Joi.array().items(stringSchema.valid(...VEHICLE_EVENTS)) }),
+        {}
+      )
+    )
     .allow(null),
   vehicle_types: Joi.array().items(Joi.string().valid(...Object.values(VEHICLE_TYPES))),
   maximum: Joi.number(),

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -333,7 +333,7 @@ export interface PolicyMessage {
 
 // This gets you a type where the keys must be VEHICLE_STATES, such as 'available',
 // and the values are an array of events.
-export type StatesToEvents = { [S in VEHICLE_STATE]: typeof STATE_EVENT_MAP[S] | [] }
+export type StatesToEvents = { [S in VEHICLE_STATE]: VEHICLE_EVENT[] | [] }
 
 interface BaseRule<RuleType = 'count' | 'speed' | 'time'> {
   // TODO 'rate'


### PR DESCRIPTION
## 📚 Purpose
We previously had a tighter definition of what event_types could go under a particular state, however for MDS 1.0.0 that mapping is too prescriptive, and leads to possible gaps in Policy. This conforms more with the spec, but having a looser definition.

## 📦 Impacts:
- mds-types
- mds-policy
- mds-policy-author
- mds-compliance
