### PR TITLE
Fix mds-audit image; sharp is no longer required

### DIFF
--- a/container-images/mds-audit/Dockerfile
+++ b/container-images/mds-audit/Dockerfile
@@ -4,9 +4,6 @@ RUN apk add --no-cache tini
 
 RUN mkdir /mds
 
-#Compile Vips and Sharp
-RUN npm install sharp
-
 COPY dist/* /mds/
 
 WORKDIR /mds

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tsconfig-paths": "3.9.0",
     "typedoc": "0.20.28",
     "typedoc-plugin-lerna-packages": "0.3.1",
-    "typescript": "4.2.2",
+    "typescript": "4.2.3",
     "unit.js": "2.1.1",
     "webpack": "5.24.2",
     "webpack-cli": "4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
       '@types/sinon': 9.0.10
       '@types/sinon-express-mock': 1.3.9
       '@types/supertest': 2.0.10
-      '@typescript-eslint/eslint-plugin': 4.16.1_4fe32a7126aebc440d3400f14be2b917
-      '@typescript-eslint/parser': 4.16.1_eslint@7.21.0+typescript@4.2.2
+      '@typescript-eslint/eslint-plugin': 4.16.1_db289a69270a1846aefbe377c7369d6d
+      '@typescript-eslint/parser': 4.16.1_eslint@7.21.0+typescript@4.2.3
       dotenv: 8.2.0
       eslint: 7.21.0
       eslint-config-prettier: 8.1.0_eslint@7.21.0
@@ -38,14 +38,14 @@ importers:
       sinon-express-mock: 2.2.1_sinon@9.2.4
       source-map-support: 0.5.19
       supertest: 6.1.3
-      ts-jest: 26.5.2_jest@26.6.3+typescript@4.2.2
-      ts-loader: 8.0.17_typescript@4.2.2+webpack@5.24.2
+      ts-jest: 26.5.2_jest@26.6.3+typescript@4.2.3
+      ts-loader: 8.0.17_typescript@4.2.3+webpack@5.24.2
       ts-mocha: 8.0.0_mocha@8.3.0
-      ts-node: 9.1.1_typescript@4.2.2
+      ts-node: 9.1.1_typescript@4.2.3
       tsconfig-paths: 3.9.0
-      typedoc: 0.20.28_typescript@4.2.2
+      typedoc: 0.20.28_typescript@4.2.3
       typedoc-plugin-lerna-packages: 0.3.1_typedoc@0.20.28
-      typescript: 4.2.2
+      typescript: 4.2.3
       unit.js: 2.1.1
       webpack: 5.24.2_webpack-cli@4.5.0
       webpack-cli: 4.5.0_webpack@5.24.2
@@ -96,7 +96,7 @@ importers:
       tsconfig-paths: 3.9.0
       typedoc: 0.20.28
       typedoc-plugin-lerna-packages: 0.3.1
-      typescript: 4.2.2
+      typescript: 4.2.3
       unit.js: 2.1.1
       webpack: 5.24.2
       webpack-cli: 4.5.0
@@ -1487,7 +1487,7 @@ packages:
       '@istanbuljs/schema': 0.1.3
       nyc: 15.1.0
       source-map-support: 0.5.19
-      ts-node: 9.1.1_typescript@4.2.2
+      ts-node: 9.1.1_typescript@4.2.3
     dev: true
     engines:
       node: '>=8'
@@ -3044,10 +3044,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
-  /@typescript-eslint/eslint-plugin/4.16.1_4fe32a7126aebc440d3400f14be2b917:
+  /@typescript-eslint/eslint-plugin/4.16.1_db289a69270a1846aefbe377c7369d6d:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.16.1_eslint@7.21.0+typescript@4.2.2
-      '@typescript-eslint/parser': 4.16.1_eslint@7.21.0+typescript@4.2.2
+      '@typescript-eslint/experimental-utils': 4.16.1_eslint@7.21.0+typescript@4.2.3
+      '@typescript-eslint/parser': 4.16.1_eslint@7.21.0+typescript@4.2.3
       '@typescript-eslint/scope-manager': 4.16.1
       debug: 4.3.1
       eslint: 7.21.0
@@ -3055,8 +3055,8 @@ packages:
       lodash: 4.17.21
       regexpp: 3.1.0
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.2.2
-      typescript: 4.2.2
+      tsutils: 3.20.0_typescript@4.2.3
+      typescript: 4.2.3
     dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -3069,12 +3069,12 @@ packages:
         optional: true
     resolution:
       integrity: sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==
-  /@typescript-eslint/experimental-utils/4.16.1_eslint@7.21.0+typescript@4.2.2:
+  /@typescript-eslint/experimental-utils/4.16.1_eslint@7.21.0+typescript@4.2.3:
     dependencies:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/scope-manager': 4.16.1
       '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.2
+      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.3
       eslint: 7.21.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -3086,14 +3086,14 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==
-  /@typescript-eslint/parser/4.16.1_eslint@7.21.0+typescript@4.2.2:
+  /@typescript-eslint/parser/4.16.1_eslint@7.21.0+typescript@4.2.3:
     dependencies:
       '@typescript-eslint/scope-manager': 4.16.1
       '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.2
+      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.3
       debug: 4.3.1
       eslint: 7.21.0
-      typescript: 4.2.2
+      typescript: 4.2.3
     dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -3120,7 +3120,7 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==
-  /@typescript-eslint/typescript-estree/4.16.1_typescript@4.2.2:
+  /@typescript-eslint/typescript-estree/4.16.1_typescript@4.2.3:
     dependencies:
       '@typescript-eslint/types': 4.16.1
       '@typescript-eslint/visitor-keys': 4.16.1
@@ -3128,8 +3128,8 @@ packages:
       globby: 11.0.2
       is-glob: 4.0.1
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.2.2
-      typescript: 4.2.2
+      tsutils: 3.20.0_typescript@4.2.3
+      typescript: 4.2.3
     dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -7941,7 +7941,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
-      ts-node: 9.1.1_typescript@4.2.2
+      ts-node: 9.1.1_typescript@4.2.3
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -12659,7 +12659,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.6.0
-      webpack: 5.24.2
+      webpack: 5.24.2_webpack-cli@4.5.0
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -12867,7 +12867,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-  /ts-jest/26.5.2_jest@26.6.3+typescript@4.2.2:
+  /ts-jest/26.5.2_jest@26.6.3+typescript@4.2.3:
     dependencies:
       '@types/jest': 26.0.20
       bs-logger: 0.2.6
@@ -12880,7 +12880,7 @@ packages:
       make-error: 1.3.6
       mkdirp: 1.0.4
       semver: 7.3.4
-      typescript: 4.2.2
+      typescript: 4.2.3
       yargs-parser: 20.2.6
     dev: true
     engines:
@@ -12891,14 +12891,14 @@ packages:
       typescript: '>=3.8 <5.0'
     resolution:
       integrity: sha512-bwyJ2zJieSugf7RB+o8fgkMeoMVMM2KPDE0UklRLuACxjwJsOrZNo6chrcScmK33YavPSwhARffy8dZx5LJdUQ==
-  /ts-loader/8.0.17_typescript@4.2.2+webpack@5.24.2:
+  /ts-loader/8.0.17_typescript@4.2.3+webpack@5.24.2:
     dependencies:
       chalk: 4.1.0
       enhanced-resolve: 4.5.0
       loader-utils: 2.0.0
       micromatch: 4.0.2
       semver: 7.3.4
-      typescript: 4.2.2
+      typescript: 4.2.3
       webpack: 5.24.2_webpack-cli@4.5.0
     dev: true
     engines:
@@ -12954,14 +12954,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
-  /ts-node/9.1.1_typescript@4.2.2:
+  /ts-node/9.1.1_typescript@4.2.3:
     dependencies:
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.19
-      typescript: 4.2.2
+      typescript: 4.2.3
       yn: 3.1.1
     dev: true
     engines:
@@ -12983,10 +12983,10 @@ packages:
   /tslib/1.14.1:
     resolution:
       integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-  /tsutils/3.20.0_typescript@4.2.2:
+  /tsutils/3.20.0_typescript@4.2.3:
     dependencies:
       tslib: 1.14.1
-      typescript: 4.2.2
+      typescript: 4.2.3
     dev: true
     engines:
       node: '>= 6'
@@ -13083,13 +13083,13 @@ packages:
       integrity: sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==
   /typedoc-plugin-lerna-packages/0.3.1_typedoc@0.20.28:
     dependencies:
-      typedoc: 0.20.28_typescript@4.2.2
+      typedoc: 0.20.28_typescript@4.2.3
     dev: true
     peerDependencies:
       typedoc: ^0.17.0
     resolution:
       integrity: sha512-azeP5DVv4Me+C32RoGbMAzXo7JeYmeEstMAx4mdtVGHLtrXjitlaf0pS562vogofwyIcyVnjL6BlZWvbPQ3hmw==
-  /typedoc/0.20.28_typescript@4.2.2:
+  /typedoc/0.20.28_typescript@4.2.3:
     dependencies:
       colors: 1.4.0
       fs-extra: 9.1.0
@@ -13102,7 +13102,7 @@ packages:
       shelljs: 0.8.4
       shiki: 0.9.2
       typedoc-default-themes: 0.12.7
-      typescript: 4.2.2
+      typescript: 4.2.3
     dev: true
     engines:
       node: '>= 10.8.0'
@@ -13140,13 +13140,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-qpr8AO3Phi6ZF7qMHOrRdNisVt8jE1KfmW0ooLFcXscA87aJ12aBPyB9cJfxGNjNwd7B3WIK9ZlBveWiqd74QA==
-  /typescript/4.2.2:
+  /typescript/4.2.3:
     dev: true
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+      integrity: sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
   /uglify-js/3.13.0:
     dev: true
     engines:


### PR DESCRIPTION
`image` command for `mds-audit` is breaking Jenkins MDS Core (build/test/image). The installation of `sharp` is not longer required.