### PR TITLE
[mds-agency] [mds-schema-validators] Relax TripMetadata schema (for now), add HTTP PATCH support

### DIFF
--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -150,7 +150,7 @@ function api(app: express.Express): express.Express {
 
   /* Experimental Endpoint */
   app.post(pathPrefix('/trips'), writeTripMetadata)
-
+  app.patch(pathPrefix('/trips'), writeTripMetadata)
   return app
 }
 

--- a/packages/mds-schema-validators/trip-metadata-validators.ts
+++ b/packages/mds-schema-validators/trip-metadata-validators.ts
@@ -11,7 +11,7 @@ import {
 } from './validators'
 
 /**
- * Note: This schema is still very-much-so in flux
+ * Note: This schema is still very-much-so in flux (especially dependent on mode), so we're keeping this minimal for now. If you see any required bits commented out, this is due to wanting to retain some previous iterations for posterity.
  */
 export const tripMetadataSchema = Joi.object().keys({
   trip_id: uuidSchema.required(),

--- a/packages/mds-schema-validators/trip-metadata-validators.ts
+++ b/packages/mds-schema-validators/trip-metadata-validators.ts
@@ -10,6 +10,9 @@ import {
   stringSchema
 } from './validators'
 
+/**
+ * Note: This schema is still very-much-so in flux
+ */
 export const tripMetadataSchema = Joi.object().keys({
   trip_id: uuidSchema.required(),
   provider_id: uuidSchema.required(),
@@ -19,10 +22,10 @@ export const tripMetadataSchema = Joi.object().keys({
       lat: numberSchema.required()
     })
     .optional(),
-  reservation_time: timestampSchema.required(),
-  reservation_method: stringSchema.valid(...RESERVATION_METHODS).required(),
-  reservation_type: stringSchema.valid(...RESERVATION_TYPES).required(),
-  quoted_trip_start_time: timestampSchema.required(),
+  reservation_time: timestampSchema.optional() /*.required()*/,
+  reservation_method: stringSchema.valid(...RESERVATION_METHODS).optional() /*.required()*/,
+  reservation_type: stringSchema.valid(...RESERVATION_TYPES).optional() /*.required()*/,
+  quoted_trip_start_time: timestampSchema.optional() /*.required()*/,
   dispatch_time: timestampSchema.optional(),
   trip_start_time: timestampSchema.optional(),
   trip_end_time: timestampSchema.optional(),
@@ -43,6 +46,6 @@ export const tripMetadataSchema = Joi.object().keys({
 })
 
 export const validateTripMetadata = (metadata: unknown) => {
-  if (ValidateSchema<TripMetadata>(metadata, tripMetadataSchema, { assert: true, allowUnknown: false })) return metadata
+  if (ValidateSchema<TripMetadata>(metadata, tripMetadataSchema, { assert: true, allowUnknown: true })) return metadata
   throw new RuntimeError('This should never happen')
 }


### PR DESCRIPTION
## 📚 Purpose
Relaxes the TripMetadata schema a bit, and adds HTTP PATCH support (albeit, doing the exact same thing as POST, for now). I kept the traditionally required properties commented out for posterity.

## 👌 Resolves:
TOO MUCH STRICTNESS!

## 📦 Impacts:
- mds-agency
- mds-schema-validators

