### PR TITLE
Bump Typedoc version to resolve audit advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ts-mocha": "8.0.0",
     "ts-node": "9.1.1",
     "tsconfig-paths": "3.9.0",
-    "typedoc": "0.20.14",
+    "typedoc": "0.20.28",
     "typedoc-plugin-lerna-packages": "0.3.1",
     "typescript": "4.1.3",
     "unit.js": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
       ts-mocha: 8.0.0_mocha@8.2.1
       ts-node: 9.1.1_typescript@4.1.3
       tsconfig-paths: 3.9.0
-      typedoc: 0.20.14_typescript@4.1.3
-      typedoc-plugin-lerna-packages: 0.3.1_typedoc@0.20.14
+      typedoc: 0.20.28_typescript@4.1.3
+      typedoc-plugin-lerna-packages: 0.3.1_typedoc@0.20.28
       typescript: 4.1.3
       unit.js: 2.1.1
       webpack: 5.13.0_webpack-cli@4.3.1
@@ -96,7 +96,7 @@ importers:
       ts-mocha: 8.0.0
       ts-node: 9.1.1
       tsconfig-paths: 3.9.0
-      typedoc: 0.20.14
+      typedoc: 0.20.28
       typedoc-plugin-lerna-packages: 0.3.1
       typescript: 4.1.3
       unit.js: 2.1.1
@@ -8824,6 +8824,10 @@ packages:
   /lodash/4.17.20:
     resolution:
       integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+  /lodash/4.17.21:
+    dev: true
+    resolution:
+      integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
   /log-symbols/4.0.0:
     dependencies:
       chalk: 4.1.0
@@ -8991,13 +8995,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
-  /marked/1.2.9:
+  /marked/2.0.0:
     dev: true
     engines:
       node: '>= 8.16.2'
     hasBin: true
     resolution:
-      integrity: sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
+      integrity: sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
   /meant/1.0.3:
     dev: false
     resolution:
@@ -11708,28 +11712,13 @@ packages:
     optional: true
     resolution:
       integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-  /shiki-languages/0.2.7:
-    dependencies:
-      vscode-textmate: 5.2.0
-    dev: true
-    resolution:
-      integrity: sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==
-  /shiki-themes/0.2.7:
-    dependencies:
-      json5: 2.2.0
-      vscode-textmate: 5.2.0
-    dev: true
-    resolution:
-      integrity: sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==
-  /shiki/0.2.7:
+  /shiki/0.9.2:
     dependencies:
       onigasm: 2.2.5
-      shiki-languages: 0.2.7
-      shiki-themes: 0.2.7
       vscode-textmate: 5.2.0
     dev: true
     resolution:
-      integrity: sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==
+      integrity: sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==
   /shimmer/1.2.1:
     dev: false
     resolution:
@@ -12592,7 +12581,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.6.0
-      webpack: 5.13.0
+      webpack: 5.13.0_webpack-cli@4.3.1
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -13008,33 +12997,33 @@ packages:
   /typedarray/0.0.6:
     resolution:
       integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-  /typedoc-default-themes/0.12.1:
+  /typedoc-default-themes/0.12.7:
     dev: true
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-6PEvV+/kWAJeUwEtrKgIsZQSbybW5DGCr6s2mMjHsDplpgN8iBHI52UbA+2C+c2TMCxBNMK9TMS6pdeIdwsLSw==
-  /typedoc-plugin-lerna-packages/0.3.1_typedoc@0.20.14:
+      integrity: sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==
+  /typedoc-plugin-lerna-packages/0.3.1_typedoc@0.20.28:
     dependencies:
-      typedoc: 0.20.14_typescript@4.1.3
+      typedoc: 0.20.28_typescript@4.1.3
     dev: true
     peerDependencies:
       typedoc: ^0.17.0
     resolution:
       integrity: sha512-azeP5DVv4Me+C32RoGbMAzXo7JeYmeEstMAx4mdtVGHLtrXjitlaf0pS562vogofwyIcyVnjL6BlZWvbPQ3hmw==
-  /typedoc/0.20.14_typescript@4.1.3:
+  /typedoc/0.20.28_typescript@4.1.3:
     dependencies:
       colors: 1.4.0
       fs-extra: 9.1.0
       handlebars: 4.7.7
-      lodash: 4.17.20
+      lodash: 4.17.21
       lunr: 2.3.9
-      marked: 1.2.9
+      marked: 2.0.0
       minimatch: 3.0.4
       progress: 2.0.3
       shelljs: 0.8.4
-      shiki: 0.2.7
-      typedoc-default-themes: 0.12.1
+      shiki: 0.9.2
+      typedoc-default-themes: 0.12.7
       typescript: 4.1.3
     dev: true
     engines:
@@ -13043,7 +13032,7 @@ packages:
     peerDependencies:
       typescript: 3.9.x || 4.0.x || 4.1.x
     resolution:
-      integrity: sha512-9bsZp5/qkl+gDSv9DRvHbfbY8Sr0tD8fKx7hNIvcluxeAFzBCEo9o0qDCdLUZw+/axbfd9TaqHvSuCVRu+YH6Q==
+      integrity: sha512-8j0T8u9FuyDkoe+M/3cyoaGJSVgXCY9KwVoo7TLUnmQuzXwqH+wkScY530ZEdK6G39UZ2LFTYPIrL5eykWjx6A==
   /typeorm-cursor-pagination/0.6.0_typeorm@0.2.30:
     dependencies:
       typeorm: 0.2.30


### PR DESCRIPTION
## 👌 Resolves:
```
Running: "pnpm audit --json --audit-level=low"
Found 1 known vulnerability in 1830 dependencies (excluding 1556, 1561)
 - https://npmjs.com/advisories/1623: Regular Expression Denial of Service (MODERATE)
    - . > typedoc > marked@1.2.9
```
## 📦 Impacts:
nothing really
