### PR TITLE
[mds-service-helpers] Add isError helper

### DIFF
--- a/packages/mds-service-helpers/client/index.ts
+++ b/packages/mds-service-helpers/client/index.ts
@@ -26,6 +26,10 @@ export const isServiceError = <E extends string = ServiceErrorDescriptorType>(
   (error as ServiceErrorDescriptor<E>).isServiceError === true &&
   (types.length === 0 || types.includes((error as ServiceErrorDescriptor<E>).type))
 
+/** Will match an error if it's thrown locally, or from a service */
+export const isError = <E extends Error>(error: unknown, type: new () => E) =>
+  error instanceof type || isServiceError(error, type.name)
+
 // eslint-reason type inference requires any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ServiceResponseMethod<R = any> = AnyFunction<Promise<ServiceResponse<R>>>

--- a/packages/mds-service-helpers/tests/index.spec.ts
+++ b/packages/mds-service-helpers/tests/index.spec.ts
@@ -15,8 +15,9 @@
  */
 
 import test from 'unit.js'
+import { ValidationError } from '@mds-core/mds-utils'
 import { ServiceResult, ServiceError, ServiceException, isServiceError, ProcessManager } from '../index'
-import { UnwrapServiceResult } from '../client'
+import { isError, UnwrapServiceResult } from '../client'
 
 describe('Tests Service Helpers', () => {
   it('ServiceResult', async () => {
@@ -73,6 +74,13 @@ describe('Tests Service Helpers', () => {
   it('Custom ServiceError type', async () => {
     const { error } = ServiceError({ type: 'CustomError', message: 'Custom Error Message' })
     test.value(isServiceError(error, 'CustomError')).is(true)
+  })
+
+  it('Tests isError', () => {
+    const { error } = ServiceError({ type: 'ValidationError', message: 'Validation Error' })
+    test.value(isError(error, ValidationError))
+
+    test.value(isError(new ValidationError(), ValidationError))
   })
 
   it('ServiceError type guard', async () => {


### PR DESCRIPTION
## 📚 Purpose
Adds isError helper, for all your error handling needs.

## 📦 Impacts:
- [x] mds-service-helpers