### PR TITLE
[mds-agency] Remove TripMetadata cache writes

### DIFF
--- a/packages/mds-agency-cache/index.ts
+++ b/packages/mds-agency-cache/index.ts
@@ -27,7 +27,7 @@ import {
   tail,
   setEmptyArraysToUndefined
 } from '@mds-core/mds-utils'
-import { UUID, Timestamp, Device, VehicleEvent, Telemetry, BoundingBox, TripMetadata } from '@mds-core/mds-types'
+import { UUID, Timestamp, Device, VehicleEvent, Telemetry, BoundingBox } from '@mds-core/mds-types'
 import { RedisCache } from '@mds-core/mds-cache'
 
 import { parseTelemetry, parseEvent, parseDevice, parseCachedItem } from './unflatteners'
@@ -157,17 +157,6 @@ async function hwrite(suffix: string, item: CacheReadDeviceResult | Telemetry | 
   await Promise.all(keys.map(k => client.hset(k, hmap)))
 
   return updateVehicleList(device_id)
-}
-
-const writeTripMetadata = async (metadata: TripMetadata) => {
-  try {
-    const { trip_id } = metadata
-
-    return client.set(decorateKey(`trip:${trip_id}:metadata`), JSON.stringify(metadata))
-  } catch (err) {
-    logger.error('Failed to write TripMetadata to cache', err)
-    throw err
-  }
 }
 
 // put basics of device in the cache
@@ -562,6 +551,5 @@ export default {
   readKeys,
   wipeDevice,
   updateVehicleList,
-  cleanup,
-  writeTripMetadata
+  cleanup
 }

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -515,7 +515,7 @@ export const writeTripMetadata = async (
     const { provider_id } = res.locals
     /* TODO Add better validation once trip metadata proposal is solidified */
     const tripMetadata = { ...validateTripMetadata({ ...req.body, provider_id }), recorded: Date.now() }
-    await Promise.all([cache.writeTripMetadata(tripMetadata), stream.writeTripMetadata(tripMetadata)])
+    await stream.writeTripMetadata(tripMetadata)
 
     return res.status(201).send(tripMetadata)
   } catch (error) {


### PR DESCRIPTION
## 📚 Purpose
There's no need to persist trip metadata to the redis cache, and in fact, this could blow up the number of entries in the redis cache over time. This PR makes it so we no longer persist TripMetadata to the redis cache, and solely write it to the stream.

## 📦 Impacts:
- mds-agency

