### PR TITLE
Add bulldozer.yml

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -1,0 +1,98 @@
+# "version" is the configuration version, currently "1".
+version: 1
+
+# "merge" defines how and when pull requests are merged. If the section is
+# missing, bulldozer will consider all pull requests and use default settings.
+merge:
+  # "trigger" defines the set of pull requests considered by bulldozer. If
+  # the section is missing, bulldozer considers all pull requests not excluded
+  # by the ignore conditions.
+  trigger:
+    # Pull requests with any of these labels (case-insensitive) are added to
+    # the trigger.
+    labels: ["merge when ready", "bulldozer-merge"]
+
+    # Pull requests where the body or any comment contains any of these
+    # substrings are added to the trigger.
+    comment_substrings: ["==MERGE_WHEN_READY==", "merge when ready"]
+
+    # Pull requests where any comment matches one of these exact strings are
+    # added to the trigger.
+    comments:
+      [
+        "Please merge this pull request!",
+        "Mr. Bulldozer, please merge",
+        "@bulldozer merge",
+        "ready to merge",
+      ]
+
+    # Pull requests where the body contains any of these substrings are added
+    # to the trigger.
+    pr_body_substrings: ["==MERGE_WHEN_READY=="]
+
+    # Pull requests targeting branches matching any of these regular expressions are added to the trigger.
+    # branch_patterns: ["feature/.*"]
+
+  # "ignore" defines the set of pull request ignored by bulldozer. If the
+  # section is missing, bulldozer considers all pull requests. It takes the
+  # same keys as the "trigger" section.
+  ignore:
+    labels: ["do not merge"]
+    comment_substrings: ["==DO_NOT_MERGE=="]
+
+  # "method" defines the merge method. The available options are "merge",
+  # "rebase", "squash", and "ff-only".
+  method: squash
+
+  # Allows the merge method that is used when auto-merging a PR to be different based on the
+  # target branch. The keys of the hash are the target branch name, and the values are the merge method that
+  # will be used for PRs targeting that branch. The valid values are the same as for the "method" key.
+  # Note: If the target branch does not match any of the specified keys, the "method" key is used instead.
+  branch_method:
+    develop: squash
+    master: merge
+
+  # "options" defines additional options for the individual merge methods.
+  options:
+    # "squash" options are only used when the merge method is "squash"
+    squash:
+      # "title" defines how the title of the commit message is created when
+      # generating a squash commit. The options are "pull_request_title",
+      # "first_commit_title", and "github_default_title". The default is
+      # "pull_request_title".
+      title: "pull_request_title"
+
+      # "body" defines how the body of the commit message is created when
+      # generating a squash commit. The options are "pull_request_body",
+      # "summarize_commits", and "empty_body". The default is "empty_body".
+      body: "empty_body"
+
+      # If "body" is "pull_request_body", then the commit message will be the
+      # part of the pull request body surrounded by "message_delimiter"
+      # strings. This is disabled (empty string) by default.
+      message_delimiter: ==COMMIT_MSG==
+
+  # "required_statuses" is a list of additional status contexts that must pass
+  # before bulldozer can merge a pull request. This is useful if you want to
+  # require extra testing for automated merges, but not for manual merges.
+  required_statuses:
+    - "continuous-integration/jenkins/pr-head"
+
+  # If true, bulldozer will delete branches after their pull requests merge.
+  delete_after_merge: true
+
+# "update" defines how and when to update pull request branches. Unlike with
+# merges, if this section is missing, bulldozer will not update any pull requests.
+update:
+  # "trigger" defines the set of pull requests that should be updated by
+  # bulldozer. It accepts the same keys as the trigger in the "merge" block.
+  trigger:
+    labels: ["Update Me", "bulldozer-update"]
+
+    comments: ["@bulldozer update", "keep updated"]
+
+  # "ignore" defines the set of pull requests that should not be updated by
+  # bulldozer. It accepts the same keys as the ignore in the "merge" block.
+  ignore:
+    labels: ["Do Not Update"]
+

--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -10,25 +10,7 @@ merge:
   trigger:
     # Pull requests with any of these labels (case-insensitive) are added to
     # the trigger.
-    labels: ["merge when ready", "bulldozer-merge"]
-
-    # Pull requests where the body or any comment contains any of these
-    # substrings are added to the trigger.
-    comment_substrings: ["==MERGE_WHEN_READY==", "merge when ready"]
-
-    # Pull requests where any comment matches one of these exact strings are
-    # added to the trigger.
-    comments:
-      [
-        "Please merge this pull request!",
-        "Mr. Bulldozer, please merge",
-        "@bulldozer merge",
-        "ready to merge",
-      ]
-
-    # Pull requests where the body contains any of these substrings are added
-    # to the trigger.
-    pr_body_substrings: ["==MERGE_WHEN_READY=="]
+    labels: ["bulldozer-merge"]
 
     # Pull requests targeting branches matching any of these regular expressions are added to the trigger.
     # branch_patterns: ["feature/.*"]
@@ -38,7 +20,6 @@ merge:
   # same keys as the "trigger" section.
   ignore:
     labels: ["do not merge"]
-    comment_substrings: ["==DO_NOT_MERGE=="]
 
   # "method" defines the merge method. The available options are "merge",
   # "rebase", "squash", and "ff-only".
@@ -87,12 +68,9 @@ update:
   # "trigger" defines the set of pull requests that should be updated by
   # bulldozer. It accepts the same keys as the trigger in the "merge" block.
   trigger:
-    labels: ["Update Me", "bulldozer-update"]
-
-    comments: ["@bulldozer update", "keep updated"]
+    labels: ["bulldozer-update"]
 
   # "ignore" defines the set of pull requests that should not be updated by
   # bulldozer. It accepts the same keys as the ignore in the "merge" block.
   ignore:
     labels: ["Do Not Update"]
-


### PR DESCRIPTION
## 📚 Purpose
As the amount of contributors scales up, and the size of mds-core grows, there's a need to automate more portions of the PR process. This adds [Bulldozer](https://github.com/palantir/bulldozer) to the mds-core repo, which allows a PR creator to mark a PR as "ready to merge", and once requisite status-checks & approvals have come through, will automatically merge. Additionally, it will keep PRs up to date, so no longer will developers have to continuously hit the "update branch" button in Github.

## Usage
To mark a PR as 'ready to merge', you can add the label `bulldozer-merge`, and Bulldozer will auto-merge upon all status checks & review requirements being passed. Additionally, you can mark a PR as 'keep updated' using the label `bulldozer-update`, and Bulldozer will automatically keep your PR branch up-to-date with the target branch.