### PR TITLE
Removing circular dependency on mds-utils

### DIFF
--- a/packages/mds-types/package.json
+++ b/packages/mds-types/package.json
@@ -19,7 +19,6 @@
     "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc ts-mocha --project ../../tsconfig.json"
   },
   "dependencies": {
-    "@types/geojson": "7946.0.7",
-    "@mds-core/mds-utils": "0.1.26"
+    "@types/geojson": "7946.0.7"
   }
 }

--- a/packages/mds-types/tests/transformers/device_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/device_transformers_spec.ts
@@ -1,13 +1,12 @@
 import assert from 'assert'
-import { uuid, now } from '@mds-core/mds-utils'
 import { Device_v0_4_1 } from '../../transformers/@types'
 import { Device_v1_0_0 } from '../../index'
 import { convert_v0_4_1_device_to_1_0_0, convert_v1_0_0_device_to_0_4_1 } from '../../transformers'
 
-const TIME = now()
-const DEVICE_ID = uuid()
-const PROVIDER_ID = uuid()
-const VEHICLE_ID = uuid()
+const TIME = 1600720345
+const DEVICE_ID = 'd0d9c274-773f-46c4-8c3a-f3cd35e4f99c'
+const PROVIDER_ID = 'baf215d4-8b4b-4be4-8189-980171a964ba'
+const VEHICLE_ID = '3f411cb1-a5a4-4b29-9e72-2714fdd24bc8'
 
 describe('Test transformers', () => {
   it('checks the transformation between v0.4.1 and v1.0.0 Device types', done => {

--- a/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
@@ -1,7 +1,11 @@
 import assert from 'assert'
 import { VehicleEvent_v0_4_1 } from '../../transformers/@types'
 import { VehicleEvent_v1_0_0 } from '../../index'
-import { convert_v1_0_0_vehicle_event_to_v0_4_1, convert_v0_4_1_vehicle_event_to_v1_0_0 } from '../../transformers'
+import {
+  convert_v1_0_0_vehicle_event_to_v0_4_1,
+  convert_v0_4_1_vehicle_event_to_v1_0_0,
+  UnsupportedEventTypeError
+} from '../../transformers'
 
 const TIME = Date.now()
 const DEVICE_ID = 'd0d9c274-773f-46c4-8c3a-f3cd35e4f99c'
@@ -97,7 +101,7 @@ describe('Test transformers', () => {
         recorded: TIME
       }
 
-      assert.throws(() => convert_v0_4_1_vehicle_event_to_v1_0_0(event), Error)
+      assert.throws(() => convert_v0_4_1_vehicle_event_to_v1_0_0(event), UnsupportedEventTypeError)
     })
   })
 

--- a/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
@@ -9,8 +9,8 @@ const PROVIDER_ID = 'baf215d4-8b4b-4be4-8189-980171a964ba'
 const STOP_ID = '3f411cb1-a5a4-4b29-9e72-2714fdd24bc8'
 
 describe('Test transformers', () => {
-  it('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {
-    it('checks the provider_pick_up and charge combo translate correctly', finished => {
+  describe('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', () => {
+    it('checks the provider_pick_up and charge combo translate correctly', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -34,10 +34,9 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    it('checks that the service_end and low_battery combo translate correctly', finished => {
+    it('checks that the service_end and low_battery combo translate correctly', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -61,10 +60,9 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    it('verifies the translation of trip_enter to on_trip', finished => {
+    it('verifies the translation of trip_enter to on_trip', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -88,13 +86,22 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    done()
+    it('throws an error with the event_type `register`', () => {
+      const event: VehicleEvent_v0_4_1 = {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'register',
+        recorded: TIME
+      }
+
+      assert.throws(() => convert_v0_4_1_vehicle_event_to_v1_0_0(event), Error)
+    })
   })
 
-  it('spot checks the transformations between v1.0.0 VehicleEvent and v0.4.1 VehicleEvent when there are multiple event types', done => {
+  it('spot checks the transformations between v1.0.0 VehicleEvent and v0.4.1 VehicleEvent when there are multiple event types', () => {
     const eventA: VehicleEvent_v1_0_0 = {
       device_id: DEVICE_ID,
       provider_id: PROVIDER_ID,
@@ -145,6 +152,5 @@ describe('Test transformers', () => {
         heading: 5
       }
     })
-    done()
   })
 })

--- a/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
@@ -1,13 +1,12 @@
 import assert from 'assert'
-import { uuid, now } from '@mds-core/mds-utils'
 import { VehicleEvent_v0_4_1 } from '../../transformers/@types'
 import { VehicleEvent_v1_0_0 } from '../../index'
 import { convert_v1_0_0_vehicle_event_to_v0_4_1, convert_v0_4_1_vehicle_event_to_v1_0_0 } from '../../transformers'
 
-const TIME = now()
-const DEVICE_ID = uuid()
-const PROVIDER_ID = uuid()
-const STOP_ID = uuid()
+const TIME = 1600720345
+const DEVICE_ID = 'd0d9c274-773f-46c4-8c3a-f3cd35e4f99c'
+const PROVIDER_ID = 'baf215d4-8b4b-4be4-8189-980171a964ba'
+const STOP_ID = '3f411cb1-a5a4-4b29-9e72-2714fdd24bc8'
 
 describe('Test transformers', () => {
   it('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -98,6 +98,10 @@ export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_
     recorded
   } = event
 
+  if (event_type === 'register') {
+    throw new Error(`Unexpected 'register' event_type for device_id ${device_id}`)
+  }
+
   const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
     event_type as INGESTABLE_VEHICLE_EVENT,
     event_type_reason

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -7,11 +7,12 @@ import {
 } from '../@types'
 import { VEHICLE_EVENT_v1_0_0, VEHICLE_STATE_v1_0_0, VehicleEvent_v1_0_0 } from '../../index'
 
+type INGESTABLE_VEHICLE_EVENT = Exclude<VEHICLE_EVENT_v0_4_1, 'register'>
 export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
   /* We don't actually accept/ingest events with the `register` event_type in 0.4.1 Agency, so
    * it's omitted here.
    */
-  [P in Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT]: {
+  [P in INGESTABLE_VEHICLE_EVENT | TRANSFORMER_VEHICLE_EVENT]: {
     [Q in VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON]: {
       event_type: VEHICLE_EVENT_v1_0_0
       vehicle_state: VEHICLE_STATE_v1_0_0
@@ -73,7 +74,7 @@ export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
 }
 
 function map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
-  event_type: VEHICLE_EVENT_v0_4_1 | TRANSFORMER_VEHICLE_EVENT,
+  event_type: INGESTABLE_VEHICLE_EVENT | TRANSFORMER_VEHICLE_EVENT,
   event_type_reason: VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON | null | undefined
 ): { event_type: VEHICLE_EVENT_v1_0_0; vehicle_state: VEHICLE_STATE_v1_0_0 } {
   if (event_type_reason) {
@@ -98,7 +99,7 @@ export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_
   } = event
 
   const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
-    event_type,
+    event_type as INGESTABLE_VEHICLE_EVENT,
     event_type_reason
   )
   return {

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -7,6 +7,13 @@ import {
 } from '../@types'
 import { VEHICLE_EVENT_v1_0_0, VEHICLE_STATE_v1_0_0, VehicleEvent_v1_0_0 } from '../../index'
 
+export class UnsupportedEventTypeError extends Error {
+  public constructor(public name: string, public reason?: string, public info?: unknown) {
+    super(reason)
+    Error.captureStackTrace(this, Error)
+  }
+}
+
 type INGESTABLE_VEHICLE_EVENT = Exclude<VEHICLE_EVENT_v0_4_1, 'register'>
 export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
   /* We don't actually accept/ingest events with the `register` event_type in 0.4.1 Agency, so
@@ -99,7 +106,7 @@ export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_
   } = event
 
   if (event_type === 'register') {
-    throw new Error(`Unexpected 'register' event_type for device_id ${device_id}`)
+    throw new UnsupportedEventTypeError(`Unexpected 'register' event_type for device_id ${device_id}`)
   }
 
   const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -110,7 +110,7 @@ export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_
   }
 
   const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
-    event_type as INGESTABLE_VEHICLE_EVENT,
+    event_type,
     event_type_reason
   )
   return {

--- a/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
+++ b/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
@@ -1,4 +1,3 @@
-import { clone } from '@mds-core/mds-utils'
 import { VEHICLE_REASON_v0_4_1, VehicleEvent_v0_4_1, VEHICLE_EVENT_v0_4_1, TRANSFORMER_VEHICLE_EVENT } from '../@types'
 import { VehicleEvent_v1_0_0, VEHICLE_EVENT_v1_0_0 } from '../../index'
 
@@ -66,19 +65,22 @@ export const FULL_STATE_MAPPING_v1_0_0_to_v0_4_1: {
   battery_charged: {
     event_type: 'service_start'
   },
-  trip_cancel: {
-    event_type: 'no_backconversion_available'
-  },
   comms_lost: {
     event_type: 'no_backconversion_available'
   },
   comms_restored: {
     event_type: 'no_backconversion_available'
   },
+  located: {
+    event_type: 'no_backconversion_available'
+  },
   system_resume: {
     event_type: 'no_backconversion_available'
   },
   system_suspend: {
+    event_type: 'no_backconversion_available'
+  },
+  trip_cancel: {
     event_type: 'no_backconversion_available'
   },
   unspecified: {
@@ -92,7 +94,7 @@ function convert_v1_0_0_to_v0_4_1_helper(
 ): VehicleEvent_v0_4_1 {
   const { event_type, event_type_reason } = FULL_STATE_MAPPING_v1_0_0_to_v0_4_1[current_event_type]
 
-  const telemetry = event.telemetry ? clone(event.telemetry) : null
+  const telemetry = event.telemetry ? JSON.parse(JSON.stringify(event.telemetry)) : null
   if (telemetry && telemetry.stop_id) {
     delete telemetry.stop_id
   }


### PR DESCRIPTION
## 📚 Purpose
Remove circular dependenc between mds-utils and mds-types that was causing a compilation failure.

@avatarneil Sorry, I know you don't like it here, but it doesn't feel like it makes sense to have the 0.4.1 types in anywhere but mds-types, and then it feels weird separating them from the transformers code. I didn't want to stick them in `mds-agency`, cause the validators require the transformers, and stickng them in `mds-utils` would've caused another circular dependency since that depends on `mds-types`.

## 👌 Resolves:
- [ ] 🐛 JRA-834 fixes bug
- [ ] ✨ JRA-756 implements new feature

## 📦 Impacts:
*[list of packages]*

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs