### PR TITLE
gps optional attributes when null should be ignored

### DIFF
--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -74,7 +74,10 @@ const TEST_TELEMETRY = {
     lng: -121.8863,
     speed: 0,
     hdop: 1,
-    heading: 180
+    heading: 180,
+    accuracy: null,
+    altitude: null,
+    charge: null
   },
   charge: 0.5,
   timestamp: now()
@@ -1125,6 +1128,7 @@ describe('Tests API', () => {
       .end((err, result) => {
         if (err) {
           log('telemetry err', err)
+          log('telemetry res', result)
         } else {
           // log('telemetry result', result)
         }

--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -282,19 +282,20 @@ export function badTelemetry(telemetry: Telemetry | null | undefined): ErrorObje
       error_description: `invalid lng ${lng}`
     }
   }
-  if (altitude !== undefined && !isFloat(altitude)) {
+  if (altitude !== undefined && altitude !== null && !isFloat(altitude)) {
     return {
       error: 'bad_param',
       error_description: `invalid altitude ${altitude}`
     }
   }
-  if (accuracy !== undefined && !isFloat(accuracy)) {
+
+  if (accuracy !== undefined && accuracy !== null && !isFloat(accuracy)) {
     return {
       error: 'bad_param',
       error_description: `invalid accuracy ${accuracy}`
     }
   }
-  if (speed !== undefined && !isFloat(speed)) {
+  if (speed !== undefined && speed !== null && !isFloat(speed)) {
     return {
       error: 'bad_param',
       error_description: `invalid speed ${speed}`
@@ -306,7 +307,7 @@ export function badTelemetry(telemetry: Telemetry | null | undefined): ErrorObje
       error_description: `invalid satellites ${satellites}`
     }
   }
-  if (charge !== undefined && !isPct(charge)) {
+  if (charge !== undefined && charge !== null && !isPct(charge)) {
     return {
       error: 'bad_param',
       error_description: `invalid charge ${charge}`


### PR DESCRIPTION
## 📚 Purpose
*[telemetry gps validation should ignore optional attributes when values are null]*

## 📦 Impacts:
*[mds-agency]*
