### PR TITLE
Data pipeline needs trip metadata recorded property for watermarking.

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -514,7 +514,7 @@ export const writeTripMetadata = async (
   try {
     const { provider_id } = res.locals
     /* TODO Add better validation once trip metadata proposal is solidified */
-    const tripMetadata = validateTripMetadata({ ...req.body, provider_id })
+    const tripMetadata = { ...validateTripMetadata({ ...req.body, provider_id }), recorded: Date.now() }
     await Promise.all([cache.writeTripMetadata(tripMetadata), stream.writeTripMetadata(tripMetadata)])
 
     return res.status(201).send(tripMetadata)


### PR DESCRIPTION
@avatarneil Evan requires that the `recorded` property be present for watermarking to function properly. I don't see any issues with just appending it here. Thoughts?