### PR TITLE
[mds-logger] Verify that defaultOptions is available before use

### DIFF
--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -17,8 +17,11 @@
 import httpContext from 'express-http-context'
 import { inspect } from 'util'
 
-// Set the inspector depth to infinity. To the moooooooon 🚀 🌕
-inspect.defaultOptions.depth = null
+// Verify that defaultOptions is available (not available on non-nodejs platforms)
+if (inspect?.defaultOptions) {
+  // Set the inspector depth to infinity. To the moooooooon 🚀 🌕
+  inspect.defaultOptions.depth = null
+}
 
 const logger: Pick<Console, 'info' | 'warn' | 'error'> = console
 type LogLevel = keyof typeof logger


### PR DESCRIPTION
## 📚 Purpose/Resolves
Resolves an issue with the latest version of mds-logger that prevented it working in non-nodejs environments.

## 📦 Impacts:
- mds-logger

