### PR TITLE
[mds-types] Make MDS TripMetadata extensible

### DIFF
--- a/packages/mds-types/trip.ts
+++ b/packages/mds-types/trip.ts
@@ -28,10 +28,10 @@ export interface TripsStats {
 export type TripMetadata<T extends any = {}> = {
   trip_id: UUID
   provider_id: UUID
-  reservation_time: Timestamp
-  reservation_method: RESERVATION_METHOD
-  reservation_type: RESERVATION_TYPE
-  quoted_trip_start_time: Timestamp
+  reservation_time?: Timestamp
+  reservation_method?: RESERVATION_METHOD
+  reservation_type?: RESERVATION_TYPE
+  quoted_trip_start_time?: Timestamp
   requested_trip_start_location?: Pick<GpsData, 'lat' | 'lng'>
   cancellation_reason?: string
   dispatch_time?: Timestamp

--- a/packages/mds-types/trip.ts
+++ b/packages/mds-types/trip.ts
@@ -25,7 +25,7 @@ export interface TripsStats {
   mystery_examples: { [key: string]: UUID[] }
 }
 
-export type TripMetadata<T extends any = {}> = {
+export type TripMetadata<T = {}> = {
   trip_id: UUID
   provider_id: UUID
   reservation_time?: Timestamp

--- a/packages/mds-types/trip.ts
+++ b/packages/mds-types/trip.ts
@@ -25,7 +25,7 @@ export interface TripsStats {
   mystery_examples: { [key: string]: UUID[] }
 }
 
-export interface TripMetadata {
+export type TripMetadata<T extends any = {}> = {
   trip_id: UUID
   provider_id: UUID
   reservation_time: Timestamp
@@ -46,4 +46,4 @@ export interface TripMetadata {
     currency?: string
     payment_methods?: PAYMENT_METHOD[]
   }
-}
+} & T


### PR DESCRIPTION
## 📚 Purpose
This PR allows for foreign-key type injection to the TripMetadata type, in addition to some base required properties. It also sets many properties which were previously required to Optional.

## 📦 Impacts:
- mds-types

