### PR TITLE
[mds-agency] Switch Device validation to AJV

### DIFF
--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -21,6 +21,7 @@
     "@mds-core/mds-api-helpers": "0.1.28",
     "@mds-core/mds-api-server": "0.1.28",
     "@mds-core/mds-db": "0.1.28",
+    "@mds-core/mds-ingest-service": "0.1.2",
     "@mds-core/mds-logger": "0.2.2",
     "@mds-core/mds-providers": "0.1.28",
     "@mds-core/mds-schema-validators": "0.1.4",
@@ -29,6 +30,7 @@
     "@mds-core/mds-types": "0.1.25",
     "@mds-core/mds-utils": "0.1.28",
     "@types/express": "4.17.12",
+    "ajv": "8.6.0",
     "express": "4.17.1"
   },
   "devDependencies": {

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -131,7 +131,7 @@ export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res:
     }
 
     logger.error('register vehicle failed:', { err: error, providerName: providerName(res.locals.provider_id) })
-    res.status(500).send(agencyServerError)
+    return res.status(500).send(agencyServerError)
   }
 }
 

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -59,7 +59,7 @@ import {
   badTelemetry,
   readPayload,
   computeCompositeVehicleData,
-  agencyErrorParser
+  agencyValidationErrorParser
 } from './utils'
 import { isError } from '@mds-core/mds-service-helpers'
 import { validateDeviceDomainModel } from '@mds-core/mds-ingest-service'
@@ -76,8 +76,6 @@ export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res:
     // TODO: Transform 0.4.1 -> 1.0.0
   }
 
