### PR TITLE
adds zremrangebyscore to mds-cache

### DIFF
--- a/packages/mds-cache/redis/index.ts
+++ b/packages/mds-cache/redis/index.ts
@@ -110,6 +110,9 @@ export const RedisCache = () => {
     zrangebyscore: async (key: KeyType, min: string | number, max: string | number) =>
       safelyExec(theClient => theClient.zrangebyscore(key, min, max)),
 
+    zremrangebyscore: async (key: KeyType, min: string | number, max: string | number) =>
+      safelyExec(theClient => theClient.zremrangebyscore(key, min, max)),
+
     geoadd: async (key: KeyType, longitude: number, latitude: number, member: KeyType) =>
       safelyExec(theClient => theClient.geoadd(key, longitude, latitude, member)),
 

--- a/packages/mds-cache/tests/redis.spec.ts
+++ b/packages/mds-cache/tests/redis.spec.ts
@@ -114,6 +114,11 @@ describe('Redis Tests', () => {
       await expect(redis.zrangebyscore('foo', 0, 2)).resolves.toEqual(['bar', 'baz'])
     })
 
+    it('zremrangebyscore()', async () => {
+      await redis.zadd('foo', { bar: 1, baz: 2 })
+      await expect(redis.zremrangebyscore('foo', 0, 2)).resolves.toEqual(2)
+    })
+
     it('multihgetall()', async () => {
       await redis.hset('foo', 'bar', 'baz')
       await redis.hset('foo', 'qux', 'quux')


### PR DESCRIPTION
## 📚 Purpose
*[allow you to delete a range of items by score from a sorted set]*

Humans: Sorted sets have a score, we’re using “time” to sort items. This lets you “remove all items between (begining-of-time) and 8-hours ago”

## 📦 Impacts:
- [ ] mds-core

## ✅ PR Checklist
- [ ] publish artifacts when done