### PR TITLE
Remove remaining mds-db migration code

### DIFF
--- a/packages/mds-db/client.ts
+++ b/packages/mds-db/client.ts
@@ -1,6 +1,4 @@
 import logger from '@mds-core/mds-logger'
-import { csv } from '@mds-core/mds-utils'
-import schema from './schema'
 
 import { logSql, configureClient, MDSPostgresClient, SqlVals } from './sql-utils'
 
@@ -10,17 +8,7 @@ let writeableCachedClient: MDSPostgresClient | null = null
 let readOnlyCachedClient: MDSPostgresClient | null = null
 
 async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
-  const {
-    PG_HOST,
-    PG_HOST_READER,
-    PG_MIGRATIONS = 'false',
-    PG_NAME,
-    PG_PASS,
-    PG_PASS_READER,
-    PG_PORT,
-    PG_USER,
-    PG_USER_READER
-  } = env
+  const { PG_HOST, PG_HOST_READER, PG_NAME, PG_PASS, PG_PASS_READER, PG_PORT, PG_USER, PG_USER_READER } = env
 
   const info = {
     client_type: useWriteable ? 'writeable' : 'readonly',
@@ -36,12 +24,6 @@ async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
 
   try {
     await client.connect()
-    if (useWriteable) {
-      if (PG_MIGRATIONS === 'true') {
-        // Drop deprecated tables
-        await client.query(`DROP TABLE IF EXISTS ${csv(schema.DEPRECATED_TABLES)};`)
-      }
-    }
     client.setConnected(true)
     return client
   } catch (err) {

--- a/packages/mds-db/schema.ts
+++ b/packages/mds-db/schema.ts
@@ -16,7 +16,6 @@ const TABLE = Enum(
 export type TABLE_NAME = keyof typeof TABLE
 
 const TABLES = Object.keys(TABLE) as TABLE_NAME[]
-const DEPRECATED_TABLES = ['migrations', 'status_changes', 'stops', 'trips']
 
 const COLUMN = Enum(
   'accuracy',
@@ -173,7 +172,6 @@ const TABLE_COLUMNS: { [T in TABLE_NAME]: Readonly<COLUMN_NAME[]> } = {
 export default {
   COLUMN,
   COLUMNS,
-  DEPRECATED_TABLES,
   TABLE,
   TABLES,
   TABLE_COLUMNS


### PR DESCRIPTION
## 📚 Purpose
Remove the final vestiges of `mds-db`'s usage of `PG_MIGRATIONS` for legacy side-effect style migrations. All migrations are now managed at startup by the new service pods.

## 📦 Impacts:
- [x] mds-db