### PR TITLE
[mds-agency] Switch Telemetry Validation to AJV, fix spec discontinuities

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -12,5 +12,8 @@
       }
     }
   ],
-  "plugins": ["./node_modules/prettier-plugin-packagejson"]
+  "plugins": [
+    "./node_modules/prettier-plugin-packagejson",
+    "./node_modules/prettier-plugin-organize-imports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "nyc": "15.1.0",
     "pnpm-ci-tools": "1.0.1",
     "prettier": "2.3.1",
+    "prettier-plugin-organize-imports": "2.2.0",
     "prettier-plugin-packagejson": "2.2.11",
     "should": "13.2.3",
     "sinon": "11.1.1",

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-import express from 'express'
-
+import { AccessTokenScopeValidator, checkAccess } from '@mds-core/mds-api-server'
 import logger from '@mds-core/mds-logger'
 import { isUUID, pathPrefix } from '@mds-core/mds-utils'
-import { checkAccess, AccessTokenScopeValidator } from '@mds-core/mds-api-server'
-import { AgencyApiRequest, AgencyApiResponse, AgencyApiAccessTokenScopes } from './types'
+import express from 'express'
+import { readAllVehicleIds } from './agency-candidate-request-handlers'
+import { createTelemetryHandler } from './handlers/create-telemetry'
+import { AgencyApiVersionMiddleware } from './middleware/agency-api-version'
 import {
-  registerVehicle,
   getVehicleById,
   getVehiclesByProvider,
-  updateVehicle,
+  registerVehicle,
   submitVehicleEvent,
-  submitVehicleTelemetry,
+  updateVehicle,
   writeTripMetadata
 } from './request-handlers'
-import { readAllVehicleIds } from './agency-candidate-request-handlers'
-import { getCacheInfo, wipeDevice, refreshCache } from './sandbox-admin-request-handlers'
+import { getCacheInfo, refreshCache, wipeDevice } from './sandbox-admin-request-handlers'
+import { AgencyApiAccessTokenScopes, AgencyApiRequest, AgencyApiResponse } from './types'
 import { validateDeviceId } from './utils'
-
-import { AgencyApiVersionMiddleware } from './middleware/agency-api-version'
 
 const checkAgencyApiAccess = (validator: AccessTokenScopeValidator<AgencyApiAccessTokenScopes>) =>
   checkAccess(validator)
@@ -105,7 +103,7 @@ function api(app: express.Express): express.Express {
    * Endpoint to submit telemetry
    * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
    */
-  app.post(pathPrefix('/vehicles/telemetry'), submitVehicleTelemetry)
+  app.post(pathPrefix('/vehicles/telemetry'), createTelemetryHandler)
 
   // ///////////////////// begin Agency candidate endpoints ///////////////////////
 

--- a/packages/mds-agency/handlers/create-telemetry.ts
+++ b/packages/mds-agency/handlers/create-telemetry.ts
@@ -1,0 +1,225 @@
+import db from '@mds-core/mds-db'
+import { validateTelemetryDomainModel } from '@mds-core/mds-ingest-service'
+import logger from '@mds-core/mds-logger'
+import { isError } from '@mds-core/mds-service-helpers'
+import { Telemetry, Timestamp, UUID } from '@mds-core/mds-types'
+import { NotFoundError, now, ServerError, ValidationError } from '@mds-core/mds-utils'
+import { AgencyApiSubmitVehicleTelemetryRequest, AgencyApiSubmitVehicleTelemetryResponse } from '../types'
+import { agencyValidationErrorParser, writeTelemetry } from '../utils'
+
+type TelemetryFailures = { telemetry: Object; reason: string }[]
+
+/**
+ *
+ * @param options
+ * @param options.data *UNVALIDATED* `Telemetry` data straight from the API (hence the Object[] type)
+ * @param options.provider_id `provider_id` in question
+ * @param options.recorded Recorded time
+ * @returns Set with either all UUIDs for the provider, or the UUID of the telemetry point in question
+ */
+const getDeviceIdsForProvider = async ({
+  data,
+  provider_id,
+  recorded
+}: {
+  data: Object[]
+  provider_id: UUID
+  recorded: Timestamp
+}): Promise<Set<UUID>> => {
+  /**
+   * If there's only one point in the telemetry payload, we can avoid reading all device_ids for the provider,
+   * and simply verify that the device in question is valid
+   */
+  if (data.length === 1) {
+    const [nonValidatedTelemetry] = data
+
+    const telemetry = validateTelemetryDomainModel({ ...nonValidatedTelemetry, provider_id, recorded })
+
+    const { device_id } = telemetry
+
+    const device = await db.readDevice(device_id, provider_id)
+
+    // Set with only one entry
+    return new Set<UUID>([device.device_id])
+  }
+
+  const deviceIdsWithProviderIds = await db.readDeviceIds(provider_id)
+
+  // Turn array returned to a Set for fast lookups
+  return new Set(deviceIdsWithProviderIds.map(({ device_id }) => device_id))
+}
+
+/**
+ * @param options
+ * @param options.data *UNVALIDATED* `Telemetry` data straight from the API (hence the Object[] type)
+ * @param options.provider_id `provider_id` in question
+ * @param options.recorded Recorded time
+ * @returns Valid telemetry points & invalid telemetry points
+ */
+export const validateTelemetry = async ({
+  data,
+  provider_id,
+  recorded
+}: {
+  data: Object[]
+  provider_id: UUID
+  recorded: Timestamp
+}) => {
+  const deviceIds = await getDeviceIdsForProvider({ data, provider_id, recorded })
+
+  return data.reduce<{
+    valid: Telemetry[]
+    failures: TelemetryFailures
+  }>(
+    ({ valid, failures }, rawTelemetry) => {
+      // Raw telemetry + provider_id (extracted from token) + recorded (generated at ingestion)
+      const nonValidatedTelemetry = {
+        ...rawTelemetry,
+        provider_id,
+        recorded
+      }
+
+      try {
+        // Validate telemetry, and prune foreign properties
+        const validatedTelemetry = validateTelemetryDomainModel(nonValidatedTelemetry)
+
+        const { device_id } = validatedTelemetry
+
+        if (!deviceIds.has(device_id))
+          return {
+            valid,
+            failures: [...failures, { telemetry: validatedTelemetry, reason: `device_id: ${device_id} not found` }]
+          }
+
+        return { valid: [...valid, validatedTelemetry], failures }
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          const parsedError = agencyValidationErrorParser(error)
+
+          return {
+            valid,
+            failures: [...failures, { telemetry: nonValidatedTelemetry, reason: parsedError.error_description }]
+          }
+        }
+
+        /* we should never hit this */
+        /* istanbul ignore next */
+        throw error
+      }
+    },
+    { valid: [], failures: [] }
+  )
+}
+
+/**
+ *
+ * @param options
+ * @param options.start Start time of telemetry query
+ * @param options.provider_id MDS `provider_id`
+ * @param options.data All telemetry provided in request
+ * @param options.valid Telemetry which successfully validated
+ * @param options.recorded_telemetry Telemetry which was successfully persisted
+ *
+ * Logs performance of telemetry validation + write
+ */
+const logTelemetryWritePerformance = ({
+  start,
+  provider_id,
+  data,
+  valid,
+  recorded_telemetry
+}: {
+  start: Timestamp
+  provider_id: UUID
+  data: Object[]
+  valid: Telemetry[]
+  recorded_telemetry: Telemetry[]
+}) => {
+  const delta = Date.now() - start
+
+  /* we ought not to hit this during our test suite */
+  /* istanbul ignore next */
+  if (delta > 300) {
+    logger.info('writeTelemetry performance >.3s', {
+      provider_id,
+      validItems: valid.length,
+      total: data.length,
+      unique: recorded_telemetry.length,
+      delta: `${delta} ms (${Math.round((1000 * valid.length) / delta)}/s)`
+    })
+  }
+}
+
+const allInvalidDataBody = (failures: TelemetryFailures) => ({
+  error: 'invalid_data',
+  error_description: 'None of the provided data was valid',
+  error_details: failures
+})
+
+export const createTelemetryHandler = async (
+  req: AgencyApiSubmitVehicleTelemetryRequest,
+  res: AgencyApiSubmitVehicleTelemetryResponse
+) => {
+  const recorded = now()
+  const start = now()
+
+  const { provider_id } = res.locals
+  const { data } = req.body
+
+  if (!data) {
+    return res.status(400).send({
+      error: 'bad_param',
+      error_description: 'Missing data from post-body'
+    })
+  }
+
+  try {
+    const { valid, failures } = await validateTelemetry({ data, provider_id, recorded })
+
+    if (valid.length) {
+      const recorded_telemetry = await writeTelemetry(valid)
+
+      logTelemetryWritePerformance({ start, provider_id, data, valid, recorded_telemetry })
+
+      if (recorded_telemetry.length) {
+        return res.status(200).send({
+          success: valid.length,
+          total: data.length,
+          failures: failures.map(({ telemetry }) => telemetry)
+        })
+      }
+
+      // None of the telemetry was persisted by the db (even though it passed schema validation), ergo, none of it was unique
+      logger.info(`no unique telemetry in ${data.length} items for ${provider_id}`)
+      return res.status(400).send(allInvalidDataBody(failures))
+    }
+
+    // None of the telemetry passed validation
+    const body = `${JSON.stringify(req.body).substring(0, 128)} ...`
+    const fails = `${JSON.stringify(failures).substring(0, 128)} ...`
+    logger.info(`no valid telemetry in ${data.length} items for ${provider_id}`, { body, fails })
+
+    return res.status(400).send(allInvalidDataBody(failures))
+  } catch (err) {
+    if (isError(err, NotFoundError)) {
+      /**
+       * TODO: as of MDS v1.1 this is what we should be sending, but we're on 1.0 for now
+       */
+      // return res.status(400).send({
+      //   error: 'unregistered',
+      //   error_description: 'Some of the devices are unregistered',
+      //   error_details: [data[0].device_id]
+      // })
+
+      return res.status(400).send({
+        error: 'invalid_data',
+        error_description: 'None of the provided data was valid',
+        error_details: [`device: ${data[0].device_id} not found`]
+      })
+    }
+
+    if (isError(err, ValidationError)) return res.status(400).send(agencyValidationErrorParser(err))
+
+    return res.status(500).send({ error: new ServerError() })
+  }
+}

--- a/packages/mds-agency/handlers/create-telemetry.ts
+++ b/packages/mds-agency/handlers/create-telemetry.ts
@@ -220,6 +220,7 @@ export const createTelemetryHandler = async (
 
     if (isError(err, ValidationError)) return res.status(400).send(agencyValidationErrorParser(err))
 
+    logger.error('createTelemetryHandler fatal error', { error: err })
     return res.status(500).send({ error: new ServerError() })
   }
 }

