### PR TITLE
[mds-agency] Remove known provider_id check

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "images": "pnpm run:concurrent image",
     "preinstall": "npx check-node-version --package && npx only-allow pnpm && pnpm i -g pnpm",
     "lint": "pnpm lint:audit && pnpm lint:prettier '**/package.json' && pnpm lint:eslint '**/!(*.spec).ts'",
-    "lint:audit": "pnpm-ci audit -i 1556,1561,1677 --strict",
+    "lint:audit": "pnpm-ci audit -i 1556,1561 --strict",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-path .eslintignore",
     "lint:prettier": "prettier --check",
     "prepare": "husky install",

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -17,7 +17,6 @@
 import express from 'express'
 
 import logger from '@mds-core/mds-logger'
-import { isProviderId } from '@mds-core/mds-providers'
 import { isUUID, pathPrefix } from '@mds-core/mds-utils'
 import { checkAccess, AccessTokenScopeValidator } from '@mds-core/mds-api-server'
 import { AgencyApiRequest, AgencyApiResponse, AgencyApiAccessTokenScopes } from './types'
@@ -57,13 +56,6 @@ function api(app: express.Express): express.Express {
             return res.status(400).send({
               error: 'authentication_error',
               error_description: `invalid provider_id ${provider_id} is not a UUID`
-            })
-          }
-
-          if (!isProviderId(provider_id)) {
-            return res.status(400).send({
-              error: 'authentication_error',
-              error_description: `invalid provider_id ${provider_id} is not a known provider`
             })
           }
 

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -1363,6 +1363,15 @@ describe('Tests API', () => {
     test.assert(JSON.stringify(result.body.prev_events) === JSON.stringify(['decommissioned']))
   })
 
+  it('verifies can make request for foreign provider_id', async () => {
+    const provider_id = uuid()
+    const AUTH = `basic ${Buffer.from(`${provider_id}|${PROVIDER_SCOPES}`).toString('base64')}`
+
+    const [device] = makeDevices(1, now(), provider_id)
+
+    await request.post(pathPrefix('/vehicles')).set('Authorization', AUTH).send(device).expect(201)
+  })
+
   it('get multiple devices endpoint has vehicle status default to `inactive` if event is missing for a device', async () => {
     const result = await request.get(pathPrefix(`/vehicles/`)).set('Authorization', AUTH).expect(200)
     const ids = result.body.vehicles.map((device: any) => device.device_id)

--- a/packages/mds-policy/api.ts
+++ b/packages/mds-policy/api.ts
@@ -15,7 +15,6 @@
  */
 
 import express, { NextFunction } from 'express'
-// import { isProviderId, providerName } from '@mds-core/mds-providers'
 import { PolicyTypeInfo, UUID } from '@mds-core/mds-types'
 import db from '@mds-core/mds-db'
 import { now, pathPrefix, NotFoundError, isUUID, BadParamsError, ServerError } from '@mds-core/mds-utils'
@@ -23,8 +22,6 @@ import logger from '@mds-core/mds-logger'
 import { parseRequest } from '@mds-core/mds-api-helpers'
 import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
 import {
-  PolicyApiRequest,
-  PolicyApiResponse,
   PolicyApiGetPoliciesResponse,
   PolicyApiGetPolicyResponse,
   PolicyApiGetPoliciesRequest,
@@ -34,43 +31,6 @@ import { PolicyApiVersionMiddleware } from './middleware'
 
 function api<PInfo extends PolicyTypeInfo>(app: express.Express): express.Express {
   app.use(PolicyApiVersionMiddleware)
-  /**
-   * Policy-specific middleware to extract provider_id into locals, do some logging, etc.
-   */
-  app.use(async (req: PolicyApiRequest, res: PolicyApiResponse, next: express.NextFunction) => {
-    res.header('Access-Control-Allow-Origin', '*')
-    try {
-      // verify presence of provider_id
-      if (!(req.path.includes('/health') || req.path.includes('/schema/policy'))) {
-        if (res.locals.claims) {
-          /* TEMPORARILY REMOVING SO NON-PROVIDERS CAN ACCESS POLICY API */
-          // const { provider_id } = res.locals.claims
-          // /* istanbul ignore next */
-          // if (!provider_id) {
-          //   logger.warn('Missing provider_id in', req.originalUrl)
-          //   return res.status(400).send({ result: 'missing provider_id' })
-          // }
-          // /* istanbul ignore next */
-          // if (!isUUID(provider_id)) {
-          //   logger.warn(req.originalUrl, 'bogus provider_id', provider_id)
-          //   return res.status(400).send({ result: `invalid provider_id ${provider_id} is not a UUID` })
-          // }
-          // if (!isProviderId(provider_id)) {
-          //   return res.status(400).send({
-          //     result: `invalid provider_id ${provider_id} is not a known provider`
-          //   })
-          // }
-          // logger.info(providerName(provider_id), req.method, req.originalUrl)
-        } else {
-          return res.status(401).send({ error: 'Unauthorized' })
-        }
-      }
-    } catch (error) {
-      /* istanbul ignore next */
-      logger.error('request validation fail', { error, originalUrl: req.originalUrl })
-    }
-    next()
-  })
 
   app.get(
     pathPrefix('/policies'),

--- a/packages/mds-providers/index.ts
+++ b/packages/mds-providers/index.ts
@@ -238,11 +238,15 @@ export const providers: Readonly<{ [P in PROVIDER_ID]: Readonly<Provider> }> = O
   })
 })
 
+const isProviderId = (provider_id: unknown): provider_id is PROVIDER_ID => {
+  return typeof provider_id === 'string' && providers[provider_id as PROVIDER_ID] !== undefined
+}
+
 /**
  * convert provider_id to provider name (if available), or a subset of the UUID for humans
  * @param  provider_id
  * @return name or provider_id substring
  */
-export function providerName(provider_id: string): string {
-  return provider_id in providers ? providers[provider_id].provider_name : provider_id
+export const providerName = (provider_id: string): string => {
+  return isProviderId(provider_id) ? providers[provider_id].provider_name : provider_id
 }

--- a/packages/mds-providers/index.ts
+++ b/packages/mds-providers/index.ts
@@ -238,15 +238,11 @@ export const providers: Readonly<{ [P in PROVIDER_ID]: Readonly<Provider> }> = O
   })
 })
 
-export function isProviderId(provider_id: unknown): provider_id is PROVIDER_ID {
-  return typeof provider_id === 'string' && providers[provider_id as PROVIDER_ID] !== undefined
-}
-
 /**
  * convert provider_id to provider name (if available), or a subset of the UUID for humans
  * @param  provider_id
  * @return name or provider_id substring
  */
 export function providerName(provider_id: string): string {
-  return isProviderId(provider_id) ? providers[provider_id].provider_name : provider_id
+  return provider_id in providers ? providers[provider_id].provider_name : provider_id
 }


### PR DESCRIPTION
## 📚 Purpose
`mds-agency` had middleware which verified that any `provider_id` claims made in the token were considered 'known' providers, meaning they were enumerated within the `mds-providers` package. Because that package really mirrors what is currently considered a Provider by the OMF, and is not considering other modes of transportation, for ease of integration with non-micromobility providers, I have removed the requirement for a `provider_id` check in `mds-agency`. 

## 👌 Resolves:
Some new provider traffic being bounced

## 📦 Impacts:
- mds-agency

