### PR TITLE
Drop schema before running unit tests

### DIFF
--- a/packages/mds-attachment-service/package.json
+++ b/packages/mds-attachment-service/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-audit-service/package.json
+++ b/packages/mds-audit-service/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-geography-service/package.json
+++ b/packages/mds-geography-service/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-ingest-service/package.json
+++ b/packages/mds-ingest-service/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-jurisdiction-service/package.json
+++ b/packages/mds-jurisdiction-service/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-policy-service/package.json
+++ b/packages/mds-policy-service/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "pretest:unit": "yarn typeorm schema:drop",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",


### PR DESCRIPTION
## 📚 Purpose
Drop schema before unit tests to prevent failure on multiple test runs (for example, revert migrations with existing data).