### PR TITLE
[mds-logger] Add infinite logging depth for nested JSON

### DIFF
--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -15,6 +15,10 @@
  */
 
 import httpContext from 'express-http-context'
+import { inspect } from 'util'
+
+// Set the inspector depth to infinity. To the moooooooon 🚀 🌕
+inspect.defaultOptions.depth = null
 
 const logger: Pick<Console, 'info' | 'warn' | 'error'> = console
 type LogLevel = keyof typeof logger

--- a/packages/mds-logger/tests/index.spec.ts
+++ b/packages/mds-logger/tests/index.spec.ts
@@ -97,9 +97,37 @@ describe('MDS Logger', () => {
     process.env.QUIET = 'true'
     const result = logger.log('error', 'some message', { key1: 'key1', key2: 'key2' })
     test.value(Object.keys(result).length).is(0)
+    process.env.QUIET = 'false'
   })
 
   it('can write a log with only a message, and no data', () => {
     logger.info('some message')
+  })
+
+  it('can write out a reasonably deep object and retain proper format', () => {
+    /**
+     * NOTE: This test doesn't really _test_ anything, because unfortunately we can't listen to the console output trivially.
+     *       That being said, for any future engineers looking at this test...
+     *       Make sure that the output in the console doesn't contain `[Object]` instead of fully qualifying :)
+     */
+
+    // With default logger depth, this will be printed out as `{ a: 'a', b: { c: 'c', d: [Object] } }`. Not ideal, we want the full object.
+    const object = {
+      a: 'a',
+      b: {
+        c: 'c',
+        d: {
+          e: 'e',
+          f: {
+            g: 'g',
+            h: {
+              i: 'i'
+            }
+          }
+        }
+      }
+    }
+
+    logger.log('error', 'some message', object)
   })
 })


### PR DESCRIPTION
## 📚 Purpose
Since switching from `JSON.stringify()` to printing out JSON logs directly, we've been seeing shallow-depth printing that appears like: `{ a: 'a', b: { c: 'c', d: [Object] } }`. This isn't ideal, as oftentimes you want to see the full object. This PR makes it so mds-logger will print objects with infinite depth, which it was _technically_ doing before, albeit under the purview of `JSON.stringify()`, so I'm not concerned about any performance issues.

## 👌 Resolves:
` a: 'a', b: { c: 'c', d: [Object] } }`

## 📦 Impacts:
- mds-logger

## ✅ PR Checklist
- [x] Manually test 
