### PR TITLE
[mds-types] [all-the-things] Merge in changes from dev/upgrade-to-1.0, move 1.0 types to transformers folder, make Taxi-on-MDS be v1.1.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -523,6 +523,27 @@
       "env": {
         "DOTENV_CONFIG_PATH": "${workspaceFolder}/.env"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tests: mds-schema-validators",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--project",
+        "${workspaceFolder}/tsconfig.json",
+        "-r",
+        "ts-node/register",
+        "--timeout",
+        "0"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector",
+      "cwd": "${workspaceFolder}/packages/mds-schema-validators",
+      "env": {
+        "DOTENV_CONFIG_PATH": "${workspaceFolder}/.env"
+      }
     }
   ]
 }

--- a/packages/mds-schema-validators/index.ts
+++ b/packages/mds-schema-validators/index.ts
@@ -1,2 +1,3 @@
 export * from './validators'
 export * from './trip-metadata-validators'
+export * from './v0_4_1'

--- a/packages/mds-schema-validators/tests/v0_4_1/vehicle_event_validators.spec.ts
+++ b/packages/mds-schema-validators/tests/v0_4_1/vehicle_event_validators.spec.ts
@@ -1,0 +1,94 @@
+import test from 'unit.js'
+import { validateEvent_v0_4_1 } from '../../v0_4_1'
+import { ValidationError } from '../../validators'
+
+describe('Tests validators', () => {
+  it('verifies v0.4.1 Vehicle Event validator', done => {
+    const DEREGISTER_EVENT_TYPE_REASONS = ['missing', 'decommissioned']
+    const PROVIDER_PICK_UP_EVENT_TYPE_REASONS = ['rebalance', 'maintenance', 'charge', 'compliance']
+    const SERVICE_END_EVENT_TYPE_REASONS = ['low_battery', 'maintenance', 'compliance', 'off_hours']
+
+    test.assert.throws(() => validateEvent_v0_4_1(undefined), ValidationError)
+    test.assert.throws(() => validateEvent_v0_4_1(null), ValidationError)
+    test.assert.throws(() => validateEvent_v0_4_1('invalid'), ValidationError)
+    test.assert.throws(
+      () =>
+        validateEvent_v0_4_1({
+          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+          event_type: 'decommissioned',
+          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+          timestamp: Date.now()
+        }),
+      ValidationError
+    )
+    test.assert.throws(
+      () =>
+        validateEvent_v0_4_1({
+          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+          event_type: 'provider_pick_up',
+          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+          timestamp: Date.now()
+        }),
+      ValidationError
+    )
+    test.assert.throws(
+      () =>
+        validateEvent_v0_4_1({
+          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+          event_type: 'service_end',
+          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+          timestamp: Date.now()
+        }),
+      ValidationError
+    )
+
+    DEREGISTER_EVENT_TYPE_REASONS.forEach(event_type_reason => {
+      test
+        .value(
+          validateEvent_v0_4_1({
+            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+            event_type: 'deregister',
+            event_type_reason,
+            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+            timestamp: Date.now()
+          })
+        )
+        .is(true)
+    })
+
+    PROVIDER_PICK_UP_EVENT_TYPE_REASONS.forEach(event_type_reason => {
+      test
+        .value(
+          validateEvent_v0_4_1({
+            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+            event_type: 'provider_pick_up',
+            event_type_reason,
+            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+            timestamp: Date.now()
+          })
+        )
+        .is(true)
+    })
+
+    SERVICE_END_EVENT_TYPE_REASONS.forEach(event_type_reason => {
+      test
+        .value(
+          validateEvent_v0_4_1({
+            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
+            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
+            event_type: 'service_end',
+            event_type_reason,
+            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
+            timestamp: Date.now()
+          })
+        )
+        .is(true)
+    })
+    done()
+  })
+})

