### PR TITLE
[mds-types] Remove maintenance from TNC State Machine

### DIFF
--- a/packages/mds-types/event.ts
+++ b/packages/mds-types/event.ts
@@ -71,7 +71,6 @@ export const TNC_VEHICLE_EVENT = [
   'driver_cancellation',
   'enter_jurisdiction',
   'leave_jurisdiction',
-  'maintenance',
   'passenger_cancellation',
   'provider_cancellation',
   'reservation_start',

--- a/packages/mds-types/event_states_maps.ts
+++ b/packages/mds-types/event_states_maps.ts
@@ -66,7 +66,6 @@ export const TNC_EVENT_STATES_MAP: {
   driver_cancellation: ['available', 'on_trip', 'reserved', 'stopped'],
   enter_jurisdiction: ['available', 'reserved', 'on_trip', 'non_operational'],
   leave_jurisdiction: ['elsewhere'],
-  maintenance: ['available', 'non_operational'],
   passenger_cancellation: ['available', 'on_trip', 'reserved', 'stopped'],
   provider_cancellation: ['available', 'on_trip', 'reserved', 'stopped'],
   reservation_start: ['reserved'],


### PR DESCRIPTION
## 📚 Purpose
Removes a bad copy-pasta from the initial implementation of the TNC State Machine, and brings it into conformance with the MDS Standard.

## 👌 Resolves:
- spec/code discontinuity

## 📦 Impacts:
- mds-types

