### PR TITLE
[mds-attachment-service] Remove unused import so CI/CD is happy

### DIFF
--- a/packages/mds-attachment-service/tests/index.spec.ts
+++ b/packages/mds-attachment-service/tests/index.spec.ts
@@ -1,5 +1,4 @@
 import { AttachmentServiceManager } from '../service/manager'
-import { AttachmentServiceClient } from '../client'
 import { AttachmentRepository } from '../repository'
 
 describe('Attachment Repository Tests', () => {

--- a/packages/mds-audit/attachments.ts
+++ b/packages/mds-audit/attachments.ts
@@ -16,13 +16,11 @@
 
 import db from '@mds-core/mds-db'
 import logger from '@mds-core/mds-logger'
-import aws from 'aws-sdk'
 import { Attachment, AttachmentSummary, AuditAttachment, Recorded, UUID } from '@mds-core/mds-types'
 import { AttachmentServiceClient } from '@mds-core/mds-attachment-service'
 
 /* eslint-disable-next-line */
 const multer = require('multer')
-const { env } = process
 const memoryStorage = multer.memoryStorage()
 
 export const multipartFormUpload = multer({ storage: memoryStorage }).single('file')


### PR DESCRIPTION
## 📚 Purpose
Hotfix fixing something that shouldn't have gotten through the CI tests in the first place...

## 📦 Impacts:
- mds-attachment-service (tests)