### PR TITLE
Add ComplianceViolationEntity

### DIFF
--- a/.changeset/tidy-eggs-shop.md
+++ b/.changeset/tidy-eggs-shop.md
@@ -1,0 +1,8 @@
+---
+"@mds-core/mds-compliance-service": minor
+"@mds-core/mds-policy": patch
+"@mds-core/mds-transaction-api": patch
+"@mds-core/mds-types": patch
+---
+
+Add Compliance Violation Entity

--- a/packages/mds-compliance-service/@types/index.ts
+++ b/packages/mds-compliance-service/@types/index.ts
@@ -75,6 +75,30 @@ export interface ComplianceViolationPeriodEntityModel {
   sum_total_violations: number
 }
 
+export interface ComplianceViolationDetailsEvent {
+  /** Timestamp of the event that triggered the violation */
+  event_timestamp: Timestamp
+  /** The device that violated the policy */
+  device_id: UUID
+  /** Pointer to the trip which was ongoing when this violation occurred (if any) */
+  trip_id: Nullable<UUID>
+}
+
+export interface ComplianceViolationDomainModel {
+  /** Unique ID for the violation */
+  violation_id: UUID
+  /** Timestamp of the violation being generated */
+  timestamp: Timestamp
+  /** The policy that was violated */
+  policy_id: UUID
+  /** Provider managing whatever entity violated the policy */
+  provider_id: UUID
+  /** The rule that was applied */
+  rule_id: UUID
+  /** Details of the violation (linkage to other tables) */
+  violation_details: ComplianceViolationDetailsEvent
+}
+
 export type GetComplianceSnapshotOptions =
   | {
       compliance_snapshot_id: UUID

--- a/packages/mds-compliance-service/repository/entities/compliance-violation-entity.ts
+++ b/packages/mds-compliance-service/repository/entities/compliance-violation-entity.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2021 City of Los Angeles
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BigintTransformer, IdentityColumn, RecordedColumn } from '@mds-core/mds-repository'
+import { Column, Entity } from 'typeorm'
+import { ComplianceViolationDomainModel } from '../../@types'
+
+export interface ComplianceViolationEntityModel extends IdentityColumn, RecordedColumn {
+  violation_id: ComplianceViolationDomainModel['violation_id']
+  timestamp: ComplianceViolationDomainModel['timestamp']
+  policy_id: ComplianceViolationDomainModel['policy_id'] // TODO check/fix
+  provider_id: ComplianceViolationDomainModel['provider_id']
+  rule_id: ComplianceViolationDomainModel['rule_id']
+  event_timestamp: ComplianceViolationDomainModel['violation_details']['event_timestamp']
+  device_id: ComplianceViolationDomainModel['violation_details']['device_id']
+  trip_id: ComplianceViolationDomainModel['violation_details']['trip_id']
+}
+
+@Entity('compliance_violations')
+export class ComplianceViolationEntity
+  extends IdentityColumn(RecordedColumn(class {}))
+  implements ComplianceViolationEntityModel
+{
+  @Column('uuid', { primary: true })
+  violation_id: ComplianceViolationEntityModel['violation_id']
+
+  @Column('bigint', { transformer: BigintTransformer })
+  timestamp: ComplianceViolationEntityModel['timestamp']
+
+  @Column('uuid')
+  policy_id: ComplianceViolationEntityModel['policy_id']
+
+  @Column('uuid')
+  provider_id: ComplianceViolationEntityModel['provider_id']
+
+  @Column('uuid')
+  rule_id: ComplianceViolationEntityModel['rule_id']
+
+  @Column('bigint', { transformer: BigintTransformer })
+  event_timestamp: ComplianceViolationEntityModel['event_timestamp']
+
+  @Column('uuid')
+  device_id: ComplianceViolationEntityModel['device_id']
+
+  @Column('uuid')
+  trip_id: ComplianceViolationEntityModel['trip_id']
+}

--- a/packages/mds-policy/schema-gen/PolicyDomainModelSchema.json
+++ b/packages/mds-policy/schema-gen/PolicyDomainModelSchema.json
@@ -82,8 +82,7 @@
           },
           "end_time": {
             "type": "string",
-            "nullable": true,
-            "pattern": "^\\d{2}:\\d{2}:\\d{2}$"
+            "nullable": true
           },
           "geographies": {
             "type": "array",
@@ -152,253 +151,9 @@
               }
             ]
           },
