### PR TITLE
Fix duplicate values in VEHICLE_EVENTS_v1_1_0 and VEHICLE_STATES_v1_1_0

### DIFF
--- a/packages/mds-types/event.ts
+++ b/packages/mds-types/event.ts
@@ -101,11 +101,11 @@ export const TNC_TRIP_EXIT_EVENTS: TNC_VEHICLE_EVENT[] = [
   'driver_cancellation'
 ]
 
-export const VEHICLE_EVENTS_v1_1_0 = [
+export const VEHICLE_EVENTS_v1_1_0 = [...new Set([
   ...MICRO_MOBILITY_VEHICLE_EVENTS,
   ...TAXI_VEHICLE_EVENTS,
   ...TNC_VEHICLE_EVENT
-] as const
+])] as const
 export type VEHICLE_EVENT_v1_1_0 = typeof VEHICLE_EVENTS[number]
 
 export const VEHICLE_EVENTS = VEHICLE_EVENTS_v1_1_0

--- a/packages/mds-types/vehicle/vehicle_states.ts
+++ b/packages/mds-types/vehicle/vehicle_states.ts
@@ -35,11 +35,11 @@ export const TNC_VEHICLE_STATE = <const>[
 ]
 export type TNC_VEHICLE_STATE = typeof TNC_VEHICLE_STATE[number]
 
-export const VEHICLE_STATES_v1_1_0 = [
+export const VEHICLE_STATES_v1_1_0 = [...new Set([
   ...MICRO_MOBILITY_VEHICLE_STATES_v1_1_0,
   ...TAXI_VEHICLE_STATES,
   ...TNC_VEHICLE_STATE
-] as const
+])] as const
 export type VEHICLE_STATE_v1_1_0 = typeof VEHICLE_STATES_v1_1_0[number]
 
 export const VEHICLE_STATES = VEHICLE_STATES_v1_1_0


### PR DESCRIPTION
## 📚 Purpose
I noticed that mds-types@0.1.26-lacuna-tech.31 contains vehicle event and state consts with duplicated values, which was causing my AJV to complain.

## 📦 Impacts:
* mds-types