### PR TITLE
Increase attachment-service RPC request size

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,4 +1,4 @@
-name: mds-agency
+name: mds-attachment-service
 namespace: mds
 image: node:15.11.0
 command: ["bash"]
@@ -8,3 +8,5 @@ resources:
   limits:
     cpu: 2000m
     memory: 4Gi
+sync:
+  - .:/usr/src/app

--- a/packages/mds-attachment-service/service/manager.ts
+++ b/packages/mds-attachment-service/service/manager.ts
@@ -36,6 +36,7 @@ export const AttachmentServiceManager = RpcServer(
     repl: {
       port: process.env.ATTACHMENT_SERVICE_REPL_PORT,
       context: { client: AttachmentServiceClient }
-    }
+    },
+    maxRequestSize: '20mb'
   }
 )

--- a/packages/mds-attachment-service/service/manager.ts
+++ b/packages/mds-attachment-service/service/manager.ts
@@ -37,6 +37,6 @@ export const AttachmentServiceManager = RpcServer(
       port: process.env.ATTACHMENT_SERVICE_REPL_PORT,
       context: { client: AttachmentServiceClient }
     },
-    maxRequestSize: '20mb'
+    maxRequestSize: '10mb'
   }
 )


### PR DESCRIPTION
## 📚 Purpose
Increases `mds-attachment-service` RPC request size limit.

Also updates the okteto config with some new required properties.

## 📦 Impacts:
- mds-attachment-service

