### PR TITLE
[mds-stream] Rework NATS Cb Signature

### DIFF
--- a/packages/mds-stream/nats/codecs.ts
+++ b/packages/mds-stream/nats/codecs.ts
@@ -6,7 +6,7 @@ import logger from '@mds-core/mds-logger'
  */
 export const { decode: decodeAsUInt8Array, encode: encodeAsUInt8Array } = StringCodec()
 
-export type DecodedNatsMsg = Omit<Msg, 'data'> & { data: string }
+export type DecodedNatsMsg = { data: string } & Pick<Msg, 'subject'>
 
 export type NatsProcessorFn = (message: DecodedNatsMsg) => void
 
@@ -20,8 +20,8 @@ export const natsCbWrapper: (processor: NatsProcessorFn) => SubOpts<Msg>['callba
     logger.error('NATS Error', { err })
     return
   }
-  const { data, ...msgMeta } = msg
+  const { data, subject } = msg
 
-  const decodedMsg = { ...msgMeta, data: decodeAsUInt8Array(data) }
+  const decodedMsg = { data: decodeAsUInt8Array(data), subject }
   processor(decodedMsg)
 }


### PR DESCRIPTION
## 📚 Purpose
It seems like the `nats.js` library uses JS Getters for NATS messages, which results in issues with how we're trying to inherit all properties from a `Msg` and override `data`. Attempting to access vanilla `Msg` properties, such as `subject` from within a `processor` function results in an inability to access properties that appear to exist given the typedef. This PR makes it so we only pass `subject` and a decoded `data` property to our processors, so that we can access `subject` using the getter prior to the object being unbound. Gotta love it when the types lie to you. 

## 👌 Resolves:
Being unable to access `subject` from processors.

## 📦 Impacts:
- mds-stream