### PR TITLE
[mds-attachment-service] Move sharp installation in Dockerfile

### DIFF
--- a/container-images/mds-attachment-service/Dockerfile
+++ b/container-images/mds-attachment-service/Dockerfile
@@ -4,11 +4,11 @@ RUN apk add --no-cache tini
 
 RUN mkdir /mds
 
-#Compile Vips and Sharp
-RUN npm install sharp
-
 COPY dist/* /mds/
 
 WORKDIR /mds
+
+#Compile Vips and Sharp
+RUN npm install sharp
 
 ENTRYPOINT ["/sbin/tini", "node", "--no-deprecation", "--experimental-repl-await", "server.js"]


### PR DESCRIPTION
## 📚 Purpose
After upgrading to Node v15, I experienced issues generating images that mandate the installation of `sharp`.

```
npm ERR! Tracker "idealTree" already exists

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-03-05T20_32_49_925Z-debug.log
```

This looks like it is due to a change in Node v15 where npm is executed from the root of a container, and results in a failure. This is resolved by moving the installation to after we've created a `WORKDIR`.

## 📦 Impacts:
- container-images/mds-attachment-service

