### PR TITLE
AUDIT-64 Use device information from database

### DIFF
--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -188,7 +188,7 @@ export async function getVehicle(provider_id: UUID, vehicle_id: string) {
       } else {
         const status = EVENT_STATUS_MAP[deviceStatus.event_type as VEHICLE_EVENT]
         const updated = deviceStatus.timestamp
-        deviceStatusMap.active.push({ ...device, ...deviceStatus, status, updated })
+        deviceStatusMap.active.push({ ...deviceStatus, ...device, status, updated })
       }
     })
   )

--- a/packages/mds-audit/service.ts
+++ b/packages/mds-audit/service.ts
@@ -188,6 +188,11 @@ export async function getVehicle(provider_id: UUID, vehicle_id: string) {
       } else {
         const status = EVENT_STATUS_MAP[deviceStatus.event_type as VEHICLE_EVENT]
         const updated = deviceStatus.timestamp
+        // FIXME: There are currently some scenarios in which in the latest device information
+        // isn't properly reflected in the device cache. As a result, we overwrite these values
+        // using the device information from the database. If these scenarios can be resolved then
+        // using just the cached values would be the preferred approach as the cache should always
+        // reflect the most up to date information.
         deviceStatusMap.active.push({ ...deviceStatus, ...device, status, updated })
       }
     })


### PR DESCRIPTION
## 📚 Purpose
There are scenarios where the device information (specifically the vehicle_id) in the cache gets out of sync with the information in the database. This seems to happen on occasion when a provider updates a device's vehicle_id. There is a separate effort to diagnose that issue, but in the meantime, this fix will always use device information from the database which we know to be accurate.

## 👌 Resolves:
- [x] 🐛 AUDIT-64 Searching for vehicles with updated vehicle_ids returns the correct vehicle but with the old vehicle_id

## 📦 Impacts:
- [x] mds-audit