### PR TITLE
Relax type constraint on Collector service method

### DIFF
--- a/packages/mds-collector-api/handlers/write-schema-messages.ts
+++ b/packages/mds-collector-api/handlers/write-schema-messages.ts
@@ -19,17 +19,13 @@ import HttpStatus from 'http-status-codes'
 import { ApiRequestParams } from '@mds-core/mds-api-server'
 import { CollectorService, CollectorServiceClient } from '@mds-core/mds-collector-backend'
 import { ValidationError } from '@mds-core/mds-utils'
-import { NonEmptyArray } from '@mds-core/mds-types'
 import { CollectorApiResponse, CollectorApiRequest } from '../@types'
 
-export type CollectorApiWriteSchemaMessagesRequest = CollectorApiRequest<NonEmptyArray<{}>> &
-  ApiRequestParams<'schema_id'>
+export type CollectorApiWriteSchemaMessagesRequest = CollectorApiRequest<Array<{}>> & ApiRequestParams<'schema_id'>
 
 export type CollectorApiWriteSchemaMessagesResponseBody = ReturnType<CollectorService['writeSchemaMessages']>
 
 export type CollectorApiWriteSchemaMessagesResponse = CollectorApiResponse<CollectorApiWriteSchemaMessagesResponseBody>
-
-const isNonEmptyArray = <T>(array: unknown): array is NonEmptyArray<T> => Array.isArray(array) && array.length > 0
 
 export const WriteSchemaMessagesHandler = async (
   req: CollectorApiWriteSchemaMessagesRequest,
@@ -38,7 +34,7 @@ export const WriteSchemaMessagesHandler = async (
 ) => {
   try {
     const { schema_id } = req.params
-    if (!isNonEmptyArray(req.body)) {
+    if (!Array.isArray(req.body) || req.body.length === 0) {
       throw new ValidationError('Request must contain a non-empty array of messages')
     }
     const messages = await CollectorServiceClient.writeSchemaMessages(

--- a/packages/mds-collector-backend/@types/index.ts
+++ b/packages/mds-collector-backend/@types/index.ts
@@ -16,7 +16,7 @@
 
 import { RpcRoute, RpcServiceDefinition } from '@mds-core/mds-rpc-common'
 import { DomainModelCreate } from '@mds-core/mds-repository'
-import { NonEmptyArray, Timestamp, UUID } from '@mds-core/mds-types'
+import { Timestamp, UUID } from '@mds-core/mds-types'
 import { AnySchema } from 'ajv'
 
 export interface CollectorSchemaDomainModel {
@@ -44,7 +44,7 @@ export interface CollectorService {
   writeSchemaMessages: (
     schema_id: CollectorMessageDomainModel['schema_id'],
     provider_id: CollectorMessageDomainModel['provider_id'],
-    messages: NonEmptyArray<CollectorMessageDomainModel['message']>
+    messages: Array<CollectorMessageDomainModel['message']>
   ) => Array<CollectorMessageDomainModel>
 }
 

--- a/packages/mds-collector-backend/client/index.ts
+++ b/packages/mds-collector-backend/client/index.ts
@@ -16,8 +16,12 @@
 
 import { ServiceClient } from '@mds-core/mds-service-helpers'
 import { RpcClient, RpcRequest } from '@mds-core/mds-rpc-common'
-import { UUID } from '@mds-core/mds-types'
-import { CollectorServiceRpcDefinition, CollectorService, CollectorSchemaDomainModel } from '../@types'
+import {
+  CollectorServiceRpcDefinition,
+  CollectorService,
+  CollectorSchemaDomainModel,
+  CollectorMessageDomainModel
+} from '../@types'
 
 const CollectorServiceRpcClient = RpcClient(CollectorServiceRpcDefinition, {
   host: process.env.COLLECTOR_BACKEND_RPC_HOST,
@@ -31,14 +35,15 @@ export const CollectorServiceClient: ServiceClient<CollectorService> = {
 }
 
 export const CollectorServiceClientFactory = (
-  provider_id: UUID,
   schema_id: CollectorSchemaDomainModel['schema_id'],
   schema: CollectorSchemaDomainModel['schema']
 ) => {
   return {
     registerMessageSchema: async () => CollectorServiceClient.registerMessageSchema(schema_id, schema),
     getMessageSchema: async () => CollectorServiceClient.getMessageSchema(schema_id),
-    writeSchemaMessages: async (messages: object[]) =>
-      CollectorServiceClient.writeSchemaMessages(schema_id, provider_id, messages)
+    writeSchemaMessages: async (
+      provider_id: CollectorMessageDomainModel['provider_id'],
+      messages: Array<CollectorMessageDomainModel['message']>
+    ) => CollectorServiceClient.writeSchemaMessages(schema_id, provider_id, messages)
   }
 }

--- a/packages/mds-collector-backend/client/index.ts
+++ b/packages/mds-collector-backend/client/index.ts
@@ -16,7 +16,8 @@
 
 import { ServiceClient } from '@mds-core/mds-service-helpers'
 import { RpcClient, RpcRequest } from '@mds-core/mds-rpc-common'
-import { CollectorServiceRpcDefinition, CollectorService } from '../@types'
+import { UUID } from '@mds-core/mds-types'
+import { CollectorServiceRpcDefinition, CollectorService, CollectorSchemaDomainModel } from '../@types'
 
 const CollectorServiceRpcClient = RpcClient(CollectorServiceRpcDefinition, {
   host: process.env.COLLECTOR_BACKEND_RPC_HOST,
@@ -27,4 +28,17 @@ export const CollectorServiceClient: ServiceClient<CollectorService> = {
   registerMessageSchema: (...args) => RpcRequest(CollectorServiceRpcClient.registerMessageSchema, args),
   getMessageSchema: (...args) => RpcRequest(CollectorServiceRpcClient.getMessageSchema, args),
   writeSchemaMessages: (...args) => RpcRequest(CollectorServiceRpcClient.writeSchemaMessages, args)
+}
+
+export const CollectorServiceClientFactory = (
+  provider_id: UUID,
+  schema_id: CollectorSchemaDomainModel['schema_id'],
+  schema: CollectorSchemaDomainModel['schema']
+) => {
+  return {
+    registerMessageSchema: async () => CollectorServiceClient.registerMessageSchema(schema_id, schema),
+    getMessageSchema: async () => CollectorServiceClient.getMessageSchema(schema_id),
+    writeSchemaMessages: async (messages: object[]) =>
+      CollectorServiceClient.writeSchemaMessages(schema_id, provider_id, messages)
+  }
 }

--- a/packages/mds-collector-backend/service/provider.ts
+++ b/packages/mds-collector-backend/service/provider.ts
@@ -103,6 +103,9 @@ export const CollectorServiceProvider: ServiceProvider<CollectorService> & Proce
   },
 
   writeSchemaMessages: async (schema_id, provider_id, messages) => {
+    if (messages.length === 0) {
+      return ServiceResult([])
+    }
     try {
       const [validator, producer] = await Promise.all([getSchemaValidator(schema_id), getStreamProducer(schema_id)])
 

--- a/packages/mds-collector-backend/tests/service.spec.ts
+++ b/packages/mds-collector-backend/tests/service.spec.ts
@@ -25,7 +25,7 @@ const TEST_COLLECTOR_MESSAGES: Array<TestSchema> = [
   { id: uuid(), name: 'Prime Minister', country: 'CA', zip: 'K1M 1M4' }
 ]
 
-const TestSchemaCollectorClient = CollectorServiceClientFactory(uuid(), TEST_SCHEMA_ID, TestSchema)
+const TestSchemaCollectorClient = CollectorServiceClientFactory(TEST_SCHEMA_ID, TestSchema)
 
 describe('Collector Service', () => {
   it('Service Unavailable', async () => {
@@ -81,14 +81,17 @@ describe('Collector Service', () => {
     })
 
     it('Write Schema Messages (OK)', async () => {
-      const written = await TestSchemaCollectorClient.writeSchemaMessages(TEST_COLLECTOR_MESSAGES)
-      expect(written).toMatchObject(TEST_COLLECTOR_MESSAGES.map(message => ({ schema_id: TEST_SCHEMA_ID, message })))
+      const provider_id = uuid()
+      const written = await TestSchemaCollectorClient.writeSchemaMessages(provider_id, TEST_COLLECTOR_MESSAGES)
+      expect(written).toMatchObject(
+        TEST_COLLECTOR_MESSAGES.map(message => ({ schema_id: TEST_SCHEMA_ID, provider_id, message }))
+      )
     })
 
     it('Write Schema Messages (Error)', async () => {
       const [message] = TEST_COLLECTOR_MESSAGES
       await expect(
-        TestSchemaCollectorClient.writeSchemaMessages([{ ...message, email: 'invalid' }])
+        TestSchemaCollectorClient.writeSchemaMessages(uuid(), [{ ...message, email: 'invalid' }])
       ).rejects.toMatchObject({
         isServiceError: true,
         type: 'ValidationError'

--- a/packages/mds-collector-backend/tests/service.spec.ts
+++ b/packages/mds-collector-backend/tests/service.spec.ts
@@ -20,13 +20,12 @@ import TestSchema from '../schemas/test.schema'
 
 const CollectorBackend = CollectorBackendController()
 const TEST_SCHEMA_ID = 'test'
-const TEST_PRODUCER_ID = uuid()
 const TEST_COLLECTOR_MESSAGES: Array<TestSchema> = [
   { id: uuid(), name: 'President', country: 'US', zip: '37188' },
   { id: uuid(), name: 'Prime Minister', country: 'CA', zip: 'K1M 1M4' }
 ]
 
-const TestSchemaCollectorClient = CollectorServiceClientFactory(TEST_PRODUCER_ID, TEST_SCHEMA_ID, TestSchema)
+const TestSchemaCollectorClient = CollectorServiceClientFactory(uuid(), TEST_SCHEMA_ID, TestSchema)
 
 describe('Collector Service', () => {
   it('Service Unavailable', async () => {
@@ -83,9 +82,7 @@ describe('Collector Service', () => {
 
     it('Write Schema Messages (OK)', async () => {
       const written = await TestSchemaCollectorClient.writeSchemaMessages(TEST_COLLECTOR_MESSAGES)
-      expect(written).toMatchObject(
-        TEST_COLLECTOR_MESSAGES.map(message => ({ schema_id: TEST_SCHEMA_ID, provider_id: TEST_PRODUCER_ID, message }))
-      )
+      expect(written).toMatchObject(TEST_COLLECTOR_MESSAGES.map(message => ({ schema_id: TEST_SCHEMA_ID, message })))
     })
 
     it('Write Schema Messages (Error)', async () => {

--- a/packages/mds-collector-backend/tests/service.spec.ts
+++ b/packages/mds-collector-backend/tests/service.spec.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { uuid } from '@mds-core/mds-utils'
-import { NonEmptyArray } from '@mds-core/mds-types'
 import { CollectorServiceClient } from '../client'
 import { CollectorBackendController } from '../service/backend'
 import { CollectorRepository } from '../repository'
@@ -22,7 +21,7 @@ import TestSchema from '../schemas/test.schema'
 const CollectorBackend = CollectorBackendController()
 const TEST_SCHEMA_ID = 'test'
 const TEST_PRODUCER_ID = uuid()
-const TEST_COLLECTOR_MESSAGES: NonEmptyArray<TestSchema> = [
+const TEST_COLLECTOR_MESSAGES: Array<TestSchema> = [
   { id: uuid(), name: 'President', country: 'US', zip: '37188' },
   { id: uuid(), name: 'Prime Minister', country: 'CA', zip: 'K1M 1M4' }
 ]


### PR DESCRIPTION
The `NonEmptyArray` type is good in theory, but awkward in practice.