### PR TITLE
Allow randomElement function to operate on const arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "images": "pnpm run:concurrent image",
     "preinstall": "npx check-node-version --package && npx only-allow pnpm && pnpm i -g pnpm",
     "lint": "pnpm lint:audit && pnpm lint:prettier '**/package.json' && pnpm lint:eslint '**/!(*.spec).ts'",
-    "lint:audit": "pnpm-ci audit -i 1556,1561 --strict",
+    "lint:audit": "pnpm-ci audit -i 1556,1561,1748 --strict",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-path .eslintignore",
     "lint:prettier": "prettier --check",
     "prepare": "husky install",

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -164,7 +164,7 @@ function rangeRandomInt(min: number, max?: number) {
   return Math.floor(rangeRandom(min, max))
 }
 
-function randomElement<T>(list: T[]) {
+function randomElement<T>(list: T[] | readonly T[]) {
   return list[rangeRandomInt(list.length)]
 }
 

--- a/packages/mds-utils/utils.ts
+++ b/packages/mds-utils/utils.ts
@@ -168,14 +168,14 @@ function randomElement<T>(list: T[] | readonly T[]) {
   return list[rangeRandomInt(list.length)]
 }
 
-function head<T>(list: T[]) {
+function head<T>(list: T[] | readonly T[]) {
   if (!Array.isArray(list)) {
     throw new Error('not a list')
   }
   return list[0]
 }
 
-function tail<T>(list: T[]) {
+function tail<T>(list: T[] | readonly T[]) {
   if (!Array.isArray(list)) {
     throw new Error('not a list')
   }


### PR DESCRIPTION
## 📚 Purpose
This function was written before the advent of const assertions in TypeScript. Allow the function to work with readonly arrays.

## Before
<img width="879" alt="Screen Shot 2021-06-03 at 9 39 01 AM" src="https://user-images.githubusercontent.com/3439869/120655151-61131380-c450-11eb-8518-a4ccfaf352b5.png">

## After
<img width="513" alt="Screen Shot 2021-06-03 at 9 39 31 AM" src="https://user-images.githubusercontent.com/3439869/120655289-856ef000-c450-11eb-8402-c05555b81ed7.png">

## 📦 Impacts:
- mds-utils