### PR TITLE
Add beforeAll/initialize; afterAll/shutdown to repository tests

### DIFF
--- a/packages/mds-attachment-service/tests/index.spec.ts
+++ b/packages/mds-attachment-service/tests/index.spec.ts
@@ -2,13 +2,21 @@ import { AttachmentServiceManager } from '../service/manager'
 import { AttachmentServiceClient } from '../client'
 import { AttachmentRepository } from '../repository'
 
-describe('Test Migrations', () => {
+describe('Attachment Repository Tests', () => {
+  beforeAll(async () => {
+    await AttachmentRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await AttachmentRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await AttachmentRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await AttachmentRepository.shutdown()
   })
 })
 

--- a/packages/mds-audit-service/tests/index.spec.ts
+++ b/packages/mds-audit-service/tests/index.spec.ts
@@ -2,13 +2,21 @@ import { AuditServiceManager } from '../service/manager'
 import { AuditServiceClient } from '../client'
 import { AuditRepository } from '../repository'
 
-describe('Test Migrations', () => {
+describe('Audit Repository Tests', () => {
+  beforeAll(async () => {
+    await AuditRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await AuditRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await AuditRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await AuditRepository.shutdown()
   })
 })
 

--- a/packages/mds-geography-service/tests/index.spec.ts
+++ b/packages/mds-geography-service/tests/index.spec.ts
@@ -2,13 +2,21 @@ import { GeographyServiceManager } from '../service/manager'
 import { GeographyServiceClient } from '../client'
 import { GeographyRepository } from '../repository'
 
-describe('Test Migrations', () => {
+describe('Geography Repository Tests', () => {
+  beforeAll(async () => {
+    await GeographyRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await GeographyRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await GeographyRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await GeographyRepository.shutdown()
   })
 })
 

--- a/packages/mds-ingest-service/tests/index.spec.ts
+++ b/packages/mds-ingest-service/tests/index.spec.ts
@@ -2,13 +2,21 @@ import { IngestServiceManager } from '../service/manager'
 import { IngestServiceClient } from '../client'
 import { IngestRepository } from '../repository'
 
-describe('Test Migrations', () => {
+describe('Ingest Repository Tests', () => {
+  beforeAll(async () => {
+    await IngestRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await IngestRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await IngestRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await IngestRepository.shutdown()
   })
 })
 

--- a/packages/mds-jurisdiction-service/tests/index.spec.ts
+++ b/packages/mds-jurisdiction-service/tests/index.spec.ts
@@ -29,13 +29,21 @@ const LAST_WEEK = TODAY - days(7)
 
 const JurisdictionServer = JurisdictionServiceManager.controller()
 
-describe('Test Migrations', () => {
+describe('Jurisdiction Repository Tests', () => {
+  beforeAll(async () => {
+    await JurisdictionRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await JurisdictionRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await JurisdictionRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await JurisdictionRepository.shutdown()
   })
 })
 

--- a/packages/mds-policy-service/tests/index.spec.ts
+++ b/packages/mds-policy-service/tests/index.spec.ts
@@ -2,13 +2,21 @@ import { PolicyServiceManager } from '../service/manager'
 import { PolicyServiceClient } from '../client'
 import { PolicyRepository } from '../repository'
 
-describe('Test Migrations', () => {
+describe('Policy Repository Tests', () => {
+  beforeAll(async () => {
+    await PolicyRepository.initialize()
+  })
+
   it('Run Migrations', async () => {
     await PolicyRepository.runAllMigrations()
   })
 
   it('Revert Migrations', async () => {
     await PolicyRepository.revertAllMigrations()
+  })
+
+  afterAll(async () => {
+    await PolicyRepository.shutdown()
   })
 })
 


### PR DESCRIPTION
## 📚 Purpose
Initialize/shutdown repositories so tests are independent (i.e. `describe.only` does not hang)