### PR TITLE
[dependencies] Ignore hosted-git-info audit advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "images": "pnpm run:concurrent image",
     "preinstall": "npx check-node-version --package && npx only-allow pnpm && pnpm i -g pnpm",
     "lint": "pnpm lint:audit && pnpm lint:prettier '**/package.json' && pnpm lint:eslint '**/!(*.spec).ts'",
-    "lint:audit": "pnpm-ci audit -i 1556,1561 --strict",
+    "lint:audit": "pnpm-ci audit -i 1556,1561,1677 --strict",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-path .eslintignore",
     "lint:prettier": "prettier --check",
     "prepare": "husky install",


### PR DESCRIPTION
## 📚 Purpose
There was a vulnerability in `hosted-git-info` posted yesterday, and this package is a downstream dependency of some of our eslint plugins. It appears that the version which we use is actually up to date, though, according to [this GitHub issue](https://github.com/benmosher/eslint-plugin-import/issues/2046), but they have yet to update the CVE. This PR ignores the advisory temporarily so CI/CD can pass.

## 👌 Resolves:
- failing CI/CD

## 📦 Impacts:
n/a

