### PR TITLE
[mds-agency] Fix POST telemetry response in accordance with 1.0 spec, improve performance

### DIFF
--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -406,7 +406,7 @@ export const submitVehicleTelemetry = async (
   const valid: Telemetry[] = []
 
   try {
-    const deviceIds = await (async () => {
+    const deviceIds: Map<UUID, Boolean> = await (async () => {
       if (data.length === 1) {
         const [telemetry] = data
 

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -22,11 +22,9 @@ import cache from '@mds-core/mds-agency-cache'
 import stream from '@mds-core/mds-stream'
 import { providerName } from '@mds-core/mds-providers'
 import {
-  Device,
   VehicleEvent,
   Telemetry,
   ErrorObject,
-  DeviceID,
   VEHICLE_EVENT,
   UUID,
   VEHICLE_STATE,
@@ -384,6 +382,7 @@ export const submitVehicleTelemetry = async (
   req: AgencyApiSubmitVehicleTelemetryRequest,
   res: AgencyApiSubmitVehicleTelemetryResponse
 ) => {
+  const recorded = now()
   const start = Date.now()
 
   const { data } = req.body
@@ -406,16 +405,33 @@ export const submitVehicleTelemetry = async (
   const failures: string[] = []
   const valid: Telemetry[] = []
 
-  const recorded = now()
-  const p: Promise<Device | DeviceID[]> =
-    data.length === 1 && isUUID(data[0].device_id)
-      ? db.readDevice(data[0].device_id, provider_id)
-      : db.readDeviceIds(provider_id)
   try {
-    const deviceOrDeviceIds = await p
-    const deviceIds = Array.isArray(deviceOrDeviceIds) ? deviceOrDeviceIds : [deviceOrDeviceIds]
+    const deviceIds = await (async () => {
+      if (data.length === 1) {
+        const [telemetry] = data
+
+        if ('device_id' in telemetry) {
+          const { device_id } = telemetry
+
+          if (isUUID(device_id)) {
+            const device = await db.readDevice(device_id, provider_id)
+
+            // Map with only one entry
+            return new Map<UUID, boolean>([[device.device_id, true]])
+          }
+        }
+      }
+
+      const deviceIdsWithProviderIds = await db.readDeviceIds(provider_id)
+
+      // Turn array returned to a Map for fast lookups
+      return deviceIdsWithProviderIds.reduce((acc, { device_id: deviceId }) => {
+        acc.set(deviceId, true)
+        return acc
+      }, new Map<UUID, boolean>())
+    })()
+
     for (const item of data) {
-      // make sure the device exists
       const { gps } = item
       const telemetry: Telemetry = {
         device_id: item.device_id,
@@ -449,7 +465,7 @@ export const submitVehicleTelemetry = async (
         const msg = `bad telemetry for device_id ${telemetry.device_id}: ${bad_telemetry.error_description}`
         // append to failure
         failures.push(msg)
-      } else if (!deviceIds.some(item2 => item2.device_id === telemetry.device_id)) {
+      } else if (!deviceIds.has(telemetry.device_id)) {
         const msg = `device_id ${telemetry.device_id}: not found`
         failures.push(msg)
       } else {
@@ -470,10 +486,9 @@ export const submitVehicleTelemetry = async (
         })
       }
       if (recorded_telemetry.length) {
-        res.status(201).send({
-          result: `telemetry success for ${valid.length} of ${data.length}`,
-          recorded: now(),
-          unique: recorded_telemetry.length,
+        res.status(200).send({
+          success: valid.length,
+          total: data.length,
           failures
         })
       } else {

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -46,7 +46,7 @@ import {
 import db from '@mds-core/mds-db'
 import cache from '@mds-core/mds-agency-cache'
 import stream from '@mds-core/mds-stream'
-import { makeDevices, makeEvents, JUMP_TEST_DEVICE_1 } from '@mds-core/mds-test-data'
+import { makeDevices, makeEvents, JUMP_TEST_DEVICE_1, makeTelemetry } from '@mds-core/mds-test-data'
 import { ApiServer } from '@mds-core/mds-api-server'
 import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from '@mds-core/mds-providers'
 import { pathPrefix, uuid } from '@mds-core/mds-utils'
@@ -765,7 +765,6 @@ describe('Tests API', () => {
       })
       .expect(201)
       .end((err, result) => {
-        console.log(result.body)
         done(err)
       })
   })
@@ -1124,7 +1123,7 @@ describe('Tests API', () => {
       .send({
         data: [TEST_TELEMETRY, TEST_TELEMETRY2]
       })
-      .expect(201)
+      .expect(200)
       .end((err, result) => {
         if (err) {
           log('telemetry err', err)
@@ -1307,7 +1306,6 @@ describe('Tests API', () => {
   })
   it('verifies post telemetry with unregistered device', done => {
     const telemetry = { ...TEST_TELEMETRY, device_id: uuid() } // randomly generate a new uuid, obviously not registered
-
     request
       .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
@@ -1324,6 +1322,52 @@ describe('Tests API', () => {
         }
         done(err)
       })
+  })
+  it('verifies post telemetry bulk with unregistered devices fails', async () => {
+    const telemetry = [
+      { ...TEST_TELEMETRY, device_id: uuid() },
+      { ...TEST_TELEMETRY, device_id: uuid() }
+    ]
+
+    await request
+      .post(pathPrefix('/vehicles/telemetry'))
+      .set('Authorization', AUTH)
+      .send({
+        data: telemetry
+      })
+      .expect(400)
+  })
+  it('verifies post telemetry bulk with one unregistered device partially succeeds', async () => {
+    const telemetry = [
+      { ...TEST_TELEMETRY, timestamp: TEST_TELEMETRY.timestamp + 1 },
+      { ...TEST_TELEMETRY, device_id: uuid() }
+    ]
+
+    const result = await request
+      .post(pathPrefix('/vehicles/telemetry'))
+      .set('Authorization', AUTH)
+      .send({
+        data: telemetry
+      })
+      .expect(200)
+
+    test.value(result.body.failures.length).is(1)
+  })
+  it('verifies post telemetry with one registered device and one device registered to another provider partially succeeds', async () => {
+    const devices = [...makeDevices(1, now(), TEST1_PROVIDER_ID), ...makeDevices(1, now(), TEST2_PROVIDER_ID)]
+    const telemetry = makeTelemetry(devices, now())
+
+    await Promise.all([db.seed({ devices }), cache.seed({ devices, telemetry: [], events: [] })])
+
+    const result = await request
+      .post(pathPrefix('/vehicles/telemetry'))
+      .set('Authorization', AUTH)
+      .send({
+        data: telemetry
+      })
+      .expect(200)
+
+    test.value(result.body.failures.length).is(1)
   })
   it('verifies get device readback w/telemetry success (database)', done => {
     request

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -68,7 +68,7 @@ export type AgencyApiSubmitVehicleEventResponse = AgencyApiResponse<{
 export type AgencyApiSubmitVehicleTelemetryResponse = AgencyApiResponse<{
   success: number
   total: number
-  failures: string[]
+  failures: Telemetry[]
 }>
 
 export type AgencyApiPostTripMetadataResponse = AgencyApiResponse<TripMetadata>

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -66,9 +66,8 @@ export type AgencyApiSubmitVehicleEventResponse = AgencyApiResponse<{
 }>
 
 export type AgencyApiSubmitVehicleTelemetryResponse = AgencyApiResponse<{
-  result: string
-  recorded: Timestamp
-  unique: number
+  success: number
+  total: number
   failures: string[]
 }>
 

--- a/packages/mds-api-server/@types/index.ts
+++ b/packages/mds-api-server/@types/index.ts
@@ -40,7 +40,7 @@ export type ApiRequestQuery<S extends string, M extends string[] = never> = {
 /**
  * Standard format for API errors
  */
-export type ApiError = { error: unknown; error_description?: string; error_details?: string[] } | { errors: unknown[] }
+export type ApiError = { error: unknown; error_description?: string; error_details?: any[] } | { errors: unknown[] }
 
 /**
  * B: Type of response body (res.send)


### PR DESCRIPTION
  ## 📚 Purpose
This PR started off as an attempt to optimize checking if a `device_id` was valid during bulk Telemetry POSTs, but ended up changing a lot more than that.
 
Previously, we were doing a check on each device referenced in a bulk telemetry POST to verify that it was valid for that provider, which was a worst-case `O(N)` check per-device, where `N=total number of devices for a provider`. For the entirety of the POST, this was `O(N * M)` where `M` is the number of devices included in the bulk telemetry POST. Pretty bad performance-wise. This PR changes things, such that instead of maintaining an array of all of the providers' `device_ids` in memory, we maintain a `Set` which contains them. To generate the `Set` in the first place takes `O(N)` time, but then each individual check is `O(1)`, so the total runtime is `O(N + M)` (compared to the previous `O(N * M)`), which should result in a substantial runtime improvement.
    
Additionally, as I was verifying my changes, I decided to look at the Agency 1.0 spec, and I noticed that not only did the response body for successful telemetry POSTs change, the _response code did as well_! Instead of being a `201`, it is now a `200`. This is a pretty weird change, and I'm frustrated it was not caught during the 1.0 review cycle; a 200 response certainly makes no sense, however, it's part of the spec, and we must conform with it. I'll be opening an issue against the OMF spec to resolve this shortly, as I have some ideas about how we can improve the response for bulk Telemetry at a spec-level. 
 
## 👌 Resolves:
- Some gnarly performance
- Inconsistency with the 1.0 Agency spec

## 📦 Impacts:
- mds-agency