### PR TITLE
Adds expiry for milliseconds, crucial for mds time

### DIFF
--- a/packages/mds-cache/redis/index.ts
+++ b/packages/mds-cache/redis/index.ts
@@ -57,7 +57,16 @@ export const RedisCache = () => {
 
     set: async (key: KeyType, val: ValueType) => safelyExec(theClient => theClient.set(key, val)),
 
-    expireat: async (key: KeyType, time: Timestamp) => safelyExec(theClient => theClient.expireat(key, time)),
+    /**
+     * Expires at Unix time in seconds
+     */
+    expireat: async (key: KeyType, timeInSeconds: Timestamp) =>
+      safelyExec(theClient => theClient.expireat(key, timeInSeconds)),
+
+    /**
+     * Expires at Unix time in milliseconds
+     */
+    pexpireat: async (key: KeyType, time: Timestamp) => safelyExec(theClient => theClient.pexpireat(key, time)),
 
     dbsize: async () => safelyExec(theClient => theClient.dbsize()),
 
@@ -116,9 +125,7 @@ export const RedisCache = () => {
     zadd: async (key: KeyType, fields: OrderedFields | (string | number)[]) =>
       safelyExec(theClient => {
         const entries: (string | number)[] = !Array.isArray(fields)
-          ? Object.entries(fields).reduce((acc: (number | string)[], [field, value]) => {
-              return [...acc, value, field]
-            }, [])
+          ? Object.entries(fields).reduce((acc: (number | string)[], [field, value]) => [...acc, value, field], [])
           : fields
         return theClient.zadd(key, ...entries)
       }),

--- a/packages/mds-cache/redis/index.ts
+++ b/packages/mds-cache/redis/index.ts
@@ -64,7 +64,8 @@ export const RedisCache = () => {
     set: async (key: KeyType, val: ValueType) => safelyExec(theClient => theClient.set(key, val)),
 
     /**
-     * Expires at Unix time in seconds, or time in milliseconds.
+     * Expires a key at Unix time in seconds, or time in milliseconds.
+     * Don't add both parameters, only one of them will be used.
      */
     expireat: async (options: ExpireAtOptions) => {
       const { key, timeInSeconds, timeInMs } = options

--- a/packages/mds-cache/tests/redis.spec.ts
+++ b/packages/mds-cache/tests/redis.spec.ts
@@ -165,22 +165,20 @@ describe('Redis Tests', () => {
       it('expires at a time in seconds', async () => {
         await redis.set('foo', 'bar')
         // expire 1 minute from now
-        await redis.expireat('foo', Math.round(now() + minutes(1) / 1000))
+        await redis.expireat({ key: 'foo', timeInSeconds: Math.round(now() + minutes(1) / 1000) })
         await expect(redis.get('foo')).resolves.toEqual('bar')
         // expire 1 second ago
-        await redis.expireat('foo', Math.round(now() / 1000) - 1)
+        await redis.expireat({ key: 'foo', timeInSeconds: Math.round(now() / 1000) - 1 })
         await expect(redis.get('foo')).resolves.toEqual(null)
       })
-    })
 
-    describe('PexpireAt', () => {
       it('expires at a time in milliseconds', async () => {
         await redis.set('foo', 'bar')
         // expire 1 minute from now
-        await redis.pexpireat('foo', now() + minutes(1))
+        await redis.expireat({ key: 'foo', timeInMs: now() + minutes(1) })
         await expect(redis.get('foo')).resolves.toEqual('bar')
         // expire 1 millisecond ago
-        await redis.pexpireat('foo', now() - 1)
+        await redis.expireat({ key: 'foo', timeInMs: now() - 1 })
         await expect(redis.get('foo')).resolves.toEqual(null)
       })
     })
@@ -298,13 +296,7 @@ describe('Redis Tests', () => {
     })
 
     it('expireat()', async () => {
-      await expect(redis.expireat('foo', now() + hours(1))).rejects.toEqual(
-        new ClientDisconnectedError(ExceptionMessages.INITIALIZE_CLIENT_MESSAGE)
-      )
-    })
-
-    it('pexpireat()', async () => {
-      await expect(redis.pexpireat('foo', now() + hours(1))).rejects.toEqual(
+      await expect(redis.expireat({ key: 'foo', timeInMs: now() + hours(1) })).rejects.toEqual(
         new ClientDisconnectedError(ExceptionMessages.INITIALIZE_CLIENT_MESSAGE)
       )
     })

--- a/packages/mds-cache/tests/redis.spec.ts
+++ b/packages/mds-cache/tests/redis.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ClientDisconnectedError, now, hours, ExceptionMessages } from '@mds-core/mds-utils'
+import { ClientDisconnectedError, now, hours, ExceptionMessages, minutes } from '@mds-core/mds-utils'
 import { RedisCache } from '../redis'
 
 const redis = RedisCache()
@@ -160,6 +160,30 @@ describe('Redis Tests', () => {
         await expect(redis.smembers('foo')).resolves.toEqual([])
       })
     })
+
+    describe('ExpireAt', () => {
+      it('expires at a time in seconds', async () => {
+        await redis.set('foo', 'bar')
+        // expire 1 minute from now
+        await redis.expireat('foo', Math.round(now() + minutes(1) / 1000))
+        await expect(redis.get('foo')).resolves.toEqual('bar')
+        // expire 1 second ago
+        await redis.expireat('foo', Math.round(now() / 1000) - 1)
+        await expect(redis.get('foo')).resolves.toEqual(null)
+      })
+    })
+
+    describe('PexpireAt', () => {
+      it('expires at a time in milliseconds', async () => {
+        await redis.set('foo', 'bar')
+        // expire 1 minute from now
+        await redis.pexpireat('foo', now() + minutes(1))
+        await expect(redis.get('foo')).resolves.toEqual('bar')
+        // expire 1 millisecond ago
+        await redis.pexpireat('foo', now() - 1)
+        await expect(redis.get('foo')).resolves.toEqual(null)
+      })
+    })
   })
 
   describe('Null Client tests', () => {
@@ -275,6 +299,12 @@ describe('Redis Tests', () => {
 
     it('expireat()', async () => {
       await expect(redis.expireat('foo', now() + hours(1))).rejects.toEqual(
+        new ClientDisconnectedError(ExceptionMessages.INITIALIZE_CLIENT_MESSAGE)
+      )
+    })
+
+    it('pexpireat()', async () => {
+      await expect(redis.pexpireat('foo', now() + hours(1))).rejects.toEqual(
         new ClientDisconnectedError(ExceptionMessages.INITIALIZE_CLIENT_MESSAGE)
       )
     })

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -121,6 +121,7 @@ export const TIME_FORMAT = 'HH:mm:ss'
 export type UUID = string
 
 export type Timestamp = number
+export type TimestampInSeconds = number
 export type Stringify<T> = { [P in keyof T]: string }
 export type Nullable<T> = T | null
 export type NullableProperties<T extends object> = {


### PR DESCRIPTION
## 📚 Purpose
*[ExpireAt is powerful with Redis, but timestamps in MDS use Unix time in milliseconds]*

## 📦 Impacts:
* mds-cache