--- a/packages/mds-agency/handlers/create-telemetry.ts
+++ b/packages/mds-agency/handlers/create-telemetry.ts
@@ -168,8 +168,9 @@ export const createTelemetryHandler = async (
 
   if (!data) {
     return res.status(400).send({
-      error: 'bad_param',
-      error_description: 'Missing data from post-body'
+      error: 'missing_param',
+      error_description: 'A required parameter is missing.',
+      error_details: ['data']
     })
   }
 
@@ -213,7 +214,7 @@ export const createTelemetryHandler = async (
 
       return res.status(400).send({
         error: 'invalid_data',
-        error_description: 'None of the provided data was valid',
+        error_description: 'None of the provided data was valid.',
         error_details: [`device: ${data[0].device_id} not found`]
       })
     }

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -422,6 +422,7 @@ export const submitVehicleTelemetry = async (
         }
 
         try {
+          // Validate telemetry, and prune foreign properties
           const validatedTelemetry = validateTelemetryDomainModel(unvalidatedTelemetry)
 
           const { device_id } = validatedTelemetry

--- a/packages/mds-agency/request-handlers.ts
+++ b/packages/mds-agency/request-handlers.ts
@@ -14,45 +14,40 @@
  * limitations under the License.
  */
 
-import logger from '@mds-core/mds-logger'
-import { isUUID, now, ValidationError, normalizeToArray, ServerError, NotFoundError } from '@mds-core/mds-utils'
-import { validateEvent, validateTripMetadata } from '@mds-core/mds-schema-validators'
-import db from '@mds-core/mds-db'
 import cache from '@mds-core/mds-agency-cache'
-import stream from '@mds-core/mds-stream'
-import { providerName } from '@mds-core/mds-providers'
-import { VehicleEvent, Telemetry, VEHICLE_EVENT, UUID, VEHICLE_STATE, TRIP_STATE } from '@mds-core/mds-types'
-import urls from 'url'
 import { parseRequest } from '@mds-core/mds-api-helpers'
+import db from '@mds-core/mds-db'
+import { validateDeviceDomainModel } from '@mds-core/mds-ingest-service'
+import logger from '@mds-core/mds-logger'
+import { providerName } from '@mds-core/mds-providers'
+import { validateEvent, validateTripMetadata } from '@mds-core/mds-schema-validators'
+import stream from '@mds-core/mds-stream'
+import { TRIP_STATE, UUID, VehicleEvent, VEHICLE_EVENT, VEHICLE_STATE } from '@mds-core/mds-types'
+import { normalizeToArray, now, ServerError, ValidationError } from '@mds-core/mds-utils'
+import urls from 'url'
 import {
-  AgencyApiRequest,
-  AgencyApiRegisterVehicleResponse,
   AgencyAipGetVehicleByIdResponse,
+  AgencyApiGetVehicleByIdRequest,
   AgencyApiGetVehiclesByProviderRequest,
   AgencyApiGetVehiclesByProviderResponse,
-  AgencyApiUpdateVehicleResponse,
-  AgencyApiSubmitVehicleEventResponse,
-  AgencyApiSubmitVehicleTelemetryResponse,
-  AgencyApiGetVehicleByIdRequest,
-  AgencyApiUpdateVehicleRequest,
-  AgencyApiSubmitVehicleEventRequest,
-  AgencyApiSubmitVehicleTelemetryRequest,
   AgencyApiPostTripMetadataRequest,
   AgencyApiPostTripMetadataResponse,
-  AgencyApiRegisterVehicleRequest
+  AgencyApiRegisterVehicleRequest,
+  AgencyApiRegisterVehicleResponse,
+  AgencyApiRequest,
+  AgencyApiSubmitVehicleEventRequest,
+  AgencyApiSubmitVehicleEventResponse,
+  AgencyApiUpdateVehicleRequest,
+  AgencyApiUpdateVehicleResponse
 } from './types'
 import {
+  agencyValidationErrorParser,
+  badEvent,
+  computeCompositeVehicleData,
   getVehicles,
   lower,
-  writeTelemetry,
-  badEvent,
-  badTelemetry,
-  readPayload,
-  computeCompositeVehicleData,
-  agencyValidationErrorParser
+  readPayload
 } from './utils'
-import { isError } from '@mds-core/mds-service-helpers'
-import { validateDeviceDomainModel, validateTelemetryDomainModel } from '@mds-core/mds-ingest-service'
 
 const agencyServerError = { error: 'server_error', error_description: 'Unknown server error' }
 
@@ -322,7 +317,7 @@ export const submitVehicleEvent = async (
     if (event.telemetry) {
       event.telemetry.device_id = event.device_id
     }
-    const failure = (await badEvent(device, event)) || (event.telemetry ? badTelemetry(event.telemetry) : null)
+    const failure = await badEvent(device, event)
     // TODO unify with fail() above
     if (failure) {
       await stream.writeEventError({
@@ -358,143 +353,6 @@ export const submitVehicleEvent = async (
     }
   } catch (err) {
     await fail(err, event)
-  }
-}
-
-export const submitVehicleTelemetry = async (
-  req: AgencyApiSubmitVehicleTelemetryRequest,
-  res: AgencyApiSubmitVehicleTelemetryResponse
-) => {
-  const recorded = now()
-  const start = Date.now()
-
-  const { data } = req.body
-  const { provider_id } = res.locals
-  if (!provider_id) {
-    res.status(400).send({
-      error: 'bad_param',
-      error_description: 'Bad or missing provider_id'
-    })
-    return
-  }
-  if (!data) {
-    res.status(400).send({
-      error: 'bad_param',
-      error_description: 'Missing data from post-body'
-    })
-    return
-  }
-
-  const name = providerName(provider_id)
-
-  try {
-    const deviceIds: Set<UUID> = await (async () => {
-      if (data.length === 1) {
-        const [telemetry] = data
-
-        if ('device_id' in telemetry) {
-          const { device_id } = telemetry
-
-          if (isUUID(device_id)) {
-            const device = await db.readDevice(device_id, provider_id)
-
-            // Map with only one entry
-            return new Set<UUID>([device.device_id])
-          }
-        }
-      }
-
-      const deviceIdsWithProviderIds = await db.readDeviceIds(provider_id)
-
-      // Turn array returned to a Set for fast lookups
-      return new Set(deviceIdsWithProviderIds.map(({ device_id }) => device_id))
-    })()
-
-    const { valid, failures } = data.reduce<{
-      valid: Telemetry[]
-      failures: { telemetry: Telemetry; reason: string }[]
-    }>(
-      ({ valid, failures }, rawTelemetry) => {
-        const unvalidatedTelemetry: Telemetry = {
-          ...rawTelemetry,
-          provider_id,
-          recorded
-        }
-
-        try {
-          // Validate telemetry, and prune foreign properties
-          const validatedTelemetry = validateTelemetryDomainModel(unvalidatedTelemetry)
-
-          const { device_id } = validatedTelemetry
-
-          if (!deviceIds.has(device_id))
-            return {
-              valid,
-              failures: [...failures, { telemetry: rawTelemetry, reason: `device_id: ${device_id} not found` }]
-            }
-
-          return { valid: [...valid, validatedTelemetry], failures }
-        } catch (error) {
-          if (error instanceof ValidationError) {
-            const parsedError = agencyValidationErrorParser(error)
-
-            return {
-              valid,
-              failures: [...failures, { telemetry: unvalidatedTelemetry, reason: parsedError.error_description }]
-            }
-          }
-        }
-
-        return { valid, failures }
-      },
-      { valid: [], failures: [] }
-    )
-
-    if (valid.length) {
-      const recorded_telemetry = await writeTelemetry(valid)
-
-      const delta = Date.now() - start
-      if (delta > 300) {
-        logger.info('writeTelemetry', {
-          name,
-          validItems: valid.length,
-          unique: recorded_telemetry.length,
-          delta: `${delta} ms (${Math.round((1000 * valid.length) / delta)}/s)`
-        })
-      }
-      if (recorded_telemetry.length) {
-        res.status(200).send({
-          success: valid.length,
-          total: data.length,
-          failures: failures.map(({ telemetry }) => telemetry)
-        })
-      } else {
-        logger.info(`no unique telemetry in ${data.length} items for ${name}`)
-        res.status(400).send({
-          error: 'invalid_data',
-          error_description: 'None of the provided data was valid',
-          error_details: failures
-        })
-      }
-    } else {
-      const body = `${JSON.stringify(req.body).substring(0, 128)} ...`
-      const fails = `${JSON.stringify(failures).substring(0, 128)} ...`
-      logger.info(`no valid telemetry in ${data.length} items for ${name}`, { body, fails })
-      res.status(400).send({
-        error: 'invalid_data',
-        error_description: 'None of the provided data was valid',
-        error_details: failures
-      })
-    }
-  } catch (err) {
-    if (isError(err, NotFoundError))
-      return res.status(400).send({
-        error: 'unregistered',
-        error_description: 'Some of the devices are unregistered',
-        error_details: [data[0].device_id]
-      })
-
-    return res.status(500).send({ error: new ServerError() })
   }
 }
 

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -27,29 +27,29 @@
 /* eslint-disable promise/no-callback-in-promise */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import supertest from 'supertest'
-import test from 'unit.js'
+import cache from '@mds-core/mds-agency-cache'
+import { ApiServer } from '@mds-core/mds-api-server'
+import db from '@mds-core/mds-db'
+import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from '@mds-core/mds-providers'
+import stream from '@mds-core/mds-stream'
+import { JUMP_TEST_DEVICE_1, makeDevices, makeEvents, makeTelemetry } from '@mds-core/mds-test-data'
 import {
-  Timestamp,
   Device,
-  VehicleEvent,
-  TAXI_VEHICLE_EVENTS,
-  TAXI_VEHICLE_EVENT,
+  MICRO_MOBILITY_EVENT_STATES_MAP,
   MICRO_MOBILITY_VEHICLE_EVENTS,
   TAXI_EVENT_STATES_MAP,
-  MICRO_MOBILITY_EVENT_STATES_MAP,
+  TAXI_VEHICLE_EVENT,
+  TAXI_VEHICLE_EVENTS,
+  Timestamp,
+  TNC_EVENT_STATES_MAP,
+  TNC_VEHICLE_EVENT,
   TripMetadata,
   TRIP_STATE,
-  TNC_VEHICLE_EVENT,
-  TNC_EVENT_STATES_MAP
+  VehicleEvent
 } from '@mds-core/mds-types'
-import db from '@mds-core/mds-db'
-import cache from '@mds-core/mds-agency-cache'
-import stream from '@mds-core/mds-stream'
-import { makeDevices, makeEvents, JUMP_TEST_DEVICE_1, makeTelemetry } from '@mds-core/mds-test-data'
-import { ApiServer } from '@mds-core/mds-api-server'
-import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from '@mds-core/mds-providers'
 import { pathPrefix, uuid } from '@mds-core/mds-utils'
+import supertest from 'supertest'
+import test from 'unit.js'
 import { api } from '../api'
 
 /* eslint-disable-next-line no-console */
@@ -141,7 +141,8 @@ const test_event: Omit<VehicleEvent, 'recorded' | 'provider_id'> = {
   event_types: ['decommissioned'],
   vehicle_state: 'removed',
   trip_state: null,
-  timestamp: testTimestamp
+  timestamp: testTimestamp,
+  telemetry: makeTelemetry([TEST_BICYCLE as any], testTimestamp)[0]
 }
 
 testTimestamp += 1
@@ -914,7 +915,7 @@ describe('Tests API', () => {
 
   const { gps, ...telemetry_without_location } = deepCopy(TEST_TELEMETRY)
 
-  it('verifies post trip start missing location', done => {
+  it('verifies post trip start missing location fails', done => {
     request
       .post(pathPrefix(`/vehicles/${DEVICE_UUID}/event`))
       .set('Authorization', AUTH)
@@ -927,8 +928,6 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         log(result.body)
-        test.string(result.body.error).contains('missing')
-        test.string(result.body.error_description).contains('invalid')
         done(err)
       })
   })
@@ -970,8 +969,9 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         log(result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid')
+        test.string(result.body.error).contains('bad_param')
+        test.string(result.body.error_description).contains('A validation error occurred')
+        test.string(result.body.error_details[0].property).contains('lat')
         done(err)
       })
   })
@@ -993,8 +993,9 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         log(result.body)
-        test.string(result.body.error).contains('bad')
-        test.string(result.body.error_description).contains('invalid altitude')
+        test.string(result.body.error).contains('bad_param')
+        test.string(result.body.error_description).contains('A validation error occurred')
+        test.string(result.body.error_details[0].property).contains('altitude')
         done(err)
       })
   })
