### PR TITLE
[mds-service-helpers] Add SerializedBuffers to ServiceProvider inputs, and ServiceClient outputs.

### DIFF
--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -20,8 +20,7 @@ export const ServiceErrorDescriptorTypes = [
   'ServiceException',
   'NotFoundError',
   'ConflictError',
-  'ValidationError',
-  'UnsupportedTypeError'
+  'ValidationError'
 ] as const
 
 export type ServiceErrorDescriptorType = typeof ServiceErrorDescriptorTypes[number]

--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -49,10 +49,10 @@ export interface ServiceResultType<R> {
  * @example ```typescript
             type Foo = { x: string; y: { z: Buffer } }
 
-            type DeserializedFoo = DeserializeBuffers<Foo>
+            type SerializedFoo = SerializedBuffers<Foo>
 
             const example: Foo = { x: 'hi', y: { z: Buffer.from([1, 2, 3]) } }
-            const exampleDeserialized: DeserializedFoo = { x: 'hi', y: { z: { type: 'Buffer', data: [1, 2, 3] } } }
+            const exampleSerialized: SerializedFoo = { x: 'hi', y: { z: { type: 'Buffer', data: [1, 2, 3] } } }
             ```
  */
 export type SerializedBuffers<T> = {

--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -45,6 +45,9 @@ export interface ServiceResultType<R> {
  * Over-the-wire, Javascript Buffers are serialized into JSON, but then not converted back into Javascript Buffers when deserializing.
  * This helper type aims to mitigate type differences that could arise between a ServiceClient and ServiceProvider.
  *
+ * Note: Prettier doesn't like parens around nested ternaries in typedefs. This is a two-level-deep ternary, where the outer ternary
+ * is checking if we've bottomed out (important for recursive typing), and the second ternary is where the main logic for the type lives.
+ *
  * @example ```typescript
             type Foo = { x: string; y: { z: Buffer } }
 

--- a/packages/mds-service-helpers/@types/index.ts
+++ b/packages/mds-service-helpers/@types/index.ts
@@ -20,7 +20,8 @@ export const ServiceErrorDescriptorTypes = [
   'ServiceException',
   'NotFoundError',
   'ConflictError',
-  'ValidationError'
+  'ValidationError',
+  'UnsupportedTypeError'
 ] as const
 
 export type ServiceErrorDescriptorType = typeof ServiceErrorDescriptorTypes[number]
@@ -41,17 +42,40 @@ export interface ServiceResultType<R> {
   result: R
 }
 
+/**
+ * Over-the-wire, Javascript Buffers are serialized into JSON, but then not converted back into Javascript Buffers when deserializing.
+ * This helper type aims to mitigate type differences that could arise between a ServiceClient and ServiceProvider.
+ *
+ * @example ```typescript
+            type Foo = { x: string; y: { z: Buffer } }
+
+            type DeserializedFoo = DeserializeBuffers<Foo>
+
+            const example: Foo = { x: 'hi', y: { z: Buffer.from([1, 2, 3]) } }
+            const exampleDeserialized: DeserializedFoo = { x: 'hi', y: { z: { type: 'Buffer', data: [1, 2, 3] } } }
+            ```
+ */
+export type SerializedBuffers<T> = {
+  [K in keyof T]: T[K] extends never
+    ? never
+    : T[K] extends Buffer
+    ? ReturnType<Buffer['toJSON']>
+    : SerializedBuffers<T[K]>
+}
+
 export type ServiceResponse<R> = ServiceErrorType | ServiceResultType<R>
 
 export type ServiceClient<S> = {
-  [M in keyof S]: S[M] extends AnyFunction<infer R> ? (...args: Parameters<S[M]>) => Promise<R> : never
+  [M in keyof S]: S[M] extends AnyFunction<infer R>
+    ? (...args: Parameters<S[M]>) => Promise<SerializedBuffers<R>>
+    : never
 }
 
 export type ServiceProvider<S> = {
   [M in keyof S]: S[M] extends (...args: infer P) => infer R
     ? (
         ...args: {
-          [K in keyof P]: undefined extends P[K] ? Nullable<P[K]> : P[K]
+          [K in keyof P]: undefined extends P[K] ? Nullable<SerializedBuffers<P[K]>> : SerializedBuffers<P[K]>
         }
       ) => Promise<ServiceResponse<R>>
     : never


### PR DESCRIPTION
## 📚 Purpose
This PR adds a new SerializedBuffers type, which will take any input type, and recursively traverse the type to transform any `Buffer` types to the serialized version, `ReturnType<Buffer['toJSON']>`. I found while decoupling attachments logic from mds-audit, that when receiving a Buffer in RPC-TS, it is the JSON serialized version, as opposed to a proper JS Buffer. This aims to allow ServiceDefinitions to be passed in with the proper, deserialized types, while retaining the serialized nature of buffers when receiving them as either the client or the provider, so they can then be properly parsed.

Example:
```typescript
type Foo = { x: string; y: { z: Buffer } }

type SerializedFoo = SerializedBuffers<Foo>

const example: Foo = { x: 'hi', y: { z: Buffer.from([1, 2, 3]) } }
const exampleSerialized: SerializedFoo = { x: 'hi', y: { z: { type: 'Buffer', data: [1, 2, 3] } } }
```
## 📦 Impacts:
- mds-service-helpers