### PR TITLE
[mds-attachment-service] Remove strange S3 credential management

### DIFF
--- a/packages/mds-attachment-service/service/helpers/index.ts
+++ b/packages/mds-attachment-service/service/helpers/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import logger from '@mds-core/mds-logger'
 import aws from 'aws-sdk'
 import path from 'path'
 import sharp from 'sharp'
@@ -33,21 +32,6 @@ const s3Region = String(env.ATTACHMENTS_REGION)
 const s3ACL = String(env.ATTACHMENTS_ACL)
 const s3 = new aws.S3()
 const memoryStorage = multer.memoryStorage()
-
-if (env.ATTACHMENTS_BUCKET) {
-  /* eslint-disable-next-line */
-  aws.config.getCredentials(async err => {
-    if (err) {
-      logger.error('Error getting AWS credentials', err)
-    } else if (aws.config.credentials) {
-      aws.config.update({
-        secretAccessKey: aws.config.credentials.secretAccessKey,
-        accessKeyId: aws.config.credentials.accessKeyId,
-        region: s3Region
-      })
-    }
-  })
-}
 
 export const multipartFormUpload = multer({ storage: memoryStorage }).single('file')
 


### PR DESCRIPTION
## 📚 Purpose
We were experiencing issues in a deployed environment where we were unable to upload attachments to S3 due to an `Invalid Credentials` error. I hooked up to the cluster with Okteto, and discovered that the credential fetching code was doing WeirdThings, and basically wiping out the *good* credentials that were being loaded in automagically from the EC2's IAM roles. This PR removes that code. This PR has been tested in a remote cluster while using Okteto.

## 👌 Resolves:
- [x] my sanity returning after hours on the line with AWS support

## 📦 Impacts:
- mds-attachment-service