### PR TITLE
Prevent connection exhaustion following client cold start

### DIFF
--- a/packages/mds-db/client.ts
+++ b/packages/mds-db/client.ts
@@ -15,6 +15,7 @@
  */
 
 import logger from '@mds-core/mds-logger'
+import AwaitLock from 'await-lock'
 
 import { logSql, configureClient, MDSPostgresClient, SqlVals } from './sql-utils'
 
@@ -49,33 +50,37 @@ async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
   }
 }
 
+const readOnlyClientLock = new AwaitLock()
 export async function getReadOnlyClient(): Promise<MDSPostgresClient> {
-  if (readOnlyCachedClient && readOnlyCachedClient.connected) {
-    return readOnlyCachedClient
-  }
-
+  await readOnlyClientLock.acquireAsync()
   try {
-    readOnlyCachedClient = await setupClient(false)
+    if (!readOnlyCachedClient || !readOnlyCachedClient.connected) {
+      readOnlyCachedClient = await setupClient(false)
+    }
     return readOnlyCachedClient
   } catch (err) {
     readOnlyCachedClient = null
     logger.error('postgres connection error', err)
     throw err
+  } finally {
+    readOnlyClientLock.release()
   }
 }
 
+const writeableClientLock = new AwaitLock()
 export async function getWriteableClient(): Promise<MDSPostgresClient> {
-  if (writeableCachedClient && writeableCachedClient.connected) {
-    return writeableCachedClient
-  }
-
+  await writeableClientLock.acquireAsync()
   try {
-    writeableCachedClient = await setupClient(true)
+    if (!writeableCachedClient || !writeableCachedClient.connected) {
+      writeableCachedClient = await setupClient(true)
+    }
     return writeableCachedClient
   } catch (err) {
     writeableCachedClient = null
     logger.error('postgres connection error', err)
     throw err
+  } finally {
+    writeableClientLock.release()
   }
 }
 

--- a/packages/mds-db/package.json
+++ b/packages/mds-db/package.json
@@ -26,6 +26,7 @@
     "@mds-core/mds-types": "0.1.23",
     "@mds-core/mds-utils": "0.1.26",
     "@types/pg": "7.14.7",
+    "await-lock": "2.1.0",
     "pg": "8.5.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,7 @@ importers:
       '@mds-core/mds-types': link:../mds-types
       '@mds-core/mds-utils': link:../mds-utils
       '@types/pg': 7.14.7
+      await-lock: 2.1.0
       pg: 8.5.1
     devDependencies:
       '@mds-core/mds-test-data': link:../mds-test-data
@@ -547,6 +548,7 @@ importers:
       '@mds-core/mds-types': 0.1.23
       '@mds-core/mds-utils': 0.1.26
       '@types/pg': 7.14.7
+      await-lock: 2.1.0
       pg: 8.5.1
   packages/mds-geography:
     dependencies:


### PR DESCRIPTION
## 📚 Purpose
If an API gets hit with a number of concurrent requests following a cold start, it's possible for all requests to try to establish a DB connection resulting in potential max connection errors. Use a simple locking mechanism to implement a semaphore around the connection caching.

## 📦 Impacts:
- [x] mds-db
