### PR TITLE
Address some comments from PR #640

### DIFF
--- a/packages/mds-ingest-service/repository/entities/event-annotation-entity.ts
+++ b/packages/mds-ingest-service/repository/entities/event-annotation-entity.ts
@@ -15,50 +15,38 @@
  */
 
 import { BigintTransformer, IdentityColumn, RecordedColumn } from '@mds-core/mds-repository'
+import { PROPULSION_TYPE, Timestamp, UUID, VEHICLE_TYPE } from '@mds-core/mds-types'
 import { Column, Entity, Index } from 'typeorm'
-import { EventAnnotationDomainModel } from '../../@types'
-
-export interface EventAnnotationEntityModel extends IdentityColumn, RecordedColumn {
-  device_id: EventAnnotationDomainModel['device_id']
-  timestamp: EventAnnotationDomainModel['timestamp']
-  vehicle_id: EventAnnotationDomainModel['vehicle_id']
-  vehicle_type: EventAnnotationDomainModel['vehicle_type']
-  propulsion_types: EventAnnotationDomainModel['propulsion_types']
-  geography_ids: EventAnnotationDomainModel['geography_ids']
-  geography_types: EventAnnotationDomainModel['geography_types']
-  latency_ms: EventAnnotationDomainModel['latency_ms']
-}
 
 @Entity('event_annotations')
