### PR TITLE
Fix/redis istio connect bug

### DIFF
--- a/packages/mds-cache/redis/helpers/client.ts
+++ b/packages/mds-cache/redis/helpers/client.ts
@@ -1,5 +1,6 @@
 import Redis from 'ioredis'
 import { cleanEnv, host, num } from 'envalid'
+import logger from '@mds-core/mds-logger'
 
 const { REDIS_PORT, REDIS_HOST, REDIS_PASS } = cleanEnv(process.env, {
   REDIS_PORT: num({ default: 6379 }),
@@ -7,9 +8,24 @@ const { REDIS_PORT, REDIS_HOST, REDIS_PASS } = cleanEnv(process.env, {
 })
 
 export const initClient = async () => {
-  const client = new Redis({ lazyConnect: true, port: REDIS_PORT, host: REDIS_HOST, password: REDIS_PASS })
-
-  await client.connect()
-
+  const client = new Redis({
+    lazyConnect: true,
+    maxRetriesPerRequest: 1000, // 20 is default, but that may not be long enough
+    port: REDIS_PORT,
+    host: REDIS_HOST,
+    password: REDIS_PASS
+  })
+  client.on('connect', () => {
+    logger.warn('connected, yay')
+  })
+  try {
+    // try to connect; if fails initially, that's okay; we don't want to throw,
+    // we want it to keep using its retry mechanism
+    await client.connect()
+  } catch (err) {
+    // suppress initial connection failure
+    logger.error('failed initial connect to redis, will keep trying')
+    // log and keep going
+  }
   return client
 }


### PR DESCRIPTION
## 📚 Purpose
New redis cache was failing on initial connection, and that exception was causing the whole service initialization to fail

## 👌 Resolves:
N/A (just found it, haven't ticketed it)

## 📦 Impacts:
everything that uses mds-cache

## ✅ PR Checklist
N/A