### PR TITLE
Ignore advisory 1753 from Lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "images": "pnpm run:concurrent image",
     "preinstall": "npx check-node-version --package && npx only-allow pnpm && pnpm i -g pnpm",
     "lint": "pnpm lint:audit && pnpm lint:prettier '**/package.json' && pnpm lint:eslint '**/!(*.spec).ts'",
-    "lint:audit": "pnpm-ci audit -i 1556,1561,1748 --strict",
+    "lint:audit": "pnpm-ci audit -i 1556,1561,1748,1753 --strict",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-path .eslintignore",
     "lint:prettier": "prettier --check",
     "prepare": "husky install",


### PR DESCRIPTION
## 📚 Purpose
Ignores [Advisory 1753](https://www.npmjs.com/advisories/1753) which there is a Github issue to fix in [lerna](https://github.com/lerna/lerna/issues/2925).

## 👌 Resolves
- CI/CD failure due to advisory