@@ -1016,7 +1017,8 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         test.string(result.body.error).contains('bad_param')
-        test.string(result.body.error_description).contains('invalid accuracy')
+        test.string(result.body.error_description).contains('A validation error occurred')
+        test.string(result.body.error_details[0].property).contains('accuracy')
         done(err)
       })
   })
@@ -1038,7 +1040,8 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         test.string(result.body.error).contains('bad_param')
-        test.string(result.body.error_description).contains('invalid speed')
+        test.string(result.body.error_description).contains('A validation error occurred')
+        test.string(result.body.error_details[0].property).contains('speed')
         done(err)
       })
   })
@@ -1060,7 +1063,8 @@ describe('Tests API', () => {
       .expect(400)
       .end((err, result) => {
         test.string(result.body.error).contains('bad_param')
-        test.string(result.body.error_description).contains('invalid satellites')
+        test.string(result.body.error_description).contains('A validation error occurred')
+        test.string(result.body.error_details[0].property).contains('satellites')
         done(err)
       })
   })
@@ -1390,6 +1394,22 @@ describe('Tests API', () => {
 
     test.value(result.body.failures.length).is(1)
   })
+  it('verifies post telemetry with one schema-valid and one not schema-valid succeeds', async () => {
+    const devices = makeDevices(1, now(), TEST1_PROVIDER_ID)
+    const telemetry = [...makeTelemetry(devices, now()), { device_id: uuid(), spider: 'I am itsy-bitsy 🕷' }]
+
+    await Promise.all([db.seed({ devices }), cache.seed({ devices, telemetry: [], events: [] })])
+
+    const result = await request
+      .post(pathPrefix('/vehicles/telemetry'))
+      .set('Authorization', AUTH)
+      .send({
+        data: telemetry
+      })
+      .expect(200)
+
+    test.value(result.body.failures.length).is(1)
+  })
   it('verifies get device readback w/telemetry success (database)', done => {
     request
       .get(pathPrefix(`/vehicles/${DEVICE_UUID}`))
@@ -1429,6 +1449,7 @@ describe('Tests API', () => {
   it('verifies get device defaults to `deregister` if cache misses reads for associated events', async () => {
     await request.post(pathPrefix('/vehicles')).set('Authorization', AUTH).send(JUMP_TEST_DEVICE_1).expect(201)
 
+    const [telemetry] = makeTelemetry([JUMP_TEST_DEVICE_1], now())
     await request
       .post(pathPrefix(`/vehicles/${JUMP_TEST_DEVICE_1_ID}/event`))
       .set('Authorization', AUTH)
@@ -1436,7 +1457,8 @@ describe('Tests API', () => {
         device_id: JUMP_TEST_DEVICE_1,
         timestamp: now(),
         event_types: ['decommissioned'],
-        vehicle_state: 'removed'
+        vehicle_state: 'removed',
+        telemetry
       })
       .expect(201)
 

--- a/packages/mds-agency/tests/integration-tests.spec.ts
+++ b/packages/mds-agency/tests/integration-tests.spec.ts
@@ -1159,7 +1159,7 @@ describe('Tests API', () => {
         done(err)
       })
   })
-  it('verifies post telemetry handling of empty data payload', done => {
+  it('verifies post telemetry handling of empty data payload fails', done => {
     request
       .post(pathPrefix('/vehicles/telemetry'))
       .set('Authorization', AUTH)
@@ -1169,7 +1169,9 @@ describe('Tests API', () => {
         if (err) {
           log('telemetry err', err)
         } else {
-          test.string(result.body.error_description).contains('Missing data from post-body')
+          test.string(result.body.error).contains('missing_param')
+          test.string(result.body.error_description).contains('A required parameter is missing.')
+          test.string(result.body.error_details[0]).contains('data')
         }
         done(err)
       })

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -15,25 +15,25 @@
  */
 
 import {
-  UUID,
-  Device,
-  VehicleEvent,
-  Telemetry,
-  Timestamp,
-  Recorded,
-  VEHICLE_STATE,
-  VEHICLE_EVENT,
-  TripMetadata
-} from '@mds-core/mds-types'
-import { MultiPolygon } from 'geojson'
-import {
   ApiRequest,
+  ApiRequestParams,
   ApiResponse,
   ApiResponseLocals,
-  ApiRequestParams,
   ApiResponseLocalsClaims,
   ApiResponseLocalsVersion
 } from '@mds-core/mds-api-server'
+import {
+  Device,
+  Recorded,
+  Telemetry,
+  Timestamp,
+  TripMetadata,
+  UUID,
+  VehicleEvent,
+  VEHICLE_EVENT,
+  VEHICLE_STATE
+} from '@mds-core/mds-types'
+import { MultiPolygon } from 'geojson'
 
 export const AGENCY_API_SUPPORTED_VERSIONS = ['0.4.1', '1.0.0'] as const
 export type AGENCY_API_SUPPORTED_VERSION = typeof AGENCY_API_SUPPORTED_VERSIONS[number]
@@ -68,7 +68,7 @@ export type AgencyApiSubmitVehicleEventResponse = AgencyApiResponse<{
 export type AgencyApiSubmitVehicleTelemetryResponse = AgencyApiResponse<{
   success: number
   total: number
-  failures: Telemetry[]
+  failures: Object[]
 }>
 
 export type AgencyApiPostTripMetadataResponse = AgencyApiResponse<TripMetadata>

--- a/packages/mds-ingest-service/@types/index.ts
+++ b/packages/mds-ingest-service/@types/index.ts
@@ -53,12 +53,12 @@ type WithGpsData<T extends TelemetryData, P extends string = 'gps'> = Omit<T, ke
     [p in P]: Omit<T, 'charge'>
   }
 
-export interface TelemetryDomainModel
-  extends WithGpsData<NullableOptional<Omit<TelemetryData, 'hdop' | 'satellites'>>>,
-    RecordedColumn {
+export interface TelemetryDomainModel extends WithGpsData<NullableOptional<TelemetryData>>, RecordedColumn {
   device_id: UUID
   provider_id: UUID
   timestamp: Timestamp
+  charge: Nullable<number>
+  stop_id: Nullable<UUID>
 }
 
 export type TelemetryDomainCreateModel = DomainModelCreate<Omit<TelemetryDomainModel, keyof RecordedColumn>>

--- a/packages/mds-ingest-service/repository/entities/telemetry-entity.ts
+++ b/packages/mds-ingest-service/repository/entities/telemetry-entity.ts
@@ -16,19 +16,22 @@
 
 import { Entity, Column } from 'typeorm'
 import { BigintTransformer, IdentityColumn, RecordedColumn } from '@mds-core/mds-repository'
-import { TelemetryDomainModel } from '../../@types'
+import { Timestamp, UUID, Nullable } from '@mds-core/mds-types'
 
 export interface TelemetryEntityModel extends IdentityColumn, RecordedColumn {
-  device_id: TelemetryDomainModel['device_id']
-  provider_id: TelemetryDomainModel['provider_id']
-  timestamp: TelemetryDomainModel['timestamp']
-  lat: TelemetryDomainModel['gps']['lat']
-  lng: TelemetryDomainModel['gps']['lng']
-  speed: TelemetryDomainModel['gps']['speed']
-  heading: TelemetryDomainModel['gps']['heading']
-  accuracy: TelemetryDomainModel['gps']['accuracy']
-  altitude: TelemetryDomainModel['gps']['altitude']
-  charge: TelemetryDomainModel['charge']
+  device_id: UUID
+  provider_id: UUID
+  timestamp: Timestamp
+  lat: number
+  lng: number
+  altitude: Nullable<number>
+  heading: Nullable<number>
+  speed: Nullable<number>
+  accuracy: Nullable<number>
+  hdop: Nullable<number>
+  satellites: Nullable<number>
+  charge: Nullable<number>
+  stop_id: Nullable<UUID>
 }
 
 @Entity('telemetry')
@@ -49,6 +52,9 @@ export class TelemetryEntity extends IdentityColumn(RecordedColumn(class {})) im
   lng: TelemetryEntityModel['lng']
 
   @Column('real', { nullable: true })
+  altitude: TelemetryEntityModel['altitude']
+
+  @Column('real', { nullable: true })
   speed: TelemetryEntityModel['speed']
 
   @Column('real', { nullable: true })
@@ -58,8 +64,14 @@ export class TelemetryEntity extends IdentityColumn(RecordedColumn(class {})) im
   accuracy: TelemetryEntityModel['accuracy']
 
   @Column('real', { nullable: true })
-  altitude: TelemetryEntityModel['altitude']
+  hdop: TelemetryEntityModel['hdop']
+
+  @Column('real', { nullable: true })
+  satellites: TelemetryEntityModel['satellites']
 
   @Column('real', { nullable: true })
   charge: TelemetryEntityModel['charge']
+
+  @Column('uuid', { nullable: true })
+  stop_id: TelemetryEntityModel['stop_id']
 }

--- a/packages/mds-ingest-service/repository/mappers/telemetry-mappers.ts
+++ b/packages/mds-ingest-service/repository/mappers/telemetry-mappers.ts
@@ -26,8 +26,8 @@ export const TelemetryEntityToDomain = ModelMapper<
   TelemetryDomainModel,
   TelemetryEntityToDomainOptions
 >((entity, options) => {
-  const { id, lat, lng, speed, heading, accuracy, altitude, charge, ...domain } = entity
-  return { gps: { lat, lng, speed, heading, accuracy, altitude }, charge, ...domain }
+  const { id, lat, lng, speed, heading, accuracy, altitude, hdop, satellites, charge, stop_id, ...domain } = entity
+  return { gps: { lat, lng, speed, heading, accuracy, altitude, hdop, satellites }, charge, stop_id, ...domain }
 })
 
 type TelemetryEntityCreateOptions = Partial<{
@@ -42,7 +42,12 @@ export const TelemetryDomainToEntityCreate = ModelMapper<
   TelemetryEntityCreateOptions
 >(
   (
-    { gps: { lat, lng, speed = null, heading = null, accuracy = null, altitude = null }, charge = null, ...domain },
+    {
+      gps: { lat, lng, speed = null, heading = null, accuracy = null, altitude = null, hdop = null, satellites = null },
+      charge = null,
+      stop_id = null,
+      ...domain
+    },
     options
   ) => {
     const { recorded } = options ?? {}
@@ -53,6 +58,9 @@ export const TelemetryDomainToEntityCreate = ModelMapper<
       heading,
       accuracy,
       altitude,
+      hdop,
+      satellites,
+      stop_id,
       charge,
       recorded,
       ...domain

--- a/packages/mds-ingest-service/repository/migrations/1624574421590-AddTelemetryStopIdHdopSatellitesColumns.ts
+++ b/packages/mds-ingest-service/repository/migrations/1624574421590-AddTelemetryStopIdHdopSatellitesColumns.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTelemetryStopIdHdopSatellitesColumns1624574421590 implements MigrationInterface {
+  name = 'AddTelemetryStopIdHdopSatellitesColumns1624574421590'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "telemetry" ADD "hdop" real`)
+    await queryRunner.query(`ALTER TABLE "telemetry" ADD "satellites" real`)
+    await queryRunner.query(`ALTER TABLE "telemetry" ADD "stop_id" uuid`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "telemetry" DROP COLUMN "stop_id"`)
+    await queryRunner.query(`ALTER TABLE "telemetry" DROP COLUMN "satellites"`)
+    await queryRunner.query(`ALTER TABLE "telemetry" DROP COLUMN "hdop"`)
+  }
+}

--- a/packages/mds-ingest-service/repository/migrations/index.ts
+++ b/packages/mds-ingest-service/repository/migrations/index.ts
@@ -20,6 +20,7 @@ import { CreateEventsTable1603212540962 } from './1603212540962-CreateEventsTabl
 import { CreateTelemetryTable1603212619514 } from './1603212619514-CreateTelemetryTable'
 import { AddAccessibilityOptionsColumn1616681612878 } from './1616681612878-AddAccessibilityOptionsColumn'
 import { AddTripStateColumn1616686180925 } from './1616686180925-AddTripStateColumn'
+import { AddTelemetryStopIdHdopSatellitesColumns1624574421590 } from './1624574421590-AddTelemetryStopIdHdopSatellitesColumns'
 
 export default [
   CreateDevicesTable1603212409274,
@@ -27,5 +28,6 @@ export default [
   CreateTelemetryTable1603212619514,
   AddAccessibilityOptionsColumn1616681612878,
   AddModalityColumn1616682680014,
-  AddTripStateColumn1616686180925
+  AddTripStateColumn1616686180925,
+  AddTelemetryStopIdHdopSatellitesColumns1624574421590
 ]

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import Joi from 'joi'
 import { schemaValidator, SchemaValidator } from '@mds-core/mds-schema-validators'
 import {
-  VEHICLE_TYPES,
+  ACCESSIBILITY_OPTIONS,
+  MODALITIES,
   PROPULSION_TYPES,
+  UUID,
   VEHICLE_EVENTS,
   VEHICLE_STATES,
-  MODALITIES,
-  ACCESSIBILITY_OPTIONS,
-  UUID
+  VEHICLE_TYPES
 } from '@mds-core/mds-types'
+import Joi from 'joi'
 import {
   DeviceDomainModel,
   EventDomainModel,
-  TelemetryDomainModel,
+  GetVehicleEventsFilterParams,
   GROUPING_TYPES,
-  GetVehicleEventsFilterParams
+  TelemetryDomainModel
 } from '../@types'
 
 const uuidSchema = { type: 'string', format: 'uuid' }
@@ -119,7 +119,7 @@ export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema 
           required: ['lat', 'lng']
         },
         // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
-        charge: { type: 'number', format: 'float', minimum: 0, maximum: 1.0, nullable: true, default: null },
+        charge: { ...nullableFloat, minimum: 0, maximum: 1.0 },
         stop_id: { ...uuidSchema, nullable: true, default: null }
       },
       required: ['device_id', 'provider_id', 'timestamp', 'gps']

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -90,6 +90,10 @@ const telemetrySchema = Joi.object<TelemetryDomainModel>()
   })
   .unknown(false)
 
+const nullableInteger = { type: 'integer', nullable: true, default: null }
+
+const nullableFloat = { type: 'number', format: 'float', nullable: true, default: null }
+
 export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema } =
   SchemaValidator<TelemetryDomainModel>(
     {
@@ -105,15 +109,18 @@ export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema 
             lat: { type: 'number', format: 'float' },
             lng: { type: 'number', format: 'float' },
             // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
-            speed: { type: 'number', format: 'float', nullable: true, default: null },
-            heading: { type: 'number', format: 'float', nullable: true, default: null },
-            accuracy: { type: 'number', format: 'float', nullable: true, default: null },
-            altitude: { type: 'number', format: 'float', nullable: true, default: null }
+            altitude: nullableFloat,
+            heading: nullableFloat,
+            speed: nullableFloat,
+            accuracy: nullableFloat,
+            hdop: nullableFloat,
+            satellites: nullableInteger
           },
           required: ['lat', 'lng']
         },
         // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
-        charge: { type: 'number', format: 'float', minimum: 0, maximum: 1.0, nullable: true, default: null }
+        charge: { type: 'number', format: 'float', minimum: 0, maximum: 1.0, nullable: true, default: null },
+        stop_id: { ...uuidSchema, nullable: true, default: null }
       },
       required: ['device_id', 'provider_id', 'timestamp', 'gps']
     },

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -34,6 +34,9 @@ import {
 } from '../@types'
 
 const uuidSchema = { type: 'string', format: 'uuid' }
+const nullableInteger = { type: 'integer', nullable: true, default: null }
+const nullableFloat = { type: 'number', format: 'float', nullable: true, default: null }
+const nullableString = { type: 'string', nullable: true, default: null }
 
 export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = SchemaValidator<DeviceDomainModel>(
   {
@@ -63,9 +66,9 @@ export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = Sc
       },
       modality: { type: 'string', enum: MODALITIES, default: 'micromobility' },
       // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
-      year: { type: 'integer', nullable: true, default: null },
-      mfgr: { type: 'string', nullable: true, default: null },
-      model: { type: 'string', nullable: true, default: null }
+      year: nullableInteger,
+      mfgr: nullableString,
+      model: nullableString
     },
     required: ['device_id', 'provider_id', 'vehicle_id', 'vehicle_type', 'propulsion_types']
   },
@@ -89,10 +92,6 @@ const telemetrySchema = Joi.object<TelemetryDomainModel>()
     charge: Joi.number().allow(null)
   })
   .unknown(false)
