### PR TITLE
exit immediately on any failure, move docker cleanup to exit function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
       steps {
         nvm('version': 'v14.2.0') {
           sh '''
+            set -eu
+            set -o pipefail
+
             randport() {
                 local port=$((($RANDOM%8000)+1024));
                 while nc -zv localhost $port > /dev/null 2>&1; do
@@ -40,16 +43,18 @@ pipeline {
             export RPC_PORT=$(randport)
             source env.jenkins
 
-            PG_ID=$(docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -p $PG_PORT:5432 postgres:10-alpine)
-            REDIS_ID=$(docker run -d -p $REDIS_PORT:6379 redis:5-alpine)
+            export PG_ID=$(docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -p $PG_PORT:5432 postgres:10-alpine)
+            export REDIS_ID=$(docker run -d -p $REDIS_PORT:6379 redis:5-alpine)
+
+            function cleanup() {
+              docker stop $PG_ID
+              docker stop $REDIS_ID
+            }
+            trap cleanup EXIT
 
             yarn clean
-            PG_NAME=postgres PG_HOST=localhost PG_USER=postgres REDIS_HOST=localhost yarn test:eslint &
-            PG_NAME=postgres PG_HOST=localhost PG_USER=postgres REDIS_HOST=localhost yarn test:unit &
-            wait
-
-            docker stop $PG_ID
-            docker stop $REDIS_ID
+            PG_NAME=postgres PG_HOST=localhost PG_USER=postgres REDIS_HOST=localhost yarn test:eslint
+            PG_NAME=postgres PG_HOST=localhost PG_USER=postgres REDIS_HOST=localhost yarn test:unit
           '''
         }
       }


### PR DESCRIPTION
Fixes two issues: dangling docker containers, and not catching test failures