### PR TITLE
[mds-api-server] [mds-logger] Add Debug Express Logger

### DIFF
--- a/packages/mds-api-server/middleware/request-logging.ts
+++ b/packages/mds-api-server/middleware/request-logging.ts
@@ -62,5 +62,17 @@ export const RequestLoggingMiddleware = ({
       httpContext.set('x-request-id', xRequestId)
     }
     return next()
+  },
+  (req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
+    const { REQUEST_DEBUG } = process.env
+
+    if (REQUEST_DEBUG === 'true') {
+      const { body, params, query } = req
+      logger.debug('REQUEST_DEBUG::BODY', { body })
+      logger.debug('REQUEST_DEBUG::PARAMS', { params })
+      logger.debug('REQUEST_DEBUG::QUERY', { query })
+    }
+
+    return next()
   }
 ]

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -23,7 +23,7 @@ if (inspect?.defaultOptions) {
   inspect.defaultOptions.depth = null
 }
 
-const logger: Pick<Console, 'info' | 'warn' | 'error'> = console
+const logger: Pick<Console, 'info' | 'warn' | 'error' | 'debug'> = console
 type LogLevel = keyof typeof logger
 
 const redact = (arg: string | Record<string, unknown> | Error | undefined) => {
@@ -65,6 +65,7 @@ const log = (level: LogLevel) => (
 
 export default {
   log: (level: LogLevel, ...args: Parameters<ReturnType<typeof log>>) => log(level)(...args),
+  debug: log('debug'),
   info: log('info'),
   warn: log('warn'),
   error: log('error')


### PR DESCRIPTION
## 📚 Purpose
Sometimes when triaging issues, it's useful to see request bodies, parameters, queries, etc... This PR adds a new middleware which can be toggled by a `REQUEST_DEBUG` env var.

## 📦 Impacts:
- all APIs

