### PR TITLE
Update policy and rule validation schemas to allow rate properties

### DIFF
--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -107,7 +107,8 @@ const ruleSchema = Joi.object().keys({
   end_time: Joi.string(),
   days: Joi.array().items(Joi.string().valid(...Object.values(DAYS_OF_WEEK))),
   messages: Joi.object(),
-  value_url: Joi.string().uri()
+  value_url: Joi.string().uri(),
+  rate_amount: Joi.number()
 })
 
 export const policySchema = Joi.object().keys({
@@ -118,7 +119,9 @@ export const policySchema = Joi.object().keys({
   end_date: Joi.date().timestamp('javascript').allow(null),
   prev_policies: Joi.array().items(Joi.string().guid()).allow(null),
   provider_ids: Joi.array().items(Joi.string().guid()).allow(null),
-  rules: Joi.array().min(1).items(ruleSchema).required()
+  rules: Joi.array().min(1).items(ruleSchema).required(),
+  rate_recurrence: Joi.string().valid('once', 'each_time_unit', 'per_complete_time_unit'),
+  currency: Joi.string()
 })
 
 const policiesSchema = Joi.array().items(policySchema)

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -31,7 +31,8 @@ import {
   Telemetry,
   PROPULSION_TYPES,
   VEHICLE_STATUSES,
-  Device
+  Device,
+  RATE_RECURRENCE_VALUES
 } from '@mds-core/mds-types'
 import * as Joi from 'joi'
 import joiToJson from 'joi-to-json'
@@ -120,7 +121,7 @@ export const policySchema = Joi.object().keys({
   prev_policies: Joi.array().items(Joi.string().guid()).allow(null),
   provider_ids: Joi.array().items(Joi.string().guid()).allow(null),
   rules: Joi.array().min(1).items(ruleSchema).required(),
-  rate_recurrence: Joi.string().valid('once', 'each_time_unit', 'per_complete_time_unit'),
+  rate_recurrence: Joi.string().valid(...RATE_RECURRENCE_VALUES),
   currency: Joi.string()
 })
 

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -317,6 +317,9 @@ export interface Policy extends BasePolicy {
   rules: Rule[]
 }
 
+export const RATE_RECURRENCE_VALUES = ['once', 'each_time_unit', 'per_complete_time_unit'] as const
+export type RATE_RECURRENCE = typeof RATE_RECURRENCE_VALUES[number]
+
 /**
  * A RateRule is a rule of any type that has a `rate_amount` property.
  * @alpha Out-of-spec for MDS 0.4.1
@@ -328,7 +331,7 @@ export type RateRule = Rule & { rate_amount: number }
  * @alpha Out-of-spec for MDS 0.4.1
  */
 export interface RatePolicy extends BasePolicy {
-  rate_recurrence: 'once' | 'each_time_unit' | 'per_complete_time_unit'
+  rate_recurrence: RATE_RECURRENCE
   currency: string
   rules: RateRule[]
 }


### PR DESCRIPTION
PR #476 updated the policy and rule typedefs to allow for rates to be applied to any type of rule. This PR completes that work by updating the policy and rule validation schemas accordingly.