### PR TITLE
update image build command with correct package name

### DIFF
--- a/container-images/mds-compliance-api/package.json
+++ b/container-images/mds-compliance-api/package.json
@@ -17,8 +17,8 @@
     "bundle:development": "webpack --mode=development --env npm_package_name=${npm_package_name} --env npm_package_version=${npm_package_version}",
     "bundle:production": "webpack --mode=production --env npm_package_name=${npm_package_name} --env npm_package_version=${npm_package_version}",
     "image": "pnpm image:production",
-    "image:development": "pnpm bundle:development && ../../bin/build-helper buildImage mds-compliance:${npm_package_version}",
-    "image:production": "pnpm bundle:production && ../../bin/build-helper buildImage mds-compliance:${npm_package_version}"
+    "image:development": "pnpm bundle:development && ../../bin/build-helper buildImage mds-compliance-api:${npm_package_version}",
+    "image:production": "pnpm bundle:production && ../../bin/build-helper buildImage mds-compliance-api:${npm_package_version}"
   },
   "dependencies": {
     "@mds-core/mds-compliance-api": "0.1.0",


### PR DESCRIPTION
Fixes `mds-compliance-api` container image being built with old incorrect name "mds-compliance".