### PR TITLE
Fix events validator

### DIFF
--- a/packages/mds-schema-validators/package.json
+++ b/packages/mds-schema-validators/package.json
@@ -13,6 +13,7 @@
     "@mds-core/mds-providers": "0.1.26",
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
+    "@mds-core/mds-test-data": "0.1.26",
     "joi": "17.2.1",
     "joi-to-json": "1.2.0"
   },

--- a/packages/mds-schema-validators/tsconfig.build.json
+++ b/packages/mds-schema-validators/tsconfig.build.json
@@ -6,6 +6,7 @@
   "references": [
     { "path": "../../packages/mds-providers/tsconfig.build.json" },
     { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
     { "path": "../../packages/mds-utils/tsconfig.build.json" }
   ]
 }

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -147,8 +147,6 @@ export const geographySchema = Joi.object().keys({
 
 const geographiesSchema = Joi.array().items(geographySchema)
 
-const eventsSchema = Joi.array().items()
-
 const vehicleEventTypeSchema = stringSchema.valid(...VEHICLE_EVENTS)
 
 const vehicleTypeSchema = stringSchema.valid(...Object.keys(VEHICLE_TYPES))
@@ -161,12 +159,17 @@ const eventSchema = Joi.object().keys({
   device_id: uuidSchema.required(),
   provider_id: uuidSchema.required(),
   timestamp: timestampSchema.required(),
-  event_type: vehicleEventTypeSchema.required(),
+  timestamp_long: stringSchema.optional(),
+  delta: timestampSchema.optional(),
+  event_types: Joi.array().items(vehicleEventTypeSchema.required()),
   telemetry_timestamp: timestampSchema.optional(),
-  telemetry: telemetrySchema.required(),
-  service_area_id: uuidSchema.allow(null).optional(),
+  telemetry: telemetrySchema.allow(null).optional(),
+  trip_id: uuidSchema.allow(null).optional(),
+  vehicle_state: vehicleStatusSchema.allow(null).optional(),
   recorded: timestampSchema.optional()
 })
+
+const eventsSchema = Joi.array().items(eventSchema)
 
 const tripEventSchema = eventSchema.keys({
   trip_id: uuidSchema.required()


### PR DESCRIPTION
## 📚 Purpose
While overhauling the compliance code, which uses the event validators, I noticed a couple problems:
1. `validateEvents` actually just validates whether the parameter is an array, as opposed to `VehicleEvent[]`.
2. The `eventSchema` was never updated. This is definitely my mistake. I think I had assumed there was a test exercising the `eventSchema`, but it turns out, there wasn't one. I also added tests.



## 📦 Impacts:
* mds-schema-validators

## ✅ PR Checklist
- [ ] Add or remove checklist items to suit your needs