### PR TITLE
vehicle telemetry now handles missing data from post-body

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -377,6 +377,13 @@ export const submitVehicleTelemetry = async (
     })
     return
   }
+  if (!data) {
+    res.status(400).send({
+      error: 'bad_param',
+      error_description: 'Missing data from post-body'
+    })
+    return
+  }
   const name = providerName(provider_id)
   const failures: string[] = []
   const valid: Telemetry[] = []

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -1131,6 +1131,21 @@ describe('Tests API', () => {
         done(err)
       })
   })
+  it('verifies post telemetry handling of empty data payload', done => {
+    request
+      .post(pathPrefix('/vehicles/telemetry'))
+      .set('Authorization', AUTH)
+      .send({})
+      .expect(400)
+      .end((err, result) => {
+        if (err) {
+          log('telemetry err', err)
+        } else {
+          test.string(result.body.error_description).contains('Missing data from post-body')
+        }
+        done(err)
+      })
+  })
   it('verifies posting the same telemetry does not break things', done => {
     request
       .post(pathPrefix('/vehicles/telemetry'))

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -46,7 +46,7 @@ export type AgencyApiGetVehicleByIdRequest = AgencyApiRequest & ApiRequestParams
 export type AgencyApiGetVehiclesByProviderRequest = AgencyApiRequest
 export type AgencyApiUpdateVehicleRequest = AgencyApiRequest<Device> & ApiRequestParams<'device_id'>
 export type AgencyApiSubmitVehicleEventRequest = AgencyApiRequest<VehicleEvent> & ApiRequestParams<'device_id'>
-export type AgencyApiSubmitVehicleTelemetryRequest = AgencyApiRequest<{ data: Telemetry[] }>
+export type AgencyApiSubmitVehicleTelemetryRequest = AgencyApiRequest<{ data?: Telemetry[] }>
 export type AgencyApiPostTripMetadataRequest = AgencyApiRequest<TripMetadata>
 export type AgencyApiAccessTokenScopes = 'admin:all' | 'vehicles:read'
 


### PR DESCRIPTION
## 📚 Purpose
*[mds-agency would crash when `{data:}` was missing from post body]*

## 📦 Impacts:
*[mds-agency]*