--- a/packages/mds-schema-validators/tests/validators.spec.ts
+++ b/packages/mds-schema-validators/tests/validators.spec.ts
@@ -32,8 +32,7 @@ import {
   isValidAuditIssueCode,
   isValidAuditNote,
   isValidNumber,
-  ValidationError,
-  validateEvent
+  ValidationError
 } from '../validators'
 
 describe('Tests validators', () => {
@@ -173,96 +172,6 @@ describe('Tests validators', () => {
     test.assert.throws(() => isValidVehicleEventType('invalid'), ValidationError)
     test.value(isValidVehicleEventType(AUDIT_EVENT_TYPES.telemetry, { assert: false })).is(false)
     test.value(isValidVehicleEventType('trip_end')).is(true)
-    done()
-  })
-
-  it('verifies Vehicle Event validator', done => {
-    const DEREGISTER_EVENT_TYPE_REASONS = ['missing', 'decomissioned']
-    const PROVIDER_PICK_UP_EVENT_TYPE_REASONS = ['rebalance', 'maintenance', 'charge', 'compliance']
-    const SERVICE_END_EVENT_TYPE_REASONS = ['low_battery', 'maintenance', 'compliance', 'off_hours']
-
-    test.assert.throws(() => validateEvent(undefined), ValidationError)
-    test.assert.throws(() => validateEvent(null), ValidationError)
-    test.assert.throws(() => validateEvent('invalid'), ValidationError)
-    test.assert.throws(
-      () =>
-        validateEvent({
-          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-          event_type: 'decommissioned',
-          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-          timestamp: Date.now()
-        }),
-      ValidationError
-    )
-    test.assert.throws(
-      () =>
-        validateEvent({
-          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-          event_type: 'provider_pick_up',
-          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-          timestamp: Date.now()
-        }),
-      ValidationError
-    )
-    test.assert.throws(
-      () =>
-        validateEvent({
-          device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-          provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-          event_type: 'service_end',
-          telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-          timestamp: Date.now()
-        }),
-      ValidationError
-    )
-
-    DEREGISTER_EVENT_TYPE_REASONS.forEach(event_type_reason => {
-      test
-        .value(
-          validateEvent({
-            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-            event_type: 'decommissioned',
-            event_type_reason,
-            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-            timestamp: Date.now()
-          })
-        )
-        .is(true)
-    })
-
-    PROVIDER_PICK_UP_EVENT_TYPE_REASONS.forEach(event_type_reason => {
-      test
-        .value(
-          validateEvent({
-            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-            event_type: 'provider_pick_up',
-            event_type_reason,
-            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-            timestamp: Date.now()
-          })
-        )
-        .is(true)
-    })
-
-    SERVICE_END_EVENT_TYPE_REASONS.forEach(event_type_reason => {
-      test
-        .value(
-          validateEvent({
-            device_id: '395144fb-ebef-4842-ba91-b5ba98d34945',
-            provider_id: 'b54c08c7-884a-4c5f-b9ed-2c7dc24638cb',
-            event_type: 'service_end',
-            event_type_reason,
-            telemetry: { timestamp: Date.now(), gps: { lat: 0, lng: 0 } },
-            timestamp: Date.now()
-          })
-        )
-        .is(true)
-    })
-
     done()
   })
 

--- a/packages/mds-schema-validators/v0_4_1/index.ts
+++ b/packages/mds-schema-validators/v0_4_1/index.ts
@@ -1,0 +1,80 @@
+// **************************
+// 0.4.1 Validators, eventually to be deprecated
+// **************************
+import Joi from '@hapi/joi'
+
+import { VehicleEvent_v0_4_1, VEHICLE_EVENTS_v0_4_1 } from '@mds-core/mds-types/transformers/@types'
+import {
+  ValidatorOptions,
+  ValidateSchema,
+  uuidSchema,
+  timestampSchema,
+  telemetrySchema,
+  stringSchema
+} from '../validators'
+
+const vehicleEventTypeSchema_v0_4_1 = stringSchema.valid(...VEHICLE_EVENTS_v0_4_1)
+
+const eventSchema_v0_4_1 = Joi.object().keys({
+  device_id: uuidSchema.required(),
+  provider_id: uuidSchema.required(),
+  timestamp: timestampSchema.required(),
+  event_type: vehicleEventTypeSchema_v0_4_1.required(),
+  telemetry_timestamp: timestampSchema.optional(),
+  telemetry: telemetrySchema.required(),
+  service_area_id: uuidSchema.allow(null).optional(),
+  recorded: timestampSchema.optional()
+})
+export const isValidEvent_v0_4_1 = (
+  value: unknown,
+  options: Partial<ValidatorOptions> = {}
+): value is VehicleEvent_v0_4_1 => ValidateSchema(value, eventSchema_v0_4_1, options)
+
+const tripEventSchema_v0_4_1 = eventSchema_v0_4_1.keys({
+  trip_id: uuidSchema.required()
+})
+
+const validateTripEvent_v0_4_1 = (event: VehicleEvent_v0_4_1) => ValidateSchema(event, tripEventSchema_v0_4_1, {})
+
+const serviceEndEventSchema_v0_4_1 = eventSchema_v0_4_1.keys({
+  event_type_reason: stringSchema.valid('low_battery', 'maintenance', 'compliance', 'off_hours').required()
+})
+
+const providerPickUpEventSchema_v0_4_1 = eventSchema_v0_4_1.keys({
+  event_type_reason: stringSchema.valid('rebalance', 'maintenance', 'charge', 'compliance').required()
+})
+
+const deregisterEventSchema_v0_4_1 = eventSchema_v0_4_1.keys({
+  event_type_reason: stringSchema.valid('missing', 'decommissioned').required()
+})
+
+const validateProviderPickUpEvent_v0_4_1 = (event: VehicleEvent_v0_4_1) =>
+  ValidateSchema(event, providerPickUpEventSchema_v0_4_1, {})
+
+const validateServiceEndEvent_v0_4_1 = (event: VehicleEvent_v0_4_1) =>
+  ValidateSchema(event, serviceEndEventSchema_v0_4_1, {})
+
+const validateDeregisterEvent_v0_4_1 = (event: VehicleEvent_v0_4_1) =>
+  ValidateSchema(event, deregisterEventSchema_v0_4_1, {})
+
+export const validateEvent_v0_4_1 = (event: unknown) => {
+  if (isValidEvent_v0_4_1(event, { allowUnknown: true })) {
+    const { event_type } = event
+
+    const TRIP_EVENTS: string[] = ['trip_start', 'trip_end', 'trip_enter', 'trip_leave']
+
+    if (TRIP_EVENTS.includes(event_type)) {
+      return validateTripEvent_v0_4_1(event)
+    }
+    if (event_type === 'provider_pick_up') {
+      return validateProviderPickUpEvent_v0_4_1(event)
+    }
+    if (event_type === 'service_end') {
+      return validateServiceEndEvent_v0_4_1(event)
+    }
+    if (event_type === 'deregister') {
+      return validateDeregisterEvent_v0_4_1(event)
+    }
+    return ValidateSchema(event, eventSchema_v0_4_1, {})
+  }
+}

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -35,7 +35,7 @@ export type RULE_TYPE = keyof typeof RULE_TYPES
 export const PROPULSION_TYPES = Enum('human', 'electric', 'electric_assist', 'hybrid', 'combustion')
 export type PROPULSION_TYPE = keyof typeof PROPULSION_TYPES
 
-export const MICRO_MOBILITY_VEHICLE_STATES = [
+export const MICRO_MOBILITY_VEHICLE_STATES_v1_1_0 = [
   'available',
   'elsewhere',
   'non_operational',
@@ -44,7 +44,10 @@ export const MICRO_MOBILITY_VEHICLE_STATES = [
   'reserved',
   'unknown'
 ] as const
-export type MICRO_MOBILITY_VEHICLE_STATE = typeof MICRO_MOBILITY_VEHICLE_STATES[number]
+export type MICRO_MOBILITY_VEHICLE_STATE_v1_1_0 = typeof MICRO_MOBILITY_VEHICLE_STATES_v1_1_0[number]
+
+export const MICRO_MOBILITY_VEHICLE_STATES = MICRO_MOBILITY_VEHICLE_STATES_v1_1_0
+export type MICRO_MOBILITY_VEHICLE_STATE = MICRO_MOBILITY_VEHICLE_STATE_v1_1_0
 
 export const TAXI_VEHICLE_STATES = [
   'available',
@@ -58,32 +61,18 @@ export const TAXI_VEHICLE_STATES = [
 ] as const
 export type TAXI_VEHICLE_STATE = typeof TAXI_VEHICLE_STATES[number]
 
-export const VEHICLE_STATES = [...MICRO_MOBILITY_VEHICLE_STATES, ...TAXI_VEHICLE_STATES] as const
-export type VEHICLE_STATE = typeof VEHICLE_STATES[number]
+export const VEHICLE_STATES_v1_1_0 = [...MICRO_MOBILITY_VEHICLE_STATES_v1_1_0, ...TAXI_VEHICLE_STATES] as const
+export type VEHICLE_STATE_v1_1_0 = typeof VEHICLE_STATES_v1_1_0[number]
 
-// export const RIGHT_OF_WAY_STATUSES = ['available', 'reserved', 'unavailable', 'trip']
+export const VEHICLE_STATES = VEHICLE_STATES_v1_1_0
+export type VEHICLE_STATE = VEHICLE_STATE_v1_1_0
+
 export const RIGHT_OF_WAY_STATES = ['available', 'reserved', 'non_operational', 'trip'] as const
 
 export const TRIP_STATES = ['on_trip', 'reserved', 'stopped'] as const
 export type TRIP_STATE = typeof TRIP_STATES[number]
 
-// export const VEHICLE_EVENTS = Enum(
-//   'register',
-//   'service_start',
-//   'service_end',
-//   'provider_drop_off',
-//   'provider_pick_up',
-//   'agency_pick_up',
-//   'agency_drop_off',
-//   'reserve',
-//   'cancel_reservation',
-//   'trip_start',
-//   'trip_enter',
-//   'trip_leave',
-//   'trip_end',
-//   'deregister'
-// )
-export const MICRO_MOBILITY_VEHICLE_EVENTS = [
+export const MICRO_MOBILITY_VEHICLE_EVENTS_v1_1_0 = [
   'agency_drop_off',
   'agency_pick_up',
   'battery_charged',
@@ -92,6 +81,7 @@ export const MICRO_MOBILITY_VEHICLE_EVENTS = [
   'comms_restored',
   'compliance_pick_up',
   'decommissioned',
+  'located',
   'maintenance',
   'maintenance_pick_up',
   'missing',
@@ -110,7 +100,10 @@ export const MICRO_MOBILITY_VEHICLE_EVENTS = [
   'trip_start',
   'unspecified'
 ] as const
-export type MICRO_MOBILITY_VEHICLE_EVENT = typeof MICRO_MOBILITY_VEHICLE_EVENTS[number]
+export type MICRO_MOBILITY_VEHICLE_EVENT_v1_1_0 = typeof MICRO_MOBILITY_VEHICLE_EVENTS_v1_1_0[number]
+
+export const MICRO_MOBILITY_VEHICLE_EVENTS = MICRO_MOBILITY_VEHICLE_EVENTS_v1_1_0
+export type MICRO_MOBILITY_VEHICLE_EVENT = MICRO_MOBILITY_VEHICLE_EVENT_v1_1_0
 
 export const TAXI_VEHICLE_EVENTS = [
   'comms_lost',
@@ -143,41 +136,14 @@ export const TAXI_TRIP_EXIT_EVENTS: TAXI_VEHICLE_EVENT[] = [
   'driver_cancellation'
 ]
 
-export const VEHICLE_EVENTS = [...MICRO_MOBILITY_VEHICLE_EVENTS, ...TAXI_VEHICLE_EVENTS] as const
-export type VEHICLE_EVENT = typeof VEHICLE_EVENTS[number]
+export const VEHICLE_EVENTS_v1_1_0 = [...MICRO_MOBILITY_VEHICLE_EVENTS, ...TAXI_VEHICLE_EVENTS] as const
+export type VEHICLE_EVENT_v1_1_0 = typeof VEHICLE_EVENTS[number]
 
-// export const VEHICLE_REASONS = Enum(
-//   'battery_charged',
-//   'charge',
-//   'compliance',
-//   'decommissioned',
-//   'low_battery',
-//   'maintenance',
-//   'missing',
-//   'off_hours',
-//   'rebalance'
-// )
-// export type VEHICLE_REASON = keyof typeof VEHICLE_REASONS
+export const VEHICLE_EVENTS = VEHICLE_EVENTS_v1_1_0
+export type VEHICLE_EVENT = VEHICLE_EVENT_v1_1_0
 
 export const AUDIT_EVENT_TYPES = Enum('start', 'note', 'summary', 'issue', 'telemetry', 'end')
 export type AUDIT_EVENT_TYPE = keyof typeof AUDIT_EVENT_TYPES
-
-// export const EVENT_STATES_MAP: { [P in VEHICLE_EVENT]: VEHICLE_STATE } = {
-//   register: VEHICLE_STATES.removed,
-//   service_start: VEHICLE_STATES.available,
-//   service_end: VEHICLE_STATES.unavailable,
-//   provider_drop_off: VEHICLE_STATES.available,
-//   provider_pick_up: VEHICLE_STATES.removed,
-//   agency_pick_up: VEHICLE_STATES.removed,
-//   agency_drop_off: VEHICLE_STATES.available,
-//   reserve: VEHICLE_STATES.reserved,
-//   cancel_reservation: VEHICLE_STATES.available,
-//   trip_start: VEHICLE_STATES.trip,
-//   trip_enter: VEHICLE_STATES.trip,
-//   trip_leave: VEHICLE_STATES.elsewhere,
-//   trip_end: VEHICLE_STATES.available,
-//   deregister: VEHICLE_STATES.inactive
-// }
 
 // States you transition into based on event_type
 export const MICRO_MOBILITY_EVENT_STATES_MAP: {
@@ -191,6 +157,7 @@ export const MICRO_MOBILITY_EVENT_STATES_MAP: {
   comms_restored: ['available', 'elsewhere', 'non_operational', 'removed', 'reserved', 'on_trip'],
   compliance_pick_up: ['removed'],
   decommissioned: ['removed'],
+  located: ['available', 'non_operational', 'reserved', 'on_trip', 'elsewhere'],
   maintenance: ['available', 'non_operational'],
   maintenance_pick_up: ['removed'],
   missing: ['unknown'],
@@ -271,7 +238,7 @@ export const MICRO_MOBILITY_STATE_EVENT_MAP = MicroMobilityStatusEventMap({
     'decommissioned',
     'unspecified'
   ],
-  unknown: ['comms_lost', 'missing']
+  unknown: ['comms_lost', 'missing', 'located']
 })
 
 export const TAXI_STATE_EVENT_MAP = TaxiStatusEventMap({
@@ -317,7 +284,7 @@ export const MODALITIES = ['micro-mobility', 'taxi'] as const
 export type MODALITY = typeof MODALITIES[number]
 
 // Represents a row in the "devices" table
-export interface Device {
+export interface Device_v1_1_0 {
   accessibility_options: ACCESSIBILITY_OPTION[]
   device_id: UUID
   provider_id: UUID
@@ -331,12 +298,20 @@ export interface Device {
   recorded: Timestamp
   state?: VEHICLE_STATE | null
 }
+/**
+ * This is an alias that must be updated in the event of future changes to the type.
+ */
+export type Device = Device_v1_1_0
 
 export type DeviceID = Pick<Device, 'provider_id' | 'device_id'>
 
-// Represents a row in the "events" table
-// Named "VehicleEvent" to avoid confusion with the DOM's Event interface
-export interface VehicleEvent {
+/**
+ *  Represents a row in the "events" table
+ * Named "VehicleEvent" to avoid confusion with the DOM's Event interface
+ * Keeping 1_0_0 types in here and not in transformers/@types to avoid circular imports.
+ * This alias must be updated if this type is updated.
+ */
+export interface VehicleEvent_v1_1_0 {
   device_id: UUID
   provider_id: UUID
   timestamp: Timestamp
@@ -350,6 +325,7 @@ export interface VehicleEvent {
   trip_state: Nullable<TRIP_STATE>
   recorded: Timestamp
 }
+export type VehicleEvent = VehicleEvent_v1_1_0
 
 export interface MicroMobilityVehicleEvent extends VehicleEvent {
   event_types: MICRO_MOBILITY_VEHICLE_EVENT[]
@@ -389,6 +365,7 @@ export interface Telemetry extends WithGpsProperty<TelemetryData> {
   device_id: UUID
   timestamp: Timestamp
   recorded?: Timestamp
+  stop_id?: UUID | null
 }
 
 export const PAYMENT_METHODS = ['cash', 'card', 'equity_program'] as const
@@ -511,11 +488,13 @@ export interface PolicyMessage {
 // This gets you a type where the keys must be VEHICLE_STATES, such as 'available',
 // and the values are an array of events.
 export type MicroMobilityStatesToEvents = {
-  [S in MICRO_MOBILITY_VEHICLE_STATE]: typeof MICRO_MOBILITY_STATE_EVENT_MAP[S] | []
+  [S in MICRO_MOBILITY_VEHICLE_STATE]: MICRO_MOBILITY_VEHICLE_EVENT[] | []
 }
 export type TaxiStatesToEvents = {
-  [S in TAXI_VEHICLE_STATE]: typeof TAXI_STATE_EVENT_MAP[S] | []
+  [S in TAXI_VEHICLE_STATE]: TAXI_VEHICLE_EVENT[] | []
 }
+export type StatesToEvents = { [S in VEHICLE_STATE]: VEHICLE_EVENT[] | [] }
+
 interface BaseRule<RuleType = 'count' | 'speed' | 'time'> {
   // TODO 'rate'
   name: string

--- a/packages/mds-types/tests/transformers/device_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/device_transformers_spec.ts
@@ -1,12 +1,11 @@
 import assert from 'assert'
 import { Device_v0_4_1, Device_v1_0_0 } from '../../transformers/@types'
-
 import { convert_v0_4_1_device_to_1_0_0, convert_v1_0_0_device_to_0_4_1 } from '../../transformers'
 
 const TIME = Date.now()
-const DEVICE_ID = '79b2f745-c9a5-4ea8-a339-dcddf9184eab'
-const PROVIDER_ID = 'c5e78c3c-e816-4af0-bce4-6cf092524245'
-const VEHICLE_ID = '35d8c181-e288-40b6-bf20-29a83af4e173'
+const DEVICE_ID = 'd0d9c274-773f-46c4-8c3a-f3cd35e4f99c'
+const PROVIDER_ID = 'baf215d4-8b4b-4be4-8189-980171a964ba'
+const VEHICLE_ID = '3f411cb1-a5a4-4b29-9e72-2714fdd24bc8'
 
 describe('Test transformers', () => {
   it('checks the transformation between v0.4.1 and v1.0.0 Device types', done => {

--- a/packages/mds-types/tests/transformers/device_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/device_transformers_spec.ts
@@ -1,0 +1,70 @@
+import assert from 'assert'
+import { Device_v0_4_1, Device_v1_0_0 } from '../../transformers/@types'
+
+import { convert_v0_4_1_device_to_1_0_0, convert_v1_0_0_device_to_0_4_1 } from '../../transformers'
+
+const TIME = Date.now()
+const DEVICE_ID = '79b2f745-c9a5-4ea8-a339-dcddf9184eab'
+const PROVIDER_ID = 'c5e78c3c-e816-4af0-bce4-6cf092524245'
+const VEHICLE_ID = '35d8c181-e288-40b6-bf20-29a83af4e173'
+
+describe('Test transformers', () => {
+  it('checks the transformation between v0.4.1 and v1.0.0 Device types', done => {
+    const device: Device_v0_4_1 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      vehicle_id: VEHICLE_ID,
+      type: 'scooter',
+      propulsion: ['electric'],
+      status: 'removed',
+      year: 2000,
+      mfgr: 'Cadillac',
+      model: 'luxury',
+      recorded: TIME
+    }
+
+    assert.deepEqual(convert_v0_4_1_device_to_1_0_0(device), {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      vehicle_id: VEHICLE_ID,
+      vehicle_type: 'scooter',
+      propulsion_types: ['electric'],
+      state: 'removed',
+      recorded: TIME,
+      year: 2000,
+      mfgr: 'Cadillac',
+      model: 'luxury'
+    })
+
+    done()
+  })
+
+  it('checks the transformations from v1.0.0 Device to v0.4.0', done => {
+    const device: Device_v1_0_0 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      vehicle_id: VEHICLE_ID,
+      vehicle_type: 'scooter',
+      propulsion_types: ['electric', 'hybrid'],
+      state: 'removed',
+      recorded: TIME,
+      year: 2000,
+      mfgr: 'Schwinn',
+      model: 'fancy'
+    }
+
+    assert.deepEqual(convert_v1_0_0_device_to_0_4_1(device), {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      vehicle_id: VEHICLE_ID,
+      type: 'scooter',
+      propulsion: ['electric', 'hybrid'],
+      status: 'removed',
+      recorded: TIME,
+      year: 2000,
+      mfgr: 'Schwinn',
+      model: 'fancy'
+    })
+    done()
+  })
+})

--- a/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
@@ -1,0 +1,150 @@
+import assert from 'assert'
+import { VehicleEvent_v1_0_0, VehicleEvent_v0_4_1 } from '../../transformers/@types'
+
+import { convert_v1_0_0_vehicle_event_to_v0_4_1, convert_v0_4_1_vehicle_event_to_v1_0_0 } from '../../transformers'
+
+const TIME = Date.now()
+const DEVICE_ID = '6161580a-a839-44f4-a701-8312d29e2640'
+const PROVIDER_ID = 'c4bb9cca-de3f-42fe-82dc-e25ca6e9f724'
+const STOP_ID = '57818d48-08a8-4367-a707-81a6b4bee32c'
+
+describe('Test transformers', () => {
+  it('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {
+    it('checks the provider_pick_up and charge combo translate correctly', finished => {
+      const event: VehicleEvent_v0_4_1 = {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'provider_pick_up',
+        event_type_reason: 'charge',
+        recorded: TIME
+      }
+
+      const transformedEvent = convert_v0_4_1_vehicle_event_to_v1_0_0(event)
+      assert.deepEqual(transformedEvent, {
+        delta: null,
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        vehicle_state: 'removed',
+        event_types: ['maintenance_pick_up'],
+        recorded: TIME,
+        telemetry: null,
+        telemetry_timestamp: null,
+        timestamp_long: null,
+        trip_id: null
+      })
+      finished()
+    })
+
+    it('checks that the service_end and low_battery combo translate correctly', finished => {
+      const event: VehicleEvent_v0_4_1 = {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'service_end',
+        event_type_reason: 'low_battery',
+        recorded: TIME
+      }
+
+      const transformedEvent = convert_v0_4_1_vehicle_event_to_v1_0_0(event)
+      assert.deepEqual(transformedEvent, {
+        delta: null,
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        vehicle_state: 'non_operational',
+        event_types: ['battery_low'],
+        recorded: TIME,
+        telemetry: null,
+        telemetry_timestamp: null,
+        timestamp_long: null,
+        trip_id: null
+      })
+      finished()
+    })
+
+    it('verifies the translation of trip_enter to on_trip', finished => {
+      const event: VehicleEvent_v0_4_1 = {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'trip_enter',
+        recorded: TIME
+      }
+
+      const transformedEvent = convert_v0_4_1_vehicle_event_to_v1_0_0(event)
+
+      assert.deepEqual(transformedEvent, {
+        delta: null,
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        vehicle_state: 'on_trip',
+        event_types: ['trip_enter_jurisdiction'],
+        recorded: TIME,
+        telemetry: null,
+        telemetry_timestamp: null,
+        timestamp_long: null,
+        trip_id: null
+      })
+      finished()
+    })
+
+    done()
+  })
+
+  it('spot checks the transformations between v1.0.0 VehicleEvent and v0.4.1 VehicleEvent when there are multiple event types', done => {
+    const eventA: VehicleEvent_v1_0_0 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      vehicle_state: 'on_trip',
+      event_types: ['provider_drop_off', 'trip_start'],
+      recorded: TIME
+    }
+
+    const { 0: converted_eventA_1, 1: converted_eventA_2 } = convert_v1_0_0_vehicle_event_to_v0_4_1(eventA)
+    assert.deepEqual(converted_eventA_1.event_type, 'provider_drop_off')
+    assert.deepEqual(converted_eventA_2.event_type, 'trip_start')
+
+    const eventB: VehicleEvent_v1_0_0 = {
+      device_id: DEVICE_ID,
+      provider_id: PROVIDER_ID,
+      timestamp: TIME,
+      vehicle_state: 'available',
+      event_types: ['comms_lost', 'comms_restored'],
+      telemetry: {
+        provider_id: PROVIDER_ID,
+        device_id: DEVICE_ID,
+        timestamp: TIME,
+        gps: {
+          lat: 1000,
+          lng: 1000,
+          speed: 1,
+          hdop: 5,
+          heading: 5
+        },
+        stop_id: STOP_ID
+      },
+      recorded: TIME
+    }
+
+    const { 0: converted_eventB_1, 1: converted_eventB_2 } = convert_v1_0_0_vehicle_event_to_v0_4_1(eventB)
+    assert.deepEqual(converted_eventB_1.event_type, 'no_backconversion_available')
+    assert.deepEqual(converted_eventB_2.event_type, 'no_backconversion_available')
+    assert.deepEqual(converted_eventB_2.telemetry, {
+      provider_id: PROVIDER_ID,
+      device_id: DEVICE_ID,
+      timestamp: TIME,
+      gps: {
+        lat: 1000,
+        lng: 1000,
+        speed: 1,
+        hdop: 5,
+        heading: 5
+      }
+    })
+    done()
+  })
+})

--- a/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
+++ b/packages/mds-types/tests/transformers/vehicle_event_transformers_spec.ts
@@ -1,16 +1,20 @@
 import assert from 'assert'
-import { VehicleEvent_v1_0_0, VehicleEvent_v0_4_1 } from '../../transformers/@types'
+import { VehicleEvent_v0_4_1, VehicleEvent_v1_0_0 } from '../../transformers/@types'
 
-import { convert_v1_0_0_vehicle_event_to_v0_4_1, convert_v0_4_1_vehicle_event_to_v1_0_0 } from '../../transformers'
+import {
+  convert_v1_0_0_vehicle_event_to_v0_4_1,
+  convert_v0_4_1_vehicle_event_to_v1_0_0,
+  UnsupportedEventTypeError
+} from '../../transformers'
 
 const TIME = Date.now()
-const DEVICE_ID = '6161580a-a839-44f4-a701-8312d29e2640'
-const PROVIDER_ID = 'c4bb9cca-de3f-42fe-82dc-e25ca6e9f724'
-const STOP_ID = '57818d48-08a8-4367-a707-81a6b4bee32c'
+const DEVICE_ID = 'd0d9c274-773f-46c4-8c3a-f3cd35e4f99c'
+const PROVIDER_ID = 'baf215d4-8b4b-4be4-8189-980171a964ba'
+const STOP_ID = '3f411cb1-a5a4-4b29-9e72-2714fdd24bc8'
 
 describe('Test transformers', () => {
-  it('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', done => {
-    it('checks the provider_pick_up and charge combo translate correctly', finished => {
+  describe('spot checks the transformation between v0.4.1 and v1.0.0 VehicleEvent types', () => {
+    it('checks the provider_pick_up and charge combo translate correctly', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -34,10 +38,9 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    it('checks that the service_end and low_battery combo translate correctly', finished => {
+    it('checks that the service_end and low_battery combo translate correctly', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -61,10 +64,9 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    it('verifies the translation of trip_enter to on_trip', finished => {
+    it('verifies the translation of trip_enter to on_trip', () => {
       const event: VehicleEvent_v0_4_1 = {
         device_id: DEVICE_ID,
         provider_id: PROVIDER_ID,
@@ -88,13 +90,22 @@ describe('Test transformers', () => {
         timestamp_long: null,
         trip_id: null
       })
-      finished()
     })
 
-    done()
+    it('throws an error with the event_type `register`', () => {
+      const event: VehicleEvent_v0_4_1 = {
+        device_id: DEVICE_ID,
+        provider_id: PROVIDER_ID,
+        timestamp: TIME,
+        event_type: 'register',
+        recorded: TIME
+      }
+
+      assert.throws(() => convert_v0_4_1_vehicle_event_to_v1_0_0(event), UnsupportedEventTypeError)
+    })
   })
 
-  it('spot checks the transformations between v1.0.0 VehicleEvent and v0.4.1 VehicleEvent when there are multiple event types', done => {
+  it('spot checks the transformations between v1.0.0 VehicleEvent and v0.4.1 VehicleEvent when there are multiple event types', () => {
     const eventA: VehicleEvent_v1_0_0 = {
       device_id: DEVICE_ID,
       provider_id: PROVIDER_ID,
@@ -145,6 +156,5 @@ describe('Test transformers', () => {
         heading: 5
       }
     })
-    done()
   })
 })

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/devices.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/devices.ts
@@ -1,0 +1,27 @@
+import { Device_v0_4_1, VEHICLE_STATE_v0_4_1, Device_v1_0_0, VEHICLE_STATE_v1_0_0 } from '../@types'
+
+const STATE_TO_STATUS_MAPPING: { [P in VEHICLE_STATE_v0_4_1]: VEHICLE_STATE_v1_0_0 } = {
+  available: 'available',
+  elsewhere: 'elsewhere',
+  inactive: 'removed',
+  trip: 'on_trip',
+  removed: 'removed',
+  reserved: 'reserved',
+  unavailable: 'removed'
+}
+
+export function convert_v0_4_1_device_to_1_0_0(device: Device_v0_4_1): Device_v1_0_0 {
+  const { provider_id, device_id, vehicle_id, type, propulsion, year, mfgr, model, recorded, status } = device
+  return {
+    provider_id,
+    device_id,
+    vehicle_id,
+    vehicle_type: type,
+    propulsion_types: propulsion,
+    year,
+    mfgr,
+    model,
+    recorded,
+    state: status ? STATE_TO_STATUS_MAPPING[status] : status
+  }
+}

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/index.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/index.ts
@@ -1,0 +1,2 @@
+export * from './vehicle_events'
+export * from './devices'

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -7,11 +7,19 @@ import {
 } from '../@types'
 import { VEHICLE_EVENT_v1_0_0, VEHICLE_STATE_v1_0_0, VehicleEvent_v1_0_0 } from '../@types/1_0_0'
 
+export class UnsupportedEventTypeError extends Error {
+  public constructor(public name: string, public reason?: string, public info?: unknown) {
+    super(reason)
+    Error.captureStackTrace(this, Error)
+  }
+}
+
+type INGESTABLE_VEHICLE_EVENT = Exclude<VEHICLE_EVENT_v0_4_1, 'register'>
 export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
   /* We don't actually accept/ingest events with the `register` event_type in 0.4.1 Agency, so
    * it's omitted here.
    */
-  [P in Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT]: {
+  [P in INGESTABLE_VEHICLE_EVENT | TRANSFORMER_VEHICLE_EVENT]: {
     [Q in VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON]: {
       event_type: VEHICLE_EVENT_v1_0_0
       vehicle_state: VEHICLE_STATE_v1_0_0
@@ -73,7 +81,7 @@ export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
 }
 
 function map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
-  event_type: Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT,
+  event_type: INGESTABLE_VEHICLE_EVENT | TRANSFORMER_VEHICLE_EVENT,
   event_type_reason: VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON | null | undefined
 ): { event_type: VEHICLE_EVENT_v1_0_0; vehicle_state: VEHICLE_STATE_v1_0_0 } {
   if (event_type_reason) {
@@ -96,6 +104,10 @@ export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_
     trip_id = null,
     recorded
   } = event
+
+  if (event_type === 'register') {
+    throw new UnsupportedEventTypeError(`Unexpected 'register' event_type for device_id ${device_id}`)
+  }
 
   const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
     event_type,

--- a/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/0_4_1_to_1_0_0/vehicle_events.ts
@@ -1,0 +1,117 @@
+import {
+  VEHICLE_REASON_v0_4_1,
+  VEHICLE_EVENT_v0_4_1,
+  TRANSFORMER_VEHICLE_EVENT,
+  TRANSFORMER_EVENT_TYPE_REASON,
+  VehicleEvent_v0_4_1
+} from '../@types'
+import { VEHICLE_EVENT_v1_0_0, VEHICLE_STATE_v1_0_0, VehicleEvent_v1_0_0 } from '../@types/1_0_0'
+
+export const FULL_STATE_MAPPING_v0_4_1_to_v1_0_0: {
+  /* We don't actually accept/ingest events with the `register` event_type in 0.4.1 Agency, so
+   * it's omitted here.
+   */
+  [P in Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT]: {
+    [Q in VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON]: {
+      event_type: VEHICLE_EVENT_v1_0_0
+      vehicle_state: VEHICLE_STATE_v1_0_0
+    }
+  }
+} = {
+  /* `agency_drop_off` included for the sake of completeness. No provider will ever submit such
+   * an event type through the agency API.
+   */
+  agency_drop_off: { no_event_type_reason: { event_type: 'agency_drop_off', vehicle_state: 'available' } },
+  agency_pick_up: { no_event_type_reason: { event_type: 'agency_pick_up', vehicle_state: 'removed' } },
+  cancel_reservation: { no_event_type_reason: { event_type: 'reservation_cancel', vehicle_state: 'available' } },
+  deregister: {
+    decommissioned: { event_type: 'decommissioned', vehicle_state: 'removed' },
+    missing: { event_type: 'missing', vehicle_state: 'removed' },
+    no_event_type_reason: { event_type: 'decommissioned', vehicle_state: 'removed' }
+  },
+  provider_pick_up: {
+    rebalance: { event_type: 'rebalance_pick_up', vehicle_state: 'removed' },
+    maintenance: { event_type: 'maintenance_pick_up', vehicle_state: 'removed' },
+    charge: { event_type: 'maintenance_pick_up', vehicle_state: 'removed' },
+    compliance: { event_type: 'compliance_pick_up', vehicle_state: 'removed' },
+    no_event_type_reason: { event_type: 'maintenance_pick_up', vehicle_state: 'removed' }
+  },
+  provider_drop_off: {
+    no_event_type_reason: { event_type: 'provider_drop_off', vehicle_state: 'available' }
+  },
+  reserve: {
+    no_event_type_reason: { event_type: 'reservation_start', vehicle_state: 'reserved' }
+  },
+  service_start: {
+    no_event_type_reason: { event_type: 'on_hours', vehicle_state: 'available' }
+  },
+  service_end: {
+    low_battery: { event_type: 'battery_low', vehicle_state: 'non_operational' },
+    maintenance: { event_type: 'maintenance', vehicle_state: 'non_operational' },
+    compliance: { event_type: 'compliance_pick_up', vehicle_state: 'non_operational' },
+    off_hours: { event_type: 'off_hours', vehicle_state: 'non_operational' },
+    no_event_type_reason: { event_type: 'maintenance', vehicle_state: 'non_operational' }
+  },
+  trip_end: {
+    no_event_type_reason: { event_type: 'trip_end', vehicle_state: 'available' }
+  },
+  trip_enter: {
+    no_event_type_reason: { event_type: 'trip_enter_jurisdiction', vehicle_state: 'on_trip' }
+  },
+  trip_leave: {
+    no_event_type_reason: { event_type: 'trip_leave_jurisdiction', vehicle_state: 'elsewhere' }
+  },
+  trip_start: {
+    no_event_type_reason: { event_type: 'trip_start', vehicle_state: 'on_trip' }
+  },
+  /* This event_type exists only to ensure backconversions and should not be present in any
+   * real events submitted via 0.4.1.
+   */
+  no_backconversion_available: {
+    no_event_type_reason: { event_type: 'unspecified', vehicle_state: 'unknown' }
+  }
+}
+
+function map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
+  event_type: Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT,
+  event_type_reason: VEHICLE_REASON_v0_4_1 | TRANSFORMER_EVENT_TYPE_REASON | null | undefined
+): { event_type: VEHICLE_EVENT_v1_0_0; vehicle_state: VEHICLE_STATE_v1_0_0 } {
+  if (event_type_reason) {
+    return FULL_STATE_MAPPING_v0_4_1_to_v1_0_0[event_type][event_type_reason]
+  }
+  return FULL_STATE_MAPPING_v0_4_1_to_v1_0_0[event_type].no_event_type_reason
+}
+
+export function convert_v0_4_1_vehicle_event_to_v1_0_0(event: VehicleEvent_v0_4_1): VehicleEvent_v1_0_0 {
+  const {
+    device_id,
+    provider_id,
+    timestamp,
+    timestamp_long = null,
+    delta = null,
+    event_type,
+    event_type_reason = null,
+    telemetry_timestamp = null,
+    telemetry = null,
+    trip_id = null,
+    recorded
+  } = event
+
+  const { event_type: new_event_type, vehicle_state } = map_v0_4_1_vehicle_event_fields_to_v1_0_0_fields(
+    event_type,
+    event_type_reason
+  )
+  return {
+    device_id,
+    provider_id,
+    timestamp,
+    timestamp_long,
+    delta,
+    vehicle_state,
+    event_types: [new_event_type],
+    telemetry_timestamp,
+    telemetry,
+    trip_id,
+    recorded
+  }
+}

--- a/packages/mds-types/transformers/1_0_0_to_0_4_1/devices.ts
+++ b/packages/mds-types/transformers/1_0_0_to_0_4_1/devices.ts
@@ -1,0 +1,38 @@
+import { VEHICLE_STATE_v1_0_0, Device_v1_0_0, Device_v0_4_1, VEHICLE_STATE_v0_4_1 } from '../@types'
+
+const STATE_TO_STATUS_MAPPING: { [P in VEHICLE_STATE_v1_0_0]: VEHICLE_STATE_v0_4_1 } = {
+  available: 'available',
+  elsewhere: 'elsewhere',
+  non_operational: 'unavailable',
+  on_trip: 'trip',
+  removed: 'removed',
+  reserved: 'reserved',
+  unknown: 'unavailable'
+}
+
+export function convert_v1_0_0_device_to_0_4_1(device: Device_v1_0_0): Device_v0_4_1 {
+  const {
+    provider_id,
+    device_id,
+    vehicle_id,
+    vehicle_type,
+    propulsion_types,
+    year,
+    mfgr,
+    model,
+    recorded,
+    state
+  } = device
+  return {
+    provider_id,
+    device_id,
+    vehicle_id,
+    type: vehicle_type,
+    propulsion: propulsion_types,
+    year,
+    mfgr,
+    model,
+    recorded,
+    status: state ? STATE_TO_STATUS_MAPPING[state] : state
+  }
+}

--- a/packages/mds-types/transformers/1_0_0_to_0_4_1/index.ts
+++ b/packages/mds-types/transformers/1_0_0_to_0_4_1/index.ts
@@ -1,0 +1,2 @@
+export * from './vehicle_events'
+export * from './devices'

--- a/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
+++ b/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
@@ -1,0 +1,127 @@
+import {
+  VEHICLE_REASON_v0_4_1,
+  VehicleEvent_v0_4_1,
+  VEHICLE_EVENT_v0_4_1,
+  TRANSFORMER_VEHICLE_EVENT,
+  VehicleEvent_v1_0_0,
+  VEHICLE_EVENT_v1_0_0
+} from '../@types'
+
+export const FULL_STATE_MAPPING_v1_0_0_to_v0_4_1: {
+  [P in VEHICLE_EVENT_v1_0_0]: {
+    event_type: Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT
+    event_type_reason?: VEHICLE_REASON_v0_4_1
+  }
+} = {
+  agency_drop_off: { event_type: 'agency_drop_off' },
+  agency_pick_up: { event_type: 'agency_pick_up' },
+  battery_low: { event_type: 'service_end', event_type_reason: 'low_battery' },
+  reservation_cancel: {
+    event_type: 'cancel_reservation'
+  },
+  decommissioned: {
+    event_type: 'deregister',
+    event_type_reason: 'decommissioned'
+  },
+  missing: {
+    event_type: 'deregister',
+    event_type_reason: 'missing'
+  },
+  provider_drop_off: {
+    event_type: 'provider_drop_off'
+  },
+  rebalance_pick_up: {
+    event_type: 'provider_pick_up',
+    event_type_reason: 'rebalance'
+  },
+  maintenance_pick_up: {
+    event_type: 'provider_pick_up',
+    event_type_reason: 'maintenance'
+  },
+  compliance_pick_up: {
+    event_type: 'provider_pick_up',
+    event_type_reason: 'compliance'
+  },
+  reservation_start: {
+    event_type: 'reserve'
+  },
+  on_hours: {
+    event_type: 'service_start'
+  },
+  maintenance: {
+    event_type: 'service_end',
+    event_type_reason: 'maintenance'
+  },
+  off_hours: {
+    event_type: 'service_end',
+    event_type_reason: 'off_hours'
+  },
+  trip_end: {
+    event_type: 'trip_end'
+  },
+  trip_enter_jurisdiction: {
+    event_type: 'trip_enter'
+  },
+  trip_leave_jurisdiction: {
+    event_type: 'trip_leave'
+  },
+  trip_start: {
+    event_type: 'trip_start'
+  },
+  battery_charged: {
+    event_type: 'service_start'
+  },
+  trip_cancel: {
+    event_type: 'no_backconversion_available'
+  },
+  comms_lost: {
+    event_type: 'no_backconversion_available'
+  },
+  comms_restored: {
+    event_type: 'no_backconversion_available'
+  },
+  located: {
+    event_type: 'no_backconversion_available'
+  },
+  system_resume: {
+    event_type: 'no_backconversion_available'
+  },
+  system_suspend: {
+    event_type: 'no_backconversion_available'
+  },
+  unspecified: {
+    event_type: 'no_backconversion_available'
+  }
+}
+
+function convert_v1_0_0_to_v0_4_1_helper(
+  event: VehicleEvent_v1_0_0,
+  current_event_type: VEHICLE_EVENT_v1_0_0
+): VehicleEvent_v0_4_1 {
+  const { event_type, event_type_reason } = FULL_STATE_MAPPING_v1_0_0_to_v0_4_1[current_event_type]
+
+  const telemetry = event.telemetry ? { ...event.telemetry } : null
+  if (telemetry && telemetry.stop_id) {
+    delete telemetry.stop_id
+  }
+  return {
+    device_id: event.device_id,
+    provider_id: event.provider_id,
+    timestamp: event.timestamp,
+    timestamp_long: event.timestamp_long,
+    delta: event.delta,
+    event_type,
+    event_type_reason,
+    telemetry_timestamp: event.telemetry_timestamp,
+    telemetry,
+    trip_id: event.trip_id,
+    service_area_id: null,
+    recorded: event.recorded
+  }
+}
+
+export function convert_v1_0_0_vehicle_event_to_v0_4_1(event: VehicleEvent_v1_0_0): VehicleEvent_v0_4_1[] {
+  return event.event_types.map(event_type => {
+    return convert_v1_0_0_to_v0_4_1_helper(event, event_type)
+  })
+}

--- a/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
+++ b/packages/mds-types/transformers/1_0_0_to_0_4_1/vehicle_events.ts
@@ -71,9 +71,6 @@ export const FULL_STATE_MAPPING_v1_0_0_to_v0_4_1: {
   battery_charged: {
     event_type: 'service_start'
   },
-  trip_cancel: {
-    event_type: 'no_backconversion_available'
-  },
   comms_lost: {
     event_type: 'no_backconversion_available'
   },
@@ -87,6 +84,9 @@ export const FULL_STATE_MAPPING_v1_0_0_to_v0_4_1: {
     event_type: 'no_backconversion_available'
   },
   system_suspend: {
+    event_type: 'no_backconversion_available'
+  },
+  trip_cancel: {
     event_type: 'no_backconversion_available'
   },
   unspecified: {

--- a/packages/mds-types/transformers/1_0_0_to_1_1_0/devices.ts
+++ b/packages/mds-types/transformers/1_0_0_to_1_1_0/devices.ts
@@ -1,0 +1,8 @@
+import { Device_v1_0_0 } from '../@types'
+import { Device_v1_1_0 } from '../../index'
+
+export const convert_v1_0_0_device_to_0_4_1 = (device: Device_v1_0_0): Device_v1_1_0 => ({
+  ...device,
+  accessibility_options: [],
+  modality: 'micro-mobility'
+})

--- a/packages/mds-types/transformers/1_0_0_to_1_1_0/index.ts
+++ b/packages/mds-types/transformers/1_0_0_to_1_1_0/index.ts
@@ -1,0 +1,2 @@
+export * from './vehicle_events'
+export * from './devices'

--- a/packages/mds-types/transformers/1_0_0_to_1_1_0/vehicle_events.ts
+++ b/packages/mds-types/transformers/1_0_0_to_1_1_0/vehicle_events.ts
@@ -1,0 +1,7 @@
+import { VehicleEvent_v1_1_0 } from '../../index'
+import { VehicleEvent_v1_0_0 } from '../@types'
+
+export const convert_v1_0_0_vehicle_event_to_v1_1_0 = (event: VehicleEvent_v1_0_0): VehicleEvent_v1_1_0 => ({
+  ...event,
+  trip_state: null
+})

--- a/packages/mds-types/transformers/@types/0_4_1.ts
+++ b/packages/mds-types/transformers/@types/0_4_1.ts
@@ -1,0 +1,102 @@
+/* This file contains the v0.4.1 versions of the VehicleEvent type and all related
+ * types. The main differences between v0.4.1 and v1.0.0 are:
+ *    1. Originally, a VehicleEvent could have only one `event_type`. Now, providers are
+ *  allowed to send multiple event_types in an array.
+ *    2. The field `event_type_reason` is deprecated in v1.0.0.
+ *    3. The number of valid event_types has been expanded, and many of them correspond to
+ *  former `event_type_reasons`.
+ */
+
+import { UUID, Timestamp, Telemetry, VEHICLE_TYPE, PROPULSION_TYPE } from '../../index'
+
+export const VEHICLE_REASONS_v0_4_1 = [
+  'battery_charged',
+  'charge',
+  'compliance',
+  'decommissioned',
+  'low_battery',
+  'maintenance',
+  'missing',
+  'off_hours',
+  'rebalance'
+]
+export type VEHICLE_REASON_v0_4_1 = typeof VEHICLE_REASONS_v0_4_1[number]
+
+export const VEHICLE_EVENTS_v0_4_1 = [
+  'register',
+  'service_start',
+  'service_end',
+  'provider_drop_off',
+  'provider_pick_up',
+  'agency_pick_up',
+  'agency_drop_off',
+  'reserve',
+  'cancel_reservation',
+  'trip_start',
+  'trip_enter',
+  'trip_leave',
+  'trip_end',
+  'deregister'
+] as const
+
+export type VEHICLE_EVENT_v0_4_1 = typeof VEHICLE_EVENTS_v0_4_1[number]
+
+export interface VehicleEvent_v0_4_1 {
+  device_id: UUID
+  provider_id: UUID
+  timestamp: Timestamp
+  timestamp_long?: string | null
+  delta?: Timestamp | null
+  event_type: Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT
+  event_type_reason?: VEHICLE_REASON_v0_4_1 | null | TRANSFORMER_EVENT_TYPE_REASON
+  telemetry_timestamp?: Timestamp | null
+  telemetry?: Telemetry | null
+  trip_id?: UUID | null
+  service_area_id?: UUID | null
+  recorded: Timestamp
+}
+
+export const VEHICLE_STATES_v0_4_1 = [
+  'available',
+  'elsewhere',
+  'inactive',
+  'trip',
+  'removed',
+  'reserved',
+  'unavailable'
+] as const
+export type VEHICLE_STATE_v0_4_1 = typeof VEHICLE_STATES_v0_4_1[number]
+
+// Old event-states transitions.
+export const EVENT_STATES_MAP_v0_4_1: { [P in VEHICLE_EVENT_v0_4_1]: VEHICLE_STATE_v0_4_1 } = {
+  register: 'removed',
+  service_start: 'available',
+  service_end: 'unavailable',
+  provider_drop_off: 'available',
+  provider_pick_up: 'removed',
+  agency_pick_up: 'removed',
+  agency_drop_off: 'available',
+  reserve: 'reserved',
+  cancel_reservation: 'available',
+  trip_start: 'trip',
+  trip_enter: 'trip',
+  trip_leave: 'elsewhere',
+  trip_end: 'available',
+  deregister: 'inactive'
+}
+
+export type TRANSFORMER_VEHICLE_EVENT = 'no_backconversion_available'
+export type TRANSFORMER_EVENT_TYPE_REASON = 'no_event_type_reason'
+
+export interface Device_v0_4_1 {
+  device_id: UUID
+  provider_id: UUID
+  vehicle_id: string
+  type: VEHICLE_TYPE
+  propulsion: PROPULSION_TYPE[]
+  year?: number | null
+  mfgr?: string | null
+  model?: string | null
+  recorded: Timestamp
+  status?: VEHICLE_STATE_v0_4_1 | null
+}

--- a/packages/mds-types/transformers/@types/0_4_1.ts
+++ b/packages/mds-types/transformers/@types/0_4_1.ts
@@ -47,7 +47,7 @@ export interface VehicleEvent_v0_4_1 {
   timestamp: Timestamp
   timestamp_long?: string | null
   delta?: Timestamp | null
-  event_type: Exclude<VEHICLE_EVENT_v0_4_1, 'register'> | TRANSFORMER_VEHICLE_EVENT
+  event_type: VEHICLE_EVENT_v0_4_1 | TRANSFORMER_VEHICLE_EVENT
   event_type_reason?: VEHICLE_REASON_v0_4_1 | null | TRANSFORMER_EVENT_TYPE_REASON
   telemetry_timestamp?: Timestamp | null
   telemetry?: Telemetry | null

--- a/packages/mds-types/transformers/@types/1_0_0.ts
+++ b/packages/mds-types/transformers/@types/1_0_0.ts
@@ -1,0 +1,69 @@
+import { PROPULSION_TYPE, Telemetry, Timestamp, UUID, VEHICLE_TYPE } from '../../index'
+
+export const VEHICLE_STATES_v1_0_0 = [
+  'available',
+  'elsewhere',
+  'non_operational',
+  'on_trip',
+  'removed',
+  'reserved',
+  'unknown'
+] as const
+export type VEHICLE_STATE_v1_0_0 = typeof VEHICLE_STATES_v1_0_0[number]
+
+export const VEHICLE_EVENTS_v1_0_0 = [
+  'agency_drop_off',
+  'agency_pick_up',
+  'battery_charged',
+  'battery_low',
+  'comms_lost',
+  'comms_restored',
+  'compliance_pick_up',
+  'decommissioned',
+  'located',
+  'maintenance',
+  'maintenance_pick_up',
+  'missing',
+  'off_hours',
+  'on_hours',
+  'provider_drop_off',
+  'rebalance_pick_up',
+  'reservation_cancel',
+  'reservation_start',
+  'system_resume',
+  'system_suspend',
+  'trip_cancel',
+  'trip_end',
+  'trip_enter_jurisdiction',
+  'trip_leave_jurisdiction',
+  'trip_start',
+  'unspecified'
+] as const
+export type VEHICLE_EVENT_v1_0_0 = typeof VEHICLE_EVENTS_v1_0_0[number]
+
+export interface VehicleEvent_v1_0_0 {
+  device_id: UUID
+  provider_id: UUID
+  timestamp: Timestamp
+  timestamp_long?: string | null
+  delta?: Timestamp | null
+  event_types: VEHICLE_EVENT_v1_0_0[]
+  telemetry_timestamp?: Timestamp | null
+  telemetry?: Telemetry | null
+  trip_id?: UUID | null
+  vehicle_state: VEHICLE_STATE_v1_0_0
+  recorded: Timestamp
+}
+
+export interface Device_v1_0_0 {
+  device_id: UUID
+  provider_id: UUID
+  vehicle_id: string
+  vehicle_type: VEHICLE_TYPE // changed name in 1.0
+  propulsion_types: PROPULSION_TYPE[] // changed name in 1.0
+  year?: number | null
+  mfgr?: string | null
+  model?: string | null
+  recorded: Timestamp
+  state?: VEHICLE_STATE_v1_0_0 | null
+}

--- a/packages/mds-types/transformers/@types/index.ts
+++ b/packages/mds-types/transformers/@types/index.ts
@@ -1,0 +1,2 @@
+export * from './0_4_1'
+export * from './1_0_0'

--- a/packages/mds-types/transformers/index.ts
+++ b/packages/mds-types/transformers/index.ts
@@ -1,0 +1,2 @@
+export * from './0_4_1_to_1_0_0'
+export * from './1_0_0_to_0_4_1'

--- a/packages/mds-utils/state-machine.ts
+++ b/packages/mds-utils/state-machine.ts
@@ -89,7 +89,8 @@ const microMobilityStateTransitionDict: {
     comms_restored: ['available', 'elsewhere', 'removed', 'reserved', 'on_trip', 'non_operational'],
     decommissioned: ['removed'],
     provider_drop_off: ['available'],
-    unspecified: ['available', 'elsewhere', 'removed', 'reserved', 'on_trip', 'non_operational']
+    unspecified: ['available', 'removed'],
+    located: ['available', 'elsewhere', 'reserved', 'on_trip', 'non_operational']
   }
 }
 


### PR DESCRIPTION
## 📚 Purpose
Makes it so we can build on the 1.0.0 transformers changes by making taxi a followup version. Need to add transformers for 1.0.0 -> 1.1.0 (and the reverse).

## 📦 Impacts:
mds-types
all-the-things

## ✅ PR Checklist
- [x] Add transformers
- [ ] Pick a better version number than 1.1 for Taxi... 2.0 maybe? In a weird place because there's no expected version for Taxi to land in.