-  // writing to the DB is the crucial part.  other failures should be noted as bugs but tolerated
-  // and fixed later.
   try {
     const {
       accessibility_options,
@@ -121,7 +119,7 @@ export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res:
     return res.status(201).send({})
   } catch (error) {
     if (error instanceof ValidationError) {
-      const parsedError = agencyErrorParser(error)
+      const parsedError = agencyValidationErrorParser(error)
       return res.status(400).send(parsedError)
     }
 

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -16,7 +16,7 @@
 
 import logger from '@mds-core/mds-logger'
 import { isUUID, now, ValidationError, normalizeToArray, ServerError, NotFoundError } from '@mds-core/mds-utils'
-import { isValidDevice, validateEvent, isValidTelemetry, validateTripMetadata } from '@mds-core/mds-schema-validators'
+import { validateEvent, isValidTelemetry, validateTripMetadata } from '@mds-core/mds-schema-validators'
 import db from '@mds-core/mds-db'
 import cache from '@mds-core/mds-agency-cache'
 import stream from '@mds-core/mds-stream'
@@ -52,16 +52,17 @@ import {
   AgencyApiRegisterVehicleRequest
 } from './types'
 import {
-  badDevice,
   getVehicles,
   lower,
   writeTelemetry,
   badEvent,
   badTelemetry,
   readPayload,
-  computeCompositeVehicleData
+  computeCompositeVehicleData,
+  agencyErrorParser
 } from './utils'
 import { isError } from '@mds-core/mds-service-helpers'
+import { validateDeviceDomainModel } from '@mds-core/mds-ingest-service'
 
 const agencyServerError = { error: 'server_error', error_description: 'Unknown server error' }
 
@@ -74,73 +75,65 @@ export const registerVehicle = async (req: AgencyApiRegisterVehicleRequest, res:
   if (!version || version === '0.4.1') {
     // TODO: Transform 0.4.1 -> 1.0.0
   }
-  // const { device_id, vehicle_id, type, propulsion, year, mfgr, model } = body
-  const {
-    accessibility_options = [],
-    device_id,
-    vehicle_id,
-    vehicle_type,
-    propulsion_types,
-    year,
-    mfgr,
-    modality = 'micromobility',
-    model
-  } = body
-
-  const status: VEHICLE_STATE = 'removed'
-
-  const device = {
-    accessibility_options,
-    provider_id,
-    device_id,
-    vehicle_id,
-    vehicle_type,
-    propulsion_types,
-    year,
-    mfgr,
-    modality,
-    model,
-    recorded,
-    status
-  }
-
-  try {
-    isValidDevice(device)
-  } catch (err) {
-    logger.info(
-      `Non-critical prototype Device ValidationError for ${providerName(provider_id)}. Error: ${JSON.stringify(err)}`
-    )
-  }
-
-  const failure = badDevice(device)
-  if (failure) {
-    return res.status(400).send(failure)
-  }
 
   // writing to the DB is the crucial part.  other failures should be noted as bugs but tolerated
   // and fixed later.
   try {
+    const {
+      accessibility_options,
+      device_id,
+      vehicle_id,
+      vehicle_type,
+      propulsion_types,
+      year,
+      mfgr,
+      modality,
+      model
+    } = body
+
+    const status: VEHICLE_STATE = 'removed'
+
+    const unvalidatedDevice = {
+      accessibility_options,
+      provider_id,
+      device_id,
+      vehicle_id,
+      vehicle_type,
+      propulsion_types,
+      year,
+      mfgr,
+      modality,
+      model,
+      recorded,
+      status
+    }
+    const device = validateDeviceDomainModel(unvalidatedDevice)
+
+    // DB Write is critical, and failures to write to the cache/stream should be considered non-critical (though they are likely indicative of a bug).
     await db.writeDevice(device)
     try {
       await Promise.all([cache.writeDevice(device), stream.writeDevice(device)])
-    } catch (err) {
-      logger.error('failed to write device stream/cache', err)
+    } catch (error) {
+      logger.error('failed to write device stream/cache', error)
     }
+
     logger.info('new vehicle added', { providerName: providerName(res.locals.provider_id), device })
-    res.status(201).send({})
-  } catch (err) {
-    if (String(err).includes('duplicate')) {
-      res.status(409).send({
+    return res.status(201).send({})
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      const parsedError = agencyErrorParser(error)
+      return res.status(400).send(parsedError)
+    }
+
+    if (String(error).includes('duplicate')) {
+      return res.status(409).send({
         error: 'already_registered',
         error_description: 'A vehicle with this device_id is already registered'
       })
-    } else if (String(err).includes('db')) {
-      logger.error('register vehicle failed:', { err, providerName: providerName(res.locals.provider_id) })
-      res.status(500).send(agencyServerError)
-    } else {
-      logger.error('register vehicle failed:', { err, providerName: providerName(res.locals.provider_id) })
-      res.status(500).send(agencyServerError)
     }
+
+    logger.error('register vehicle failed:', { err: error, providerName: providerName(res.locals.provider_id) })
+    res.status(500).send(agencyServerError)
   }
 }
 

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -213,6 +213,17 @@ describe('Tests API', () => {
       })
   })
   it('verifies post device bad device id', done => {
+    const badDeviceIdErr = {
+      error: 'bad_param',
+      error_description: 'A validation error occurred.',
+      error_details: [
+        {
+          property: 'device_id',
+          message: 'must match format "uuid"'
+        }
+      ]
+    }
+
     const badVehicle = deepCopy(TEST_BICYCLE)
     badVehicle.device_id = 'bad'
     request
@@ -221,8 +232,7 @@ describe('Tests API', () => {
       .send(badVehicle)
       .expect(400)
       .end((err, result) => {
-        // log('err', err, 'body', result.body)
-        test.string(result.body.error_description).contains('not a UUID')
+        test.object(result.body).is(badDeviceIdErr)
         test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })
@@ -256,7 +266,17 @@ describe('Tests API', () => {
       })
   })
 
-  it('verifies post device bad propulsion', done => {
+  it('verifies post device bad propulsion_types', done => {
+    const badPropulsionErr = {
+      error: 'bad_param',
+      error_description: 'A validation error occurred.',
+      error_details: [
+        {
+          property: 'propulsion_types',
+          message: 'must be equal to one of the allowed values'
+        }
+      ]
+    }
     const badVehicle = deepCopy(TEST_BICYCLE)
     // @ts-ignore: Spoofing garbage data
     badVehicle.propulsion_types = ['hamster']
@@ -267,8 +287,7 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         // log('err', err, 'body', result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid')
+        test.object(result.body).is(badPropulsionErr)
         test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })
@@ -287,6 +306,17 @@ describe('Tests API', () => {
   //         })
   // })
   it('verifies post device bad year', done => {
+    const badYearErr = {
+      error: 'bad_param',
+      error_description: 'A validation error occurred.',
+      error_details: [
+        {
+          property: 'year',
+          message: 'must be integer'
+        }
+      ]
+    }
+
     const badVehicle = deepCopy(TEST_BICYCLE)
     // @ts-ignore: Spoofing garbage data
     badVehicle.year = 'hamster'
@@ -296,25 +326,7 @@ describe('Tests API', () => {
       .send(badVehicle)
       .expect(400)
       .end((err, result) => {
-        // log('err', err, 'body', result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid')
-        test.value(result).hasHeader('content-type', APP_JSON)
-        done(err)
-      })
-  })
-  it('verifies post device out-of-range year', done => {
-    const badVehicle = deepCopy(TEST_BICYCLE)
-    badVehicle.year = 3000
-    request
-      .post(pathPrefix('/vehicles'))
-      .set('Authorization', AUTH)
-      .send(badVehicle)
-      .expect(400)
-      .end((err, result) => {
-        // log('err', err, 'body', result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid')
+        test.object(result.body).is(badYearErr)
         test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })
@@ -335,6 +347,16 @@ describe('Tests API', () => {
       })
   })
   it('verifies post device bad vehicle_type', done => {
+    const badVehicleTypeErr = {
+      error: 'bad_param',
+      error_description: 'A validation error occurred.',
+      error_details: [
+        {
+          property: 'vehicle_type',
+          message: 'must be equal to one of the allowed values'
+        }
+      ]
+    }
     const badVehicle = deepCopy(TEST_BICYCLE)
     // @ts-ignore: Spoofing garbage data
     badVehicle.vehicle_type = 'hamster'
@@ -345,8 +367,7 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         // log('err', err, 'body', result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid')
+        test.object(result.body).is(badVehicleTypeErr)
         test.value(result).hasHeader('content-type', APP_JSON)
         done(err)
       })

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -110,3 +110,9 @@ export type PaginatedVehiclesList = {
   links: { first: string; last: string; prev: string | null; next: string | null }
   vehicles: (Device & { updated?: number | null; telemetry?: Telemetry | null })[]
 }
+
+export type AgencyApiError = {
+  error: 'bad_param' | 'missing_param'
+  error_description: 'A validation error occurred.' | 'A required parameter is missing.'
+  error_details: any
+}

--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -17,7 +17,15 @@
 import express from 'express'
 import { Query } from 'express-serve-static-core'
 
-import { isUUID, isPct, isTimestamp, isFloat, isInsideBoundingBox, areThereCommonElements } from '@mds-core/mds-utils'
+import {
+  isUUID,
+  isPct,
+  isTimestamp,
+  isFloat,
+  isInsideBoundingBox,
+  areThereCommonElements,
+  ValidationError
+} from '@mds-core/mds-utils'
 import stream from '@mds-core/mds-stream'
 import {
   UUID,
@@ -25,12 +33,8 @@ import {
   VehicleEvent,
   Telemetry,
   ErrorObject,
-  VEHICLE_TYPES,
-  PROPULSION_TYPES,
   BoundingBox,
   VEHICLE_STATE,
-  ACCESSIBILITY_OPTIONS,
-  MODALITIES,
   MICRO_MOBILITY_VEHICLE_EVENTS,
   MICRO_MOBILITY_VEHICLE_STATES,
   TAXI_VEHICLE_EVENTS,
@@ -49,104 +53,66 @@ import {
 import db from '@mds-core/mds-db'
 import logger from '@mds-core/mds-logger'
 import cache from '@mds-core/mds-agency-cache'
-import { isArray } from 'util'
-import { VehiclePayload, TelemetryResult, CompositeVehicle, PaginatedVehiclesList } from './types'
+import { VehiclePayload, TelemetryResult, CompositeVehicle, PaginatedVehiclesList, AgencyApiError } from './types'
+import { DefinedError } from 'ajv'
 
-export function badDevice(device: Device): { error: string; error_description: string } | null {
-  if (!device.device_id) {
-    return {
-      error: 'missing_param',
-      error_description: 'missing device_id'
-    }
+/**
+ *
+ * @param error ValidationError to parse
+ * @returns Error formatted in accordance with the [MDS-Agency spec](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/agency#vehicle---register)
+ *
+ * Note: It is assumed that these errors are typically emitted from AJV, and they are parsed accordingly. All non-AJV based validation errors will result in loose error emission.
+ */
+export const agencyErrorParser = (error: ValidationError): AgencyApiError => {
+  // Not the best typeguard in the world, but ¯\_(ツ)_/¯
+  const isAjvErrors = (x: unknown): x is DefinedError[] => {
+    return Array.isArray(x)
   }
-  if (!isUUID(device.device_id)) {
-    return {
-      error: 'bad_param',
-      error_description: `device_id ${device.device_id} is not a UUID`
-    }
-  }
-  // propulsion is a list
-  if (!Array.isArray(device.propulsion_types)) {
-    return {
-      error: 'missing_param',
-      error_description: 'missing propulsion types'
-    }
-  }
-  for (const prop of device.propulsion_types) {
-    if (!PROPULSION_TYPES.includes(prop)) {
-      return {
-        error: 'bad_param',
-        error_description: `invalid propulsion type ${prop}`
-      }
-    }
-  }
-  // if (device.year === undefined) {
-  //     return {
-  //         error: 'missing_param',
-  //         error_description: 'missing integer field "year"'
-  //     }
-  // }
-  if (device.year !== null && device.year !== undefined) {
-    if (!Number.isInteger(device.year)) {
-      return {
-        error: 'bad_param',
-        error_description: `invalid device year ${device.year} is not an integer`
-      }
-    }
-    if (device.year < 1980 || device.year > 2020) {
-      return {
-        error: 'bad_param',
-        error_description: `invalid device year ${device.year} is out of range`
-      }
-    }
-  }
-  if (device.vehicle_type === undefined) {
-    return {
-      error: 'missing_param',
-      error_description: 'missing enum field "type"'
-    }
-  }
-  if (!VEHICLE_TYPES.includes(device.vehicle_type)) {
-    return {
-      error: 'bad_param',
-      error_description: `invalid device type ${device.vehicle_type}`
-    }
-  }
-  if (!Array.isArray(device.accessibility_options)) {
-    return {
-      error: 'missing_param',
-      error_description: 'missing accessibility_options'
-    }
-  }
-  if (device.accessibility_options.length !== 0) {
-    for (const accessibility_option of device.accessibility_options) {
-      if (!ACCESSIBILITY_OPTIONS.includes(accessibility_option)) {
-        return {
-          error: 'bad_param',
-          error_description: `invalid accessibility_option ${accessibility_option} in accessibility_options list`
+
+  const { info } = error
+
+  if (isAjvErrors(info)) {
+    const [{ keyword }] = info
+
+    /**
+     * If the first error we see is a missing property, then only report missing property errors.
+     */
+    if (keyword === 'required') {
+      // See MDS-Agency spec
+      const error = 'missing_param'
+      const error_description = 'A required parameter is missing.'
+
+      // Report all missing properties, ignore other errors
+      const error_details = info.reduce<string[]>((acc, subErr) => {
+        const { params } = subErr
+
+        if ('missingProperty' in params) {
+          const { missingProperty } = params
+          return [...acc, missingProperty]
         }
-      }
+
+        return acc
+      }, [])
+
+      return { error, error_description, error_details }
     }
+
+    // If the error is something other than a missing param error...
+    const error = 'bad_param'
+    const error_description = 'A validation error occurred.'
+    const error_details = info.reduce<{ property: string; message: string | undefined }[]>((acc, subErr) => {
+      const { instancePath, message } = subErr
+
+      const property = instancePath.replace(/\W|[0-9]/g, '')
+
+      return [...acc, { property, message }]
+    }, [])
+
+    return { error, error_description, error_details }
   }
-  if (!MODALITIES.includes(device.modality)) {
-    return {
-      error: 'bad_param',
-      error_description: `invalid modality ${device.modality}`
-    }
-  }
-  // if (device.mfgr === undefined) {
-  //     return {
-  //         error: 'missing_param',
-  //         error_description: 'missing string field "mfgr"'
-  //     }
-  // }
-  // if (device.model === undefined) {
-  //     return {
-  //         error: 'missing_param',
-  //         error_description: 'missing string field "model"'
-  //     }
-  // }
-  return null
+
+  logger.error('agencyErrorParser unmatched error', error)
+  return { error: 'bad_param', error_description: 'A validation error occurred.', error_details: { error } }
 }
 
 export async function getVehicles(
@@ -546,7 +512,7 @@ export function computeCompositeVehicleData(payload: VehiclePayload) {
 }
 
 const normalizeTelemetry = (telemetry: TelemetryResult) => {
-  if (isArray(telemetry)) {
+  if (Array.isArray(telemetry)) {
     return telemetry[0]
   }
   return telemetry

--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -63,7 +63,7 @@ import { DefinedError } from 'ajv'
  *
  * Note: It is assumed that these errors are typically emitted from AJV, and they are parsed accordingly. All non-AJV based validation errors will result in loose error emission.
  */
-export const agencyErrorParser = (error: ValidationError): AgencyApiError => {
+export const agencyValidationErrorParser = (error: ValidationError): AgencyApiError => {
   // Not the best typeguard in the world, but ¯\_(ツ)_/¯
   const isAjvErrors = (x: unknown): x is DefinedError[] => {
     return Array.isArray(x)

--- a/packages/mds-db/devices.ts
+++ b/packages/mds-db/devices.ts
@@ -111,8 +111,7 @@ export async function readDeviceList(device_ids: UUID[]): Promise<Recorded<Devic
   return result.rows
 }
 
-export async function writeDevice(baseDevice: Device): Promise<Recorded<Device>> {
-  const device = { accessibility_options: [], ...baseDevice }
+export async function writeDevice(device: Device): Promise<Recorded<Device>> {
   const client = await getWriteableClient()
   const sql = `INSERT INTO ${schema.TABLE.devices} (${cols_sql(schema.TABLE_COLUMNS.devices)}) VALUES (${vals_sql(
     schema.TABLE_COLUMNS.devices
@@ -122,7 +121,7 @@ export async function writeDevice(baseDevice: Device): Promise<Recorded<Device>>
   const {
     rows: [recorded_device]
   }: { rows: Recorded<Device>[] } = await client.query(sql, values)
-  return { ...baseDevice, ...recorded_device }
+  return { ...device, ...recorded_device }
 }
 
 export async function updateDevice(device_id: UUID, provider_id: UUID, changes: Partial<Device>): Promise<Device> {

--- a/packages/mds-ingest-service/index.ts
+++ b/packages/mds-ingest-service/index.ts
@@ -17,3 +17,4 @@
 export * from './@types'
 export * from './client'
 export * from './repository'
+export * from './service/validators'

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -15,8 +15,15 @@
  */
 
 import Joi from 'joi'
-import { schemaValidator } from '@mds-core/mds-schema-validators'
-import { VEHICLE_TYPES, PROPULSION_TYPES, VEHICLE_EVENTS, VEHICLE_STATES } from '@mds-core/mds-types'
+import { schemaValidator, SchemaValidator } from '@mds-core/mds-schema-validators'
+import {
+  VEHICLE_TYPES,
+  PROPULSION_TYPES,
+  VEHICLE_EVENTS,
+  VEHICLE_STATES,
+  MODALITIES,
+  ACCESSIBILITY_OPTIONS
+} from '@mds-core/mds-types'
 import {
   DeviceDomainModel,
   EventDomainModel,
@@ -24,27 +31,41 @@ import {
   GROUPING_TYPES,
   GetVehicleEventsFilterParams
 } from '../@types'
-import { SchemaValidator } from '@mds-core/mds-schema-validators'
 
-export const {
-  validate: validateDeviceDomainModel,
-  isValid: isValidDeviceDomainModel
-} = schemaValidator<DeviceDomainModel>(
-  Joi.object<DeviceDomainModel>()
-    .keys({
-      device_id: Joi.string().uuid().required(),
-      provider_id: Joi.string().uuid().required(),
-      vehicle_id: Joi.string().required(),
-      vehicle_type: Joi.string()
-        .valid(...Object.keys(VEHICLE_TYPES))
-        .required(),
-      propulsion_types: Joi.array().valid(Joi.string().valid(...Object.keys(PROPULSION_TYPES))),
-      year: Joi.number().allow(null),
-      mfgr: Joi.string().allow(null),
-      model: Joi.string().allow(null)
-    })
-    .unknown(false)
-)
+const uuidSchema = { type: 'string', format: 'uuid' }
+
+export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = SchemaValidator<DeviceDomainModel>({
+  $id: 'Device',
+  type: 'object',
+  properties: {
+    device_id: uuidSchema,
+    provider_id: uuidSchema,
+    vehicle_id: {
+      type: 'string'
+    },
+    vehicle_type: { type: 'string', enum: VEHICLE_TYPES },
+    propulsion_types: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: PROPULSION_TYPES
+      }
+    },
+    accessibility_options: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: ACCESSIBILITY_OPTIONS
+      },
+      default: []
+    },
+    modality: { type: 'string', enum: MODALITIES, default: 'micromobility' },
+    year: { type: 'integer' },
+    mfgr: { type: 'string' },
+    model: { type: 'string' }
+  },
+  required: ['device_id', 'provider_id', 'vehicle_id', 'vehicle_type', 'propulsion_types']
+})
 
 /* Separate so we can re-use in the event domain model validator */
 const telemetrySchema = Joi.object<TelemetryDomainModel>()
@@ -64,31 +85,27 @@ const telemetrySchema = Joi.object<TelemetryDomainModel>()
   })
   .unknown(false)
 
-export const {
-  validate: validateTelemetryDomainModel,
-  isValid: isValidTelemetryDomainModel
-} = schemaValidator<DeviceDomainModel>(telemetrySchema)
+export const { validate: validateTelemetryDomainModel, isValid: isValidTelemetryDomainModel } =
+  schemaValidator<DeviceDomainModel>(telemetrySchema)
 
-export const {
-  validate: validateEventDomainModel,
-  isValid: isValidEventDomainModel
-} = schemaValidator<DeviceDomainModel>(
-  Joi.object<EventDomainModel>()
-    .keys({
-      device_id: Joi.string().uuid().required(),
-      provider_id: Joi.string().uuid().required(),
-      timestamp: Joi.number().required(),
-      event_types: Joi.array()
-        .valid(Joi.string().valid(...VEHICLE_EVENTS))
-        .required(),
-      vehicle_state: Joi.string().valid(...VEHICLE_STATES),
-      telemetry_timestamp: Joi.number().allow(null),
-      telemetry: telemetrySchema.allow(null),
-      trip_id: Joi.string().uuid().allow(null),
-      service_area_id: Joi.string().uuid().allow(null)
-    })
-    .unknown(false)
-)
+export const { validate: validateEventDomainModel, isValid: isValidEventDomainModel } =
+  schemaValidator<DeviceDomainModel>(
+    Joi.object<EventDomainModel>()
+      .keys({
+        device_id: Joi.string().uuid().required(),
+        provider_id: Joi.string().uuid().required(),
+        timestamp: Joi.number().required(),
+        event_types: Joi.array()
+          .valid(Joi.string().valid(...VEHICLE_EVENTS))
+          .required(),
+        vehicle_state: Joi.string().valid(...VEHICLE_STATES),
+        telemetry_timestamp: Joi.number().allow(null),
+        telemetry: telemetrySchema.allow(null),
+        trip_id: Joi.string().uuid().allow(null),
+        service_area_id: Joi.string().uuid().allow(null)
+      })
+      .unknown(false)
+  )
 
 export const { validate: validateGetVehicleEventsFilterParams } = SchemaValidator<GetVehicleEventsFilterParams>({
   type: 'object',

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -34,38 +34,41 @@ import {
 
 const uuidSchema = { type: 'string', format: 'uuid' }
 
-export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = SchemaValidator<DeviceDomainModel>({
-  $id: 'Device',
-  type: 'object',
-  properties: {
-    device_id: uuidSchema,
-    provider_id: uuidSchema,
-    vehicle_id: {
-      type: 'string'
-    },
-    vehicle_type: { type: 'string', enum: VEHICLE_TYPES },
-    propulsion_types: {
-      type: 'array',
-      items: {
-        type: 'string',
-        enum: PROPULSION_TYPES
-      }
-    },
-    accessibility_options: {
-      type: 'array',
-      items: {
-        type: 'string',
-        enum: ACCESSIBILITY_OPTIONS
+export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = SchemaValidator<DeviceDomainModel>(
+  {
+    $id: 'Device',
+    type: 'object',
+    properties: {
+      device_id: uuidSchema,
+      provider_id: uuidSchema,
+      vehicle_id: {
+        type: 'string'
       },
-      default: []
+      vehicle_type: { type: 'string', enum: VEHICLE_TYPES },
+      propulsion_types: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: PROPULSION_TYPES
+        }
+      },
+      accessibility_options: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ACCESSIBILITY_OPTIONS
+        },
+        default: []
+      },
+      modality: { type: 'string', enum: MODALITIES, default: 'micromobility' },
+      year: { type: 'integer' },
+      mfgr: { type: 'string' },
+      model: { type: 'string' }
     },
-    modality: { type: 'string', enum: MODALITIES, default: 'micromobility' },
-    year: { type: 'integer' },
-    mfgr: { type: 'string' },
-    model: { type: 'string' }
+    required: ['device_id', 'provider_id', 'vehicle_id', 'vehicle_type', 'propulsion_types']
   },
-  required: ['device_id', 'provider_id', 'vehicle_id', 'vehicle_type', 'propulsion_types']
-})
+  { useDefaults: true }
+)
 
 /* Separate so we can re-use in the event domain model validator */
 const telemetrySchema = Joi.object<TelemetryDomainModel>()

--- a/packages/mds-types/device.ts
+++ b/packages/mds-types/device.ts
@@ -1,4 +1,4 @@
-import { Timestamp, UUID } from './utils'
+import { Nullable, Timestamp, UUID } from './utils'
 import { VEHICLE_STATE } from './vehicle/vehicle_states'
 import { VEHICLE_TYPE } from './vehicle/vehicle_types'
 
@@ -21,7 +21,7 @@ export interface CoreDevice {
 // Represents a row in the "devices" table
 export interface Device_v1_1_0 extends CoreDevice {
   vehicle_type: VEHICLE_TYPE // changed name in 1.0
-  accessibility_options?: ACCESSIBILITY_OPTION[]
+  accessibility_options: Nullable<ACCESSIBILITY_OPTION[]>
   propulsion_types: PROPULSION_TYPE[] // changed name in 1.0
   year?: number | null
   mfgr?: string | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,7 @@ importers:
       '@mds-core/mds-api-helpers': 0.1.28
       '@mds-core/mds-api-server': 0.1.28
       '@mds-core/mds-db': 0.1.28
+      '@mds-core/mds-ingest-service': 0.1.2
       '@mds-core/mds-logger': 0.2.2
       '@mds-core/mds-providers': 0.1.28
       '@mds-core/mds-schema-validators': 0.1.4
@@ -273,12 +274,14 @@ importers:
       '@mds-core/mds-types': 0.1.25
       '@mds-core/mds-utils': 0.1.28
       '@types/express': 4.17.12
+      ajv: 8.6.0
       express: 4.17.1
     dependencies:
       '@mds-core/mds-agency-cache': link:../mds-agency-cache
       '@mds-core/mds-api-helpers': link:../mds-api-helpers
       '@mds-core/mds-api-server': link:../mds-api-server
       '@mds-core/mds-db': link:../mds-db
+      '@mds-core/mds-ingest-service': link:../mds-ingest-service
       '@mds-core/mds-logger': link:../mds-logger
       '@mds-core/mds-providers': link:../mds-providers
       '@mds-core/mds-schema-validators': link:../mds-schema-validators
@@ -287,6 +290,7 @@ importers:
       '@mds-core/mds-types': link:../mds-types
       '@mds-core/mds-utils': link:../mds-utils
       '@types/express': 4.17.12
+      ajv: 8.6.0
       express: 4.17.1
     devDependencies:
       '@mds-core/mds-test-data': link:../mds-test-data


### PR DESCRIPTION
## 📚 Purpose
Whew, this was a bit of an adventure. Parsing validation errors from AJV into a format that conforms with the MDS Agency spec was a bit of a journey, but I think this ought to work reasonably well. I adjusted the tests a bit because the error messages we previously sent were, while conformant with the spec, not necessary to continue emitting (e.g namely the data in `error_details`). I also removed one piece of validation which mandated that the device `year` property was between 1980 & 2020 (fun future bug which could hypothetically have been causing issues if Providers actually sent the `year` property in production).

Ideally, the `agencyErrorParser` will be helpful when parsing validation errors for events, though I suspect that given the odd error handling for the Telemetry endpoint it may not be especially useful there, but we'll see.


## 📦 Impacts:
- mds-agency

