### PR TITLE
[mds-agency] [LEGACY SUPPORT] Accept device registration for devices with any integer year

### DIFF
--- a/packages/mds-agency/utils.ts
+++ b/packages/mds-agency/utils.ts
@@ -67,12 +67,6 @@ export function badDevice(device: Device): { error: string; error_description: s
         error_description: `invalid device year ${device.year} is not an integer`
       }
     }
-    if (device.year < 1980 || device.year > 2020) {
-      return {
-        error: 'bad_param',
-        error_description: `invalid device year ${device.year} is out of range`
-      }
-    }
   }
   if (device.type === undefined) {
     return {


### PR DESCRIPTION
## 📚 Purpose
This PR removes some strict validation for model year in the device registration flow. It's targetted at the `support/mds-0.4.1` branch, which is what is currently deployed to 0.4.1 environments.

## 👌 Resolves:
Being unable to register vehicles >2020

## 📦 Impacts:
- mds-agency

## ✅ PR Checklist
- [x] Updated unit tests to flex required functionality 