-          "states": {
-            "type": "object",
-            "properties": {
-              "available": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "elsewhere": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "non_operational": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "on_trip": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "removed": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "reserved": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              },
-              "unknown": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "agency_drop_off",
-                    "agency_pick_up",
-                    "battery_charged",
-                    "battery_low",
-                    "comms_lost",
-                    "comms_restored",
-                    "compliance_pick_up",
-                    "decommissioned",
-                    "located",
-                    "maintenance",
-                    "maintenance_pick_up",
-                    "missing",
-                    "off_hours",
-                    "on_hours",
-                    "provider_drop_off",
-                    "rebalance_pick_up",
-                    "reservation_cancel",
-                    "reservation_start",
-                    "system_resume",
-                    "system_suspend",
-                    "trip_cancel",
-                    "trip_end",
-                    "trip_enter_jurisdiction",
-                    "trip_leave_jurisdiction",
-                    "trip_start",
-                    "unspecified"
-                  ]
-                }
-              }
-            }
-          },
           "start_time": {
             "type": "string",
-            "nullable": true,
-            "pattern": "^\\d{2}:\\d{2}:\\d{2}$"
+            "nullable": true
           },
           "value_url": {
             "type": "string",
@@ -452,10 +207,7 @@
                   "type": "string",
                   "const": "micromobility"
                 }
-              },
-              "required": [
-                "modality"
-              ]
+              }
             },
             "then": {
               "properties": {
@@ -713,10 +465,7 @@
                   "type": "string",
                   "const": "taxi"
                 }
-              },
-              "required": [
-                "modality"
-              ]
+              }
             },
             "then": {
               "properties": {
@@ -960,10 +709,7 @@
                   "type": "string",
                   "const": "tnc"
                 }
-              },
-              "required": [
-                "modality"
-              ]
+              }
             },
             "then": {
               "properties": {

--- a/packages/mds-transaction-api/schema-gen/TransactionSchema.json
+++ b/packages/mds-transaction-api/schema-gen/TransactionSchema.json
@@ -30,8 +30,7 @@
         "parking_fee",
         "reservation_fee",
         "distance_fee",
-        "tolls_fee",
-        "compliance_violation_fee"
+        "tolls_fee"
       ]
     },
     "amount": {
@@ -57,31 +56,7 @@
         },
         "receipt_details": {
           "description": "Free-form object which describes the details of this transaction. Highly use-case dependent.",
-          "oneOf": [
-            {
-              "$schema": "http://json-schema.org/draft-07/schema#",
-              "type": "object",
-              "description": "Receipt details which provide a pointer to an MDS Compliance Violation.",
-              "properties": {
-                "violation_id": {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                "trip_id": {
-                  "type": "string",
-                  "format": "uuid",
-                  "nullable": true,
-                  "default": null
-                }
-              },
-              "required": [
-                "violation_id"
-              ]
-            },
-            {
-              "type": "object"
-            }
-          ]
+          "type": "object"
         }
       },
       "required": [

--- a/packages/mds-transaction-api/spec/flat-spec.json
+++ b/packages/mds-transaction-api/spec/flat-spec.json
@@ -52,8 +52,7 @@
                       "parking_fee",
                       "reservation_fee",
                       "distance_fee",
-                      "tolls_fee",
-                      "compliance_violation_fee"
+                      "tolls_fee"
                     ]
                   },
                   "amount": {
@@ -79,31 +78,7 @@
                       },
                       "receipt_details": {
                         "description": "Free-form object which describes the details of this transaction. Highly use-case dependent.",
-                        "oneOf": [
-                          {
-                            "$schema": "http://json-schema.org/draft-07/schema#",
-                            "type": "object",
-                            "description": "Receipt details which provide a pointer to an MDS Compliance Violation.",
-                            "properties": {
-                              "violation_id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "trip_id": {
-                                "type": "string",
-                                "format": "uuid",
-                                "nullable": true,
-                                "default": null
-                              }
-                            },
-                            "required": [
-                              "violation_id"
-                            ]
-                          },
-                          {
-                            "type": "object"
-                          }
-                        ]
+                        "type": "object"
                       }
                     },
                     "required": [


### PR DESCRIPTION
## 📚 Purpose
The Violation Repository should be added to the Compliance Service following [the schema designed in PLAT-103](https://github.com/lacuna-tech/lacuna-docs/blob/main/docs/proposals/compliance-violation.mdx) , which satisfies the following user stories:
- As a CMM user, I need to be able to query for individual violations over a time period (e.g. start: A, end: B).
- As a CMM user, I need to be able to query for individual violations for a particular policy given a policy_id.
- As a CMM user, I need to be able to query for violations given an area (TBD H3, Geography, etc…)
  - If there’s a linkage to the Events Repository in the MDS Ingest Service (device_id + event timestamp), this can be done with a JOIN
- Not quite a user story, but the following workflow needs to be supported by this schema +/-: event comes into the system → it is evaluated by a compliance processor → a violation is produced → the violation has a corresponding transaction  entry added to the transactions service (with a link to the original violation)

## 👌 Resolves:
- [ ] ✨ PLAT-139 implement violation repository in compliance service

## 📦 Impacts:
- mds-compliance-service (new code)
- mds-policy (???)
- mds-transaction-api (???)

## ✅ PR Checklist
- [ ] Resolve TODOs in new code
- [ ] Revert/clean up mds-policy, mds-transaction-api changes
- [ ] Add migration
- [ ] Add query support
- [ ] Add tests
- [ ] Test in a namespace