-
-const nullableInteger = { type: 'integer', nullable: true, default: null }
-
-const nullableFloat = { type: 'number', format: 'float', nullable: true, default: null }
 
 export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema } =
   SchemaValidator<TelemetryDomainModel>(

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -62,9 +62,10 @@ export const { validate: validateDeviceDomainModel, $schema: DeviceSchema } = Sc
         default: []
       },
       modality: { type: 'string', enum: MODALITIES, default: 'micromobility' },
-      year: { type: 'integer' },
-      mfgr: { type: 'string' },
-      model: { type: 'string' }
+      // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
+      year: { type: 'integer', nullable: true, default: null },
+      mfgr: { type: 'string', nullable: true, default: null },
+      model: { type: 'string', nullable: true, default: null }
     },
     required: ['device_id', 'provider_id', 'vehicle_id', 'vehicle_type', 'propulsion_types']
   },
@@ -89,8 +90,35 @@ const telemetrySchema = Joi.object<TelemetryDomainModel>()
   })
   .unknown(false)
 
-export const { validate: validateTelemetryDomainModel, isValid: isValidTelemetryDomainModel } =
-  schemaValidator<DeviceDomainModel>(telemetrySchema)
+export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema } =
+  SchemaValidator<TelemetryDomainModel>(
+    {
+      $id: 'Telemetry',
+      type: 'object',
+      properties: {
+        device_id: uuidSchema,
+        provider_id: uuidSchema,
+        timestamp: { type: 'integer' },
+        gps: {
+          type: 'object',
+          properties: {
+            lat: { type: 'number', format: 'float' },
+            lng: { type: 'number', format: 'float' },
+            // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
+            speed: { type: 'number', format: 'float', nullable: true, default: null },
+            heading: { type: 'number', format: 'float', nullable: true, default: null },
+            accuracy: { type: 'number', format: 'float', nullable: true, default: null },
+            altitude: { type: 'number', format: 'float', nullable: true, default: null }
+          },
+          required: ['lat', 'lng']
+        },
+        // ⬇⬇⬇ NULLABLE/OPTIONAL PROPERTIES ⬇⬇⬇
+        charge: { type: 'number', format: 'float', minimum: 0, maximum: 1.0, nullable: true, default: null }
+      },
+      required: ['device_id', 'provider_id', 'timestamp', 'gps']
+    },
+    { useDefaults: true }
+  )
 
 export const { validate: validateEventDomainModel, isValid: isValidEventDomainModel } =
   schemaValidator<DeviceDomainModel>(

--- a/packages/mds-ingest-service/tests/index.spec.ts
+++ b/packages/mds-ingest-service/tests/index.spec.ts
@@ -39,7 +39,9 @@ const TEST_TELEMETRY_A1: TelemetryDomainCreateModel = {
     speed: 0,
     heading: 180,
     accuracy: null,
-    altitude: null
+    altitude: null,
+    hdop: null,
+    satellites: null
   },
   charge: 0.5,
   timestamp: testTimestamp
@@ -53,7 +55,9 @@ const TEST_TELEMETRY_A2: TelemetryDomainCreateModel = {
     speed: 0,
     heading: 180,
     accuracy: null,
-    altitude: null
+    altitude: null,
+    hdop: null,
+    satellites: null
   },
   charge: 0.5,
   timestamp: testTimestamp + 1000
@@ -68,7 +72,9 @@ const TEST_TELEMETRY_B1: TelemetryDomainCreateModel = {
     speed: 0,
     heading: 180,
     accuracy: null,
-    altitude: null
+    altitude: null,
+    hdop: null,
+    satellites: null
   },
   charge: 0.5,
   timestamp: testTimestamp
@@ -82,7 +88,9 @@ const TEST_TELEMETRY_B2: TelemetryDomainCreateModel = {
     speed: 0,
     heading: 180,
     accuracy: null,
-    altitude: null
+    altitude: null,
+    hdop: null,
+    satellites: null
   },
   charge: 0.5,
   timestamp: testTimestamp + 1000

--- a/packages/mds-types/telemetry.ts
+++ b/packages/mds-types/telemetry.ts
@@ -10,7 +10,7 @@ export interface TelemetryData {
   hdop?: number | null
   altitude?: number | null
   satellites?: number | null
-  charge?: number | null
+  charge?: number | null // NOTE: Charge is not included in the `gps` property of Telemetry
 }
 
 export type GpsData = Omit<TelemetryData, 'charge'>
@@ -28,5 +28,6 @@ export interface Telemetry extends WithGpsProperty<TelemetryData> {
   device_id: UUID
   timestamp: Timestamp
   recorded?: Timestamp
+  charge?: number | null
   stop_id?: UUID | null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       nyc: 15.1.0
       pnpm-ci-tools: 1.0.1
       prettier: 2.3.1
+      prettier-plugin-organize-imports: 2.2.0
       prettier-plugin-packagejson: 2.2.11
       should: 13.2.3
       sinon: 11.1.1
@@ -86,6 +87,7 @@ importers:
       nyc: 15.1.0
       pnpm-ci-tools: 1.0.1
       prettier: 2.3.1
+      prettier-plugin-organize-imports: 2.2.0_prettier@2.3.1+typescript@4.2.4
       prettier-plugin-packagejson: 2.2.11_prettier@2.3.1
       should: 13.2.3
       sinon: 11.1.1
@@ -9474,6 +9476,16 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.2.0
+    dev: true
+
+  /prettier-plugin-organize-imports/2.2.0_prettier@2.3.1+typescript@4.2.4:
+    resolution: {integrity: sha512-2WM3moc/cAPCCsSneYhaL4+mMws0Bypbxz+98wuRyaA7GMokhOECVkQCG7l2hcH+9/4d5NsgZs9yktfwDy4r7A==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+    dependencies:
+      prettier: 2.3.1
+      typescript: 4.2.4
     dev: true
 
   /prettier-plugin-packagejson/2.2.11_prettier@2.3.1:


### PR DESCRIPTION
## 📚 Purpose
As with many of my PRs recently, this started with the simple task of adding an AJV validator for Telemetry, but then I soon realized that there were discontinuities with the MDS spec...

- Switches mds-agency to using AJV for telemetry schema validation, nukes `badTelemetry()` from orbit
- Adds three new nullable columns to `Telemetry`: `hdop`, `satellites`, and `stop_id`.
- For bonus points, adds a new prettier plugin for import organizing :)

## 👌 Resolves:
- spec discontinuities

## 📦 Impacts:
- mds-agency
- mds-ingest-service
- mds-types

