### PR TITLE
Allow a stream consumer to subscribe to multiple topics

### DIFF
--- a/packages/mds-stream/nats/helpers.ts
+++ b/packages/mds-stream/nats/helpers.ts
@@ -1,6 +1,7 @@
 import { connect, MsgCallback, SubscriptionOptions, Client } from 'ts-nats'
 import logger from '@mds-core/mds-logger'
-import { getEnvVar } from '@mds-core/mds-utils'
+import { getEnvVar, asArray } from '@mds-core/mds-utils'
+import { SingleOrArray } from '@mds-core/mds-types'
 
 const initializeNatsClient = () => {
   const { NATS } = getEnvVar({ NATS: 'localhost' })
@@ -13,18 +14,16 @@ const initializeNatsClient = () => {
 }
 
 export const createStreamConsumer = async (
-  topic: string,
+  topics: SingleOrArray<string>,
   processor: MsgCallback,
   options: SubscriptionOptions = {}
 ) => {
   const natsClient = await initializeNatsClient()
-
   try {
-    await natsClient.subscribe(topic, processor, options)
+    await Promise.all(asArray(topics).map(topic => natsClient.subscribe(topic, processor, options)))
   } catch (err) {
     logger.error(err)
   }
-
   return natsClient
 }
 

--- a/packages/mds-stream/nats/stream-consumer.ts
+++ b/packages/mds-stream/nats/stream-consumer.ts
@@ -1,10 +1,10 @@
 import { SubscriptionOptions, Client, MsgCallback } from 'ts-nats'
-import { Nullable } from '@mds-core/mds-types'
+import { Nullable, SingleOrArray } from '@mds-core/mds-types'
 import { createStreamConsumer, disconnectClient } from './helpers'
 import { StreamConsumer } from '../stream-interface'
 
 export const NatsStreamConsumer = (
-  topic: string,
+  topics: SingleOrArray<string>,
   eachMessage: MsgCallback,
   options?: Partial<SubscriptionOptions>
 ): StreamConsumer => {
@@ -12,7 +12,7 @@ export const NatsStreamConsumer = (
   return {
     initialize: async () => {
       if (!consumer) {
-        consumer = await createStreamConsumer(topic, eachMessage, options)
+        consumer = await createStreamConsumer(topics, eachMessage, options)
       }
     },
     shutdown: async () => {


### PR DESCRIPTION
## 📚 Purpose
This allows a single process/consumer to subscribe to multiple topics rather than requiring a separate process per topic.