-export class EventAnnotationEntity
-  extends IdentityColumn(RecordedColumn(class {}))
-  implements EventAnnotationEntityModel
-{
+export class EventAnnotationEntity extends IdentityColumn(RecordedColumn(class {})) {
   @Column('uuid', { primary: true })
-  device_id: EventAnnotationEntityModel['device_id']
+  device_id: UUID
 
   @Column('bigint', { transformer: BigintTransformer, primary: true })
-  timestamp: EventAnnotationEntityModel['timestamp']
+  timestamp: Timestamp
 
   @Index()
   @Column('varchar', { length: 255 })
-  vehicle_id: EventAnnotationEntityModel['vehicle_id']
+  vehicle_id: string
 
   @Index()
   @Column('varchar', { length: 31 })
-  vehicle_type: EventAnnotationEntityModel['vehicle_type']
+  vehicle_type: VEHICLE_TYPE
 
   @Index()
   @Column('varchar', { array: true, length: 31 })
-  propulsion_types: EventAnnotationEntityModel['propulsion_types']
+  propulsion_types: PROPULSION_TYPE[]
 
   @Index()
   @Column('uuid', { array: true })
-  geography_ids: EventAnnotationEntityModel['geography_ids']
+  geography_ids: UUID[]
 
   @Column('varchar', { array: true, length: 255 })
-  geography_types: EventAnnotationEntityModel['geography_types']
+  geography_types: (string | null)[]
 
   @Column('bigint', { transformer: BigintTransformer })
-  latency_ms: EventAnnotationEntityModel['latency_ms']
+  latency_ms: Timestamp
 }
+
+export type EventAnnotationEntityModel = EventAnnotationEntity

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SchemaValidator, timestampSchema, uuidSchema } from '@mds-core/mds-schema-validators'
+import { SchemaValidator } from '@mds-core/mds-schema-validators'
 import {
   ACCESSIBILITY_OPTIONS,
   MODALITIES,
@@ -37,6 +37,8 @@ import {
   TelemetryDomainModel
 } from '../@types'
 
+const uuidSchema = { type: 'string', format: 'uuid' }
+const timestampSchema = { type: 'integer', minimum: 100_000_000_000, maximum: 99_999_999_999_999 }
 const nullableInteger = { type: 'integer', nullable: true, default: null }
 const nullableFloat = { type: 'number', format: 'float', nullable: true, default: null }
 const nullableString = { type: 'string', nullable: true, default: null }

--- a/packages/mds-ingest-service/service/validators.ts
+++ b/packages/mds-ingest-service/service/validators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SchemaValidator } from '@mds-core/mds-schema-validators'
+import { SchemaValidator, timestampSchema, uuidSchema } from '@mds-core/mds-schema-validators'
 import {
   ACCESSIBILITY_OPTIONS,
   MODALITIES,
@@ -37,7 +37,6 @@ import {
   TelemetryDomainModel
 } from '../@types'
 
-const uuidSchema = { type: 'string', format: 'uuid' }
 const nullableInteger = { type: 'integer', nullable: true, default: null }
 const nullableFloat = { type: 'number', format: 'float', nullable: true, default: null }
 const nullableString = { type: 'string', nullable: true, default: null }
@@ -87,7 +86,7 @@ export const { validate: validateTelemetryDomainModel, $schema: TelemetrySchema 
       properties: {
         device_id: uuidSchema,
         provider_id: uuidSchema,
-        timestamp: { type: 'integer' },
+        timestamp: timestampSchema,
         gps: {
           type: 'object',
           properties: {
@@ -121,7 +120,7 @@ export const { validate: validateEventDomainModel, $schema: EventSchema } = Sche
     properties: {
       device_id: uuidSchema,
       provider_id: uuidSchema,
-      timestamp: { type: 'integer' },
+      timestamp: timestampSchema,
       event_types: {
         type: 'array',
         items: {
@@ -172,7 +171,7 @@ export const { validate: validateGetVehicleEventsFilterParams } = SchemaValidato
   properties: {
     vehicle_types: { type: 'array', items: { type: 'string', enum: [...new Set(VEHICLE_TYPES)] } },
     propulsion_types: { type: 'array', items: { type: 'string', enum: [...PROPULSION_TYPES] } },
-    provider_ids: { type: 'array', items: { type: 'string', format: 'uuid' } },
+    provider_ids: { type: 'array', items: uuidSchema },
     vehicle_states: { type: 'array', items: { type: 'string', enum: [...new Set(VEHICLE_STATES)] } },
     time_range: {
       type: 'object',
@@ -183,7 +182,7 @@ export const { validate: validateGetVehicleEventsFilterParams } = SchemaValidato
     },
     grouping_type: { type: 'string', enum: [...GROUPING_TYPES] },
     vehicle_id: { type: 'string' },
-    device_ids: { type: 'array', items: { type: 'string', format: 'uuid' } },
+    device_ids: { type: 'array', items: uuidSchema },
     event_types: { type: 'array', items: { type: 'string', enum: [...new Set(VEHICLE_EVENTS)] } },
     limit: { type: 'integer' },
     order: {
@@ -210,12 +209,12 @@ export const { validate: validateEventAnnotationDomainCreateModels } = SchemaVal
   items: {
     type: 'object',
     properties: {
-      device_id: { type: 'string', format: 'uuid' },
-      timestamp: { type: 'integer' },
+      device_id: uuidSchema,
+      timestamp: timestampSchema,
       vehicle_id: { type: 'string' },
       vehicle_type: { type: 'string', enum: VEHICLE_TYPES },
       propulsion_types: { type: 'array', items: { type: 'string', enum: PROPULSION_TYPES } },
-      geography_ids: { type: 'array', items: { type: 'string', format: 'uuid' } },
+      geography_ids: { type: 'array', items: uuidSchema },
       geography_types: { type: 'array', items: nullableString },
       latency_ms: { type: 'integer' }
     },

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -60,7 +60,7 @@ export const numberSchema = Joi.number().options({ convert: false })
 
 export const uuidSchema = stringSchema.guid()
 
-export const timestampSchema = numberSchema.min(1420099200000)
+export const timestampSchema = Joi.number().integer().min(100_000_000_000).max(99_999_999_999_999)
 
 export const providerIdSchema = uuidSchema.valid(...Object.keys(providers))
 

--- a/packages/mds-schema-validators/validators.ts
+++ b/packages/mds-schema-validators/validators.ts
@@ -60,7 +60,7 @@ export const numberSchema = Joi.number().options({ convert: false })
 
 export const uuidSchema = stringSchema.guid()
 
-export const timestampSchema = Joi.number().integer().min(100_000_000_000).max(99_999_999_999_999)
+export const timestampSchema = numberSchema.min(1420099200000)
 
 export const providerIdSchema = uuidSchema.valid(...Object.keys(providers))
 


### PR DESCRIPTION
## 📚 Purpose
Some minor cleanup that didn't make it into https://github.com/lacuna-tech/mds-core/pull/640 before I merged:
* Decouple the `EventAnnotationEntity` and `EventAnotationEntityModel`
* Reuse some schema definitions from mds-schema-validators

There's opportunity for lots more cleanup across packages in consolidating our schema definitions but I'll hold off on that in favor of fixing with